### PR TITLE
Add label filters for repo lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,9 @@ name = "Rust"
 repo = "rust-lang/rust"
 show_prs = true
 show_issues = true
+labels = ["T-compiler"]
+pr_labels = ["S-waiting-on-review"]
+issue_labels = ["E-easy"]
 
 [defaults]
 view = "pull_requests"
@@ -158,9 +161,9 @@ queries = [
 exclude_repos = ["some-org/archive-*"]
 ```
 
-Use `filters` for a single GitHub search query. Use `queries` when a section should merge several GitHub searches into one deduplicated list.
+Use `filters` for a single GitHub search query. Use `queries` when a section should merge several GitHub searches into one deduplicated list. Label filters can be written directly in either form, for example `filters = "is:open label:bug archived:false sort:updated-desc"` or `label:"good first issue"` for labels with spaces.
 
-Use `[[repos]]` to add repository tabs to the top bar. Each configured repo shows its `name` as a top-level tab; inside that tab, `show_prs` and `show_issues` control whether the sections are shown as `Pull Requests` and `Issues`. Repo tabs default to open PRs and open issues.
+Use `[[repos]]` to add repository tabs to the top bar. Each configured repo shows its `name` as a top-level tab; inside that tab, `show_prs` and `show_issues` control whether the sections are shown as `Pull Requests` and `Issues`. Repo tabs default to open PRs and open issues. Set `labels` to filter both repo PR and issue lists, or use `pr_labels` / `issue_labels` for kind-specific filters.
 
 When `ghr` starts inside a Git checkout with a GitHub remote, it adds that repository as a runtime repo tab if it is not already configured. This does not write back to `config.toml`.
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -15097,12 +15097,18 @@ diff --git a/src/github.rs b/src/github.rs
             repo: "chenyukang/runnel".to_string(),
             show_prs: true,
             show_issues: true,
+            labels: Vec::new(),
+            pr_labels: Vec::new(),
+            issue_labels: Vec::new(),
         });
         config.repos.push(crate::config::RepoConfig {
             name: "Fiber".to_string(),
             repo: "nervosnetwork/fiber".to_string(),
             show_prs: true,
             show_issues: true,
+            labels: Vec::new(),
+            pr_labels: Vec::new(),
+            issue_labels: Vec::new(),
         });
         let app = AppState::new(SectionKind::PullRequests, configured_sections(&config));
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -48,6 +48,12 @@ pub struct RepoConfig {
     pub repo: String,
     pub show_prs: bool,
     pub show_issues: bool,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub labels: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub pr_labels: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub issue_labels: Vec<String>,
 }
 
 impl SearchSection {
@@ -111,6 +117,9 @@ impl Config {
                 repo,
                 show_prs: true,
                 show_issues: true,
+                labels: Vec::new(),
+                pr_labels: Vec::new(),
+                issue_labels: Vec::new(),
             },
         );
         true
@@ -296,7 +305,22 @@ impl Default for RepoConfig {
             repo: String::new(),
             show_prs: true,
             show_issues: true,
+            labels: Vec::new(),
+            pr_labels: Vec::new(),
+            issue_labels: Vec::new(),
         }
+    }
+}
+
+impl RepoConfig {
+    pub fn label_filters(&self, kind: SectionKind) -> Vec<String> {
+        let mut labels = self.labels.clone();
+        match kind {
+            SectionKind::PullRequests => labels.extend(self.pr_labels.clone()),
+            SectionKind::Issues => labels.extend(self.issue_labels.clone()),
+            SectionKind::Notifications => {}
+        }
+        labels
     }
 }
 
@@ -386,6 +410,9 @@ mod tests {
             repo: "someone-else/ghr".to_string(),
             show_prs: true,
             show_issues: true,
+            labels: Vec::new(),
+            pr_labels: Vec::new(),
+            issue_labels: Vec::new(),
         });
 
         assert!(config.add_runtime_repo("chenyukang/ghr".to_string()));
@@ -401,6 +428,9 @@ mod tests {
             repo: "nervosnetwork/fiber".to_string(),
             show_prs: true,
             show_issues: true,
+            labels: Vec::new(),
+            pr_labels: Vec::new(),
+            issue_labels: Vec::new(),
         });
 
         assert!(config.add_runtime_repo("chenyukang/runnel".to_string()));
@@ -467,6 +497,9 @@ mod tests {
             repo = "nervosnetwork/fiber"
             show_prs = true
             show_issues = true
+            labels = ["T-compiler"]
+            pr_labels = ["S-waiting-on-review"]
+            issue_labels = ["E-easy"]
 
             [defaults]
             view = "pull_requests"
@@ -499,7 +532,32 @@ mod tests {
         assert_eq!(config.repos[0].repo, "nervosnetwork/fiber");
         assert!(config.repos[0].show_prs);
         assert!(config.repos[0].show_issues);
+        assert_eq!(config.repos[0].labels, vec!["T-compiler"]);
+        assert_eq!(config.repos[0].pr_labels, vec!["S-waiting-on-review"]);
+        assert_eq!(config.repos[0].issue_labels, vec!["E-easy"]);
         assert_eq!(config.pr_sections[0].title, "Assigned to Me");
+    }
+
+    #[test]
+    fn repo_label_filters_include_common_and_kind_specific_labels() {
+        let repo = RepoConfig {
+            name: "Rust".to_string(),
+            repo: "rust-lang/rust".to_string(),
+            show_prs: true,
+            show_issues: true,
+            labels: vec!["T-compiler".to_string()],
+            pr_labels: vec!["S-waiting-on-review".to_string()],
+            issue_labels: vec!["E-easy".to_string()],
+        };
+
+        assert_eq!(
+            repo.label_filters(SectionKind::PullRequests),
+            vec!["T-compiler", "S-waiting-on-review"]
+        );
+        assert_eq!(
+            repo.label_filters(SectionKind::Issues),
+            vec!["T-compiler", "E-easy"]
+        );
     }
 
     #[test]

--- a/src/github.rs
+++ b/src/github.rs
@@ -15,8 +15,8 @@ use tracing::{info, warn};
 use crate::config::{Config, SearchSection};
 use crate::model::{
     ActionHints, CheckSummary, CommentPreview, ItemKind, ReviewCommentPreview, SectionKind,
-    SectionSnapshot, WorkItem, builtin_view_key, global_search_view_key, repo_section_filters,
-    repo_view_key,
+    SectionSnapshot, WorkItem, builtin_view_key, global_search_view_key,
+    repo_section_filters_with_labels, repo_view_key,
 };
 
 static VIEWER_LOGIN: OnceCell<String> = OnceCell::const_new();
@@ -402,12 +402,12 @@ async fn refresh_search_sections(
         }
 
         let view = repo_view_key(&repo.name);
-        let filters = repo_section_filters(&repo.repo);
         if repo.show_prs {
             let limit = config.defaults.pr_per_page;
+            let labels = repo.label_filters(SectionKind::PullRequests);
             let section = SearchSection {
                 title: "Pull Requests".to_string(),
-                filters: filters.clone(),
+                filters: repo_section_filters_with_labels(&repo.repo, &labels),
                 queries: Vec::new(),
                 limit: None,
             };
@@ -421,9 +421,10 @@ async fn refresh_search_sections(
 
         if repo.show_issues {
             let limit = config.defaults.issue_per_page;
+            let labels = repo.label_filters(SectionKind::Issues);
             let section = SearchSection {
                 title: "Issues".to_string(),
-                filters: filters.clone(),
+                filters: repo_section_filters_with_labels(&repo.repo, &labels),
                 queries: Vec::new(),
                 limit: None,
             };
@@ -1996,6 +1997,36 @@ mod tests {
                 "per_page=100",
                 "-f",
                 "page=3",
+                "-f",
+                "sort=updated",
+                "-f",
+                "order=desc"
+            ]
+        );
+    }
+
+    #[test]
+    fn search_page_args_preserve_label_filters() {
+        let args = search_page_args(
+            SectionKind::PullRequests,
+            "repo:rust-lang/rust is:open label:\"good first issue\" sort:updated-desc",
+            1,
+            50,
+        );
+
+        assert_eq!(
+            args,
+            vec![
+                "api",
+                "--method",
+                "GET",
+                "search/issues",
+                "-f",
+                "q=is:pr repo:rust-lang/rust is:open label:\"good first issue\"",
+                "-f",
+                "per_page=50",
+                "-f",
+                "page=1",
                 "-f",
                 "sort=updated",
                 "-f",

--- a/src/model.rs
+++ b/src/model.rs
@@ -258,21 +258,22 @@ pub fn configured_sections(config: &Config) -> Vec<SectionSnapshot> {
         }
 
         let view = repo_view_key(&repo.name);
-        let filters = repo_section_filters(&repo.repo);
         if repo.show_prs {
+            let labels = repo.label_filters(SectionKind::PullRequests);
             sections.push(SectionSnapshot::empty_for_view(
                 &view,
                 SectionKind::PullRequests,
                 "Pull Requests",
-                filters.clone(),
+                repo_section_filters_with_labels(&repo.repo, &labels),
             ));
         }
         if repo.show_issues {
+            let labels = repo.label_filters(SectionKind::Issues);
             sections.push(SectionSnapshot::empty_for_view(
                 &view,
                 SectionKind::Issues,
                 "Issues",
-                filters.clone(),
+                repo_section_filters_with_labels(&repo.repo, &labels),
             ));
         }
     }
@@ -280,8 +281,25 @@ pub fn configured_sections(config: &Config) -> Vec<SectionSnapshot> {
     sections
 }
 
-pub fn repo_section_filters(repo: &str) -> String {
-    format!("repo:{repo} is:open archived:false sort:updated-desc")
+pub fn repo_section_filters_with_labels(repo: &str, labels: &[String]) -> String {
+    let mut tokens = vec![
+        format!("repo:{repo}"),
+        "is:open".to_string(),
+        "archived:false".to_string(),
+    ];
+    tokens.extend(labels.iter().filter_map(|label| label_filter(label)));
+    tokens.push("sort:updated-desc".to_string());
+    tokens.join(" ")
+}
+
+fn label_filter(label: &str) -> Option<String> {
+    let label = label.trim();
+    if label.is_empty() {
+        return None;
+    }
+
+    let escaped = label.replace('\\', "\\\\").replace('"', "\\\"");
+    Some(format!("label:\"{escaped}\""))
 }
 
 pub fn merge_cached_sections(
@@ -402,6 +420,9 @@ mod tests {
             repo: "nervosnetwork/fiber".to_string(),
             show_prs: true,
             show_issues: true,
+            labels: Vec::new(),
+            pr_labels: Vec::new(),
+            issue_labels: Vec::new(),
         });
 
         let sections = configured_sections(&config);
@@ -417,6 +438,52 @@ mod tests {
         assert_eq!(
             repo_sections[0].filters,
             "repo:nervosnetwork/fiber is:open archived:false sort:updated-desc"
+        );
+    }
+
+    #[test]
+    fn repo_sections_apply_common_and_kind_specific_label_filters() {
+        let mut config = Config::default();
+        config.repos.push(crate::config::RepoConfig {
+            name: "rust".to_string(),
+            repo: "rust-lang/rust".to_string(),
+            show_prs: true,
+            show_issues: true,
+            labels: vec!["T-compiler".to_string()],
+            pr_labels: vec!["S-waiting-on-review".to_string()],
+            issue_labels: vec!["E-easy".to_string()],
+        });
+
+        let sections = configured_sections(&config);
+        let repo_sections = sections
+            .iter()
+            .filter(|section| section_view_key(section) == "repo:rust")
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            repo_sections[0].filters,
+            "repo:rust-lang/rust is:open archived:false label:\"T-compiler\" label:\"S-waiting-on-review\" sort:updated-desc"
+        );
+        assert_eq!(
+            repo_sections[1].filters,
+            "repo:rust-lang/rust is:open archived:false label:\"T-compiler\" label:\"E-easy\" sort:updated-desc"
+        );
+    }
+
+    #[test]
+    fn repo_section_label_filters_trim_skip_and_quote_labels() {
+        let filters = repo_section_filters_with_labels(
+            "rust-lang/rust",
+            &[
+                " T-compiler ".to_string(),
+                "good first issue".to_string(),
+                String::new(),
+            ],
+        );
+
+        assert_eq!(
+            filters,
+            "repo:rust-lang/rust is:open archived:false label:\"T-compiler\" label:\"good first issue\" sort:updated-desc"
         );
     }
 


### PR DESCRIPTION
## Summary

- Add `labels`, `pr_labels`, and `issue_labels` to repo tab configuration.
- Apply those filters to generated repo Pull Requests and Issues sections during snapshot setup and GitHub refresh.
- Document both direct `label:` usage in custom sections and repo-level label filter fields.

## Why

Repo tabs previously always showed open PRs and issues for the whole repository. Users could write label filters in custom sections, but generated repo lists had no structured way to narrow PRs and issues by label.

## Validation

- `rtk cargo fmt -- --check`
- `rtk git diff --check`
- `rtk cargo test -q`
- `rtk cargo clippy -- -D warnings`