### PR TITLE
[codex] Fix inline comment border alignment

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -4982,7 +4982,12 @@ fn push_diff_inline_comment(
     }
 
     let prefix = diff_inline_comment_prefix(selected, depth);
-    builder.push_prefixed_wrapped_limited(header, prefix.clone(), COMMENT_RIGHT_PADDING, 2);
+    builder.push_prefixed_wrapped_limited(
+        header,
+        prefix.clone(),
+        comment_right_padding(selected),
+        2,
+    );
     let collapsed_body;
     let body = if collapse.collapsed {
         collapsed_body = collapsed_comment_body(&comment.body);
@@ -4997,7 +5002,7 @@ fn push_diff_inline_comment(
         usize::MAX,
         MarkdownRenderOptions {
             prefix,
-            right_padding: COMMENT_RIGHT_PADDING,
+            right_padding: comment_right_padding(selected),
         },
     );
     if collapse.collapsed {
@@ -5020,7 +5025,7 @@ fn push_diff_inline_comment_separator(builder: &mut DetailsBuilder, selected: bo
     let prefix_width = segments_width(&segments);
     let width = builder
         .width
-        .saturating_sub(prefix_width + COMMENT_RIGHT_PADDING)
+        .saturating_sub(prefix_width + comment_right_padding(selected))
         .max(12);
     let line = if selected { "━" } else { "─" };
     segments.push(DetailSegment::styled(
@@ -5053,7 +5058,7 @@ fn push_diff_inline_comment_expand_line(
             ),
         ],
         diff_inline_comment_prefix(selected, depth),
-        COMMENT_RIGHT_PADDING,
+        comment_right_padding(selected),
         2,
     );
 }
@@ -10393,6 +10398,22 @@ deleted file mode 100644
                 .iter()
                 .any(|line| line.contains('↳') && line.contains("bob")),
             "review replies should stay nested in the inline thread: {rendered:?}"
+        );
+        let right_border_column = comment_right_border_column(120);
+        let selected_right_border_columns = rendered
+            .iter()
+            .filter(|line| line.ends_with('┃'))
+            .map(|line| display_width(line).saturating_sub(1))
+            .collect::<Vec<_>>();
+        assert!(
+            !selected_right_border_columns.is_empty(),
+            "selected inline comment should render a right border: {rendered:?}"
+        );
+        assert!(
+            selected_right_border_columns
+                .iter()
+                .all(|column| *column == right_border_column),
+            "selected inline comment right border should align: {rendered:?}"
         );
 
         let body_line = rendered


### PR DESCRIPTION
## Summary

- Align selected inline review comment borders by using the selected comment right padding consistently for headers, bodies, expand rows, and separators.
- Add a regression assertion that selected inline comment right borders all render in the same column.

## Why

Selected inline review comments could render their top or bottom separator one column wider than the right border, which made the right side of the highlighted comment box look jagged.

## Validation

- `rtk cargo fmt --all -- --check`
- `rtk cargo test diff_details_render_inline_review_comments_below_target_line -- --nocapture`