### PR TITLE
[codex] Add ghr feature backlog tracker

### DIFF
--- a/task.md
+++ b/task.md
@@ -40,7 +40,7 @@ review.
 | Mark draft / ready for review | `codex/pr-draft-ready-actions` | Chandrasekhar | In review | [#15](https://github.com/chenyukang/ghr/pull/15) | Add PR lifecycle actions and refresh details afterward. |
 | Update branch | `codex/pr-update-branch` | Boyle | In review | [#18](https://github.com/chenyukang/ghr/pull/18) | Use GitHub branch update API/CLI where available. |
 | Enable / disable auto-merge | `codex/pr-auto-merge-actions` | Ramanujan | In progress | - | Requires merge method choice and repository capability checks. |
-| Merge method selection: merge / squash / rebase | `codex/pr-merge-methods` | Newton | In progress | - | Existing merge confirmation should expose method selection. |
+| Merge method selection: merge / squash / rebase | `codex/pr-merge-methods` | Newton | In review | [#23](https://github.com/chenyukang/ghr/pull/23) | Existing merge confirmation exposes merge/squash/rebase selection. |
 | Full review submit flow: comment / request changes / approve, pending submit/discard | `codex/pr-review-submit-flow` | Kierkegaard | In progress | - | Existing approve and inline comment flows are a starting point. |
 | Rerun failed checks | `codex/pr-rerun-checks` | James | In progress | - | Needs check-suite/job discovery and a safe rerun action. |
 | Checkout PR locally | `codex/pr-checkout-local` | Cicero | In review | [#19](https://github.com/chenyukang/ghr/pull/19) | Should run a local checkout command with a clear confirmation/status. |
@@ -59,6 +59,6 @@ review.
 | Boyle | Update PR branch | `~/.codex/worktrees/ghr-pr-update-branch` | `codex/pr-update-branch` | In review: [#18](https://github.com/chenyukang/ghr/pull/18) |
 | Cicero | Checkout PR locally | `~/.codex/worktrees/ghr-pr-checkout-local` | `codex/pr-checkout-local` | In review: [#19](https://github.com/chenyukang/ghr/pull/19) |
 | Ramanujan | Enable / disable auto-merge | `~/.codex/worktrees/ghr-pr-auto-merge-actions` | `codex/pr-auto-merge-actions` | In progress |
-| Newton | Merge method selection | `~/.codex/worktrees/ghr-pr-merge-methods` | `codex/pr-merge-methods` | In progress |
+| Newton | Merge method selection | `~/.codex/worktrees/ghr-pr-merge-methods` | `codex/pr-merge-methods` | In review: [#23](https://github.com/chenyukang/ghr/pull/23) |
 | Kierkegaard | Full PR review submit flow | `~/.codex/worktrees/ghr-pr-review-submit-flow` | `codex/pr-review-submit-flow` | In progress |
 | James | Rerun failed checks | `~/.codex/worktrees/ghr-pr-rerun-checks` | `codex/pr-rerun-checks` | In progress |

--- a/task.md
+++ b/task.md
@@ -29,7 +29,7 @@ review.
 | Assign / unassign assignees | `codex/assignee-actions` | Harvey | In review | [#17](https://github.com/chenyukang/ghr/pull/17) | Support issues and PRs through GitHub issue assignee APIs. |
 | Request / remove reviewers, including re-request review | `codex/reviewer-actions` | Huygens | In review | [#16](https://github.com/chenyukang/ghr/pull/16) | PR-only reviewer management; user reviewers only. |
 | Close / reopen issue and PR reopen | `codex/state-actions` | Russell | In review | [#14](https://github.com/chenyukang/ghr/pull/14) | Existing PR close flow expanded to issue close/reopen and PR reopen. |
-| Edit title / body | `codex/edit-title-body` | Nietzsche | In progress | - | Needs a focused editor flow for current issue/PR metadata. |
+| Edit title / body | `codex/edit-title-body` | Nietzsche | In review | [#20](https://github.com/chenyukang/ghr/pull/20) | Uses existing editor dialog: `E`, then `t` or `b`, then `Ctrl+Enter`. |
 | Change milestone | `codex/milestone-actions` | Hegel | In progress | - | Needs milestone list/prefix selection plus clear/remove. |
 | Quick state/search filters in TUI | `codex/search-filter-shortcuts` | Hooke | In progress | - | open/closed/merged/draft/all plus assignee/author/label filters. |
 
@@ -53,7 +53,7 @@ review.
 | Huygens | Request / remove / re-request reviewers | `~/.codex/worktrees/ghr-reviewer-actions` | `codex/reviewer-actions` | In review: [#16](https://github.com/chenyukang/ghr/pull/16) |
 | Russell | Close / reopen issue and PR reopen | `~/.codex/worktrees/ghr-state-actions` | `codex/state-actions` | In review: [#14](https://github.com/chenyukang/ghr/pull/14) |
 | Chandrasekhar | Mark draft / ready for review | `~/.codex/worktrees/ghr-pr-draft-ready-actions` | `codex/pr-draft-ready-actions` | In review: [#15](https://github.com/chenyukang/ghr/pull/15) |
-| Nietzsche | Edit title / body | `~/.codex/worktrees/ghr-edit-title-body` | `codex/edit-title-body` | In progress |
+| Nietzsche | Edit title / body | `~/.codex/worktrees/ghr-edit-title-body` | `codex/edit-title-body` | In review: [#20](https://github.com/chenyukang/ghr/pull/20) |
 | Hegel | Change milestone | `~/.codex/worktrees/ghr-milestone-actions` | `codex/milestone-actions` | In progress |
 | Hooke | Quick state/search filters | `~/.codex/worktrees/ghr-search-filter-shortcuts` | `codex/search-filter-shortcuts` | In progress |
 | Boyle | Update PR branch | `~/.codex/worktrees/ghr-pr-update-branch` | `codex/pr-update-branch` | In review: [#18](https://github.com/chenyukang/ghr/pull/18) |

--- a/task.md
+++ b/task.md
@@ -42,7 +42,7 @@ review.
 | Enable / disable auto-merge | `codex/pr-auto-merge-actions` | Ramanujan | In review | [#24](https://github.com/chenyukang/ghr/pull/24) | Uses repo allowed merge policy preference: merge, squash, then rebase. |
 | Merge method selection: merge / squash / rebase | `codex/pr-merge-methods` | Newton | In review | [#23](https://github.com/chenyukang/ghr/pull/23) | Existing merge confirmation exposes merge/squash/rebase selection. |
 | Full review submit flow: comment / request changes / approve, pending submit/discard | `codex/pr-review-submit-flow` | Kierkegaard | In progress | - | Existing approve and inline comment flows are a starting point. |
-| Rerun failed checks | `codex/pr-rerun-checks` | James | In progress | - | Needs check-suite/job discovery and a safe rerun action. |
+| Rerun failed checks | `codex/pr-rerun-checks` | James | In review | [#25](https://github.com/chenyukang/ghr/pull/25) | Reruns failed GitHub Actions runs; external/status-only checks are reported as not rerunnable. |
 | Checkout PR locally | `codex/pr-checkout-local` | Cicero | In review | [#19](https://github.com/chenyukang/ghr/pull/19) | Should run a local checkout command with a clear confirmation/status. |
 
 ## Agent queue
@@ -61,4 +61,4 @@ review.
 | Ramanujan | Enable / disable auto-merge | `~/.codex/worktrees/ghr-pr-auto-merge-actions` | `codex/pr-auto-merge-actions` | In review: [#24](https://github.com/chenyukang/ghr/pull/24) |
 | Newton | Merge method selection | `~/.codex/worktrees/ghr-pr-merge-methods` | `codex/pr-merge-methods` | In review: [#23](https://github.com/chenyukang/ghr/pull/23) |
 | Kierkegaard | Full PR review submit flow | `~/.codex/worktrees/ghr-pr-review-submit-flow` | `codex/pr-review-submit-flow` | In progress |
-| James | Rerun failed checks | `~/.codex/worktrees/ghr-pr-rerun-checks` | `codex/pr-rerun-checks` | In progress |
+| James | Rerun failed checks | `~/.codex/worktrees/ghr-pr-rerun-checks` | `codex/pr-rerun-checks` | In review: [#25](https://github.com/chenyukang/ghr/pull/25) |

--- a/task.md
+++ b/task.md
@@ -39,7 +39,7 @@ review.
 | --- | --- | --- | --- | --- | --- |
 | Mark draft / ready for review | `codex/pr-draft-ready-actions` | Chandrasekhar | In review | [#15](https://github.com/chenyukang/ghr/pull/15) | Add PR lifecycle actions and refresh details afterward. |
 | Update branch | `codex/pr-update-branch` | Boyle | In review | [#18](https://github.com/chenyukang/ghr/pull/18) | Use GitHub branch update API/CLI where available. |
-| Enable / disable auto-merge | `codex/pr-auto-merge-actions` | Ramanujan | In progress | - | Requires merge method choice and repository capability checks. |
+| Enable / disable auto-merge | `codex/pr-auto-merge-actions` | Ramanujan | In review | [#24](https://github.com/chenyukang/ghr/pull/24) | Uses repo allowed merge policy preference: merge, squash, then rebase. |
 | Merge method selection: merge / squash / rebase | `codex/pr-merge-methods` | Newton | In review | [#23](https://github.com/chenyukang/ghr/pull/23) | Existing merge confirmation exposes merge/squash/rebase selection. |
 | Full review submit flow: comment / request changes / approve, pending submit/discard | `codex/pr-review-submit-flow` | Kierkegaard | In progress | - | Existing approve and inline comment flows are a starting point. |
 | Rerun failed checks | `codex/pr-rerun-checks` | James | In progress | - | Needs check-suite/job discovery and a safe rerun action. |
@@ -58,7 +58,7 @@ review.
 | Hooke | Quick state/search filters | `~/.codex/worktrees/ghr-search-filter-shortcuts` | `codex/search-filter-shortcuts` | In review: [#21](https://github.com/chenyukang/ghr/pull/21) |
 | Boyle | Update PR branch | `~/.codex/worktrees/ghr-pr-update-branch` | `codex/pr-update-branch` | In review: [#18](https://github.com/chenyukang/ghr/pull/18) |
 | Cicero | Checkout PR locally | `~/.codex/worktrees/ghr-pr-checkout-local` | `codex/pr-checkout-local` | In review: [#19](https://github.com/chenyukang/ghr/pull/19) |
-| Ramanujan | Enable / disable auto-merge | `~/.codex/worktrees/ghr-pr-auto-merge-actions` | `codex/pr-auto-merge-actions` | In progress |
+| Ramanujan | Enable / disable auto-merge | `~/.codex/worktrees/ghr-pr-auto-merge-actions` | `codex/pr-auto-merge-actions` | In review: [#24](https://github.com/chenyukang/ghr/pull/24) |
 | Newton | Merge method selection | `~/.codex/worktrees/ghr-pr-merge-methods` | `codex/pr-merge-methods` | In review: [#23](https://github.com/chenyukang/ghr/pull/23) |
 | Kierkegaard | Full PR review submit flow | `~/.codex/worktrees/ghr-pr-review-submit-flow` | `codex/pr-review-submit-flow` | In progress |
 | James | Rerun failed checks | `~/.codex/worktrees/ghr-pr-rerun-checks` | `codex/pr-rerun-checks` | In progress |

--- a/task.md
+++ b/task.md
@@ -27,7 +27,7 @@ review.
 | Feature | Branch | Owner | Status | PR | Notes |
 | --- | --- | --- | --- | --- | --- |
 | Assign / unassign assignees | `codex/assignee-actions` | Harvey | In progress | - | Support issues and PRs through GitHub issue assignee APIs. |
-| Request / remove reviewers, including re-request review | `codex/reviewer-actions` | Huygens | In progress | - | PR-only review request management. |
+| Request / remove reviewers, including re-request review | `codex/reviewer-actions` | Huygens | In review | [#16](https://github.com/chenyukang/ghr/pull/16) | PR-only reviewer management; user reviewers only. |
 | Close / reopen issue and PR reopen | `codex/state-actions` | Russell | In review | [#14](https://github.com/chenyukang/ghr/pull/14) | Existing PR close flow expanded to issue close/reopen and PR reopen. |
 | Edit title / body | `codex/edit-title-body` | Later wave | Todo | - | Needs a focused editor flow for current issue/PR metadata. |
 | Change milestone | `codex/milestone-actions` | Later wave | Todo | - | Needs milestone list/prefix selection plus clear/remove. |
@@ -50,6 +50,6 @@ review.
 | Agent | Scope | Worktree | Branch | Status |
 | --- | --- | --- | --- | --- |
 | Harvey | Assign / unassign assignees | `~/.codex/worktrees/ghr-assignee-actions` | `codex/assignee-actions` | In progress |
-| Huygens | Request / remove / re-request reviewers | `~/.codex/worktrees/ghr-reviewer-actions` | `codex/reviewer-actions` | In progress |
+| Huygens | Request / remove / re-request reviewers | `~/.codex/worktrees/ghr-reviewer-actions` | `codex/reviewer-actions` | In review: [#16](https://github.com/chenyukang/ghr/pull/16) |
 | Russell | Close / reopen issue and PR reopen | `~/.codex/worktrees/ghr-state-actions` | `codex/state-actions` | In review: [#14](https://github.com/chenyukang/ghr/pull/14) |
 | Chandrasekhar | Mark draft / ready for review | `~/.codex/worktrees/ghr-pr-draft-ready-actions` | `codex/pr-draft-ready-actions` | In review: [#15](https://github.com/chenyukang/ghr/pull/15) |

--- a/task.md
+++ b/task.md
@@ -39,10 +39,10 @@ review.
 | --- | --- | --- | --- | --- | --- |
 | Mark draft / ready for review | `codex/pr-draft-ready-actions` | Chandrasekhar | In review | [#15](https://github.com/chenyukang/ghr/pull/15) | Add PR lifecycle actions and refresh details afterward. |
 | Update branch | `codex/pr-update-branch` | Boyle | In review | [#18](https://github.com/chenyukang/ghr/pull/18) | Use GitHub branch update API/CLI where available. |
-| Enable / disable auto-merge | `codex/pr-auto-merge-actions` | Later wave | Todo | - | Requires merge method choice and repository capability checks. |
-| Merge method selection: merge / squash / rebase | `codex/pr-merge-methods` | Later wave | Todo | - | Existing merge confirmation should expose method selection. |
-| Full review submit flow: comment / request changes / approve, pending submit/discard | `codex/pr-review-submit-flow` | Later wave | Todo | - | Existing approve and inline comment flows are a starting point. |
-| Rerun failed checks | `codex/pr-rerun-checks` | Later wave | Todo | - | Needs check-suite/job discovery and a safe rerun action. |
+| Enable / disable auto-merge | `codex/pr-auto-merge-actions` | Ramanujan | In progress | - | Requires merge method choice and repository capability checks. |
+| Merge method selection: merge / squash / rebase | `codex/pr-merge-methods` | Newton | In progress | - | Existing merge confirmation should expose method selection. |
+| Full review submit flow: comment / request changes / approve, pending submit/discard | `codex/pr-review-submit-flow` | Kierkegaard | In progress | - | Existing approve and inline comment flows are a starting point. |
+| Rerun failed checks | `codex/pr-rerun-checks` | James | In progress | - | Needs check-suite/job discovery and a safe rerun action. |
 | Checkout PR locally | `codex/pr-checkout-local` | Cicero | In review | [#19](https://github.com/chenyukang/ghr/pull/19) | Should run a local checkout command with a clear confirmation/status. |
 
 ## Agent queue
@@ -58,3 +58,7 @@ review.
 | Hooke | Quick state/search filters | `~/.codex/worktrees/ghr-search-filter-shortcuts` | `codex/search-filter-shortcuts` | In review: [#21](https://github.com/chenyukang/ghr/pull/21) |
 | Boyle | Update PR branch | `~/.codex/worktrees/ghr-pr-update-branch` | `codex/pr-update-branch` | In review: [#18](https://github.com/chenyukang/ghr/pull/18) |
 | Cicero | Checkout PR locally | `~/.codex/worktrees/ghr-pr-checkout-local` | `codex/pr-checkout-local` | In review: [#19](https://github.com/chenyukang/ghr/pull/19) |
+| Ramanujan | Enable / disable auto-merge | `~/.codex/worktrees/ghr-pr-auto-merge-actions` | `codex/pr-auto-merge-actions` | In progress |
+| Newton | Merge method selection | `~/.codex/worktrees/ghr-pr-merge-methods` | `codex/pr-merge-methods` | In progress |
+| Kierkegaard | Full PR review submit flow | `~/.codex/worktrees/ghr-pr-review-submit-flow` | `codex/pr-review-submit-flow` | In progress |
+| James | Rerun failed checks | `~/.codex/worktrees/ghr-pr-rerun-checks` | `codex/pr-rerun-checks` | In progress |

--- a/task.md
+++ b/task.md
@@ -8,6 +8,7 @@ review.
 ## Working model
 
 - Tracker branch: `codex/ghr-feature-roadmap`
+- Tracker PR: [#13](https://github.com/chenyukang/ghr/pull/13)
 - Implementation branches start from `main`.
 - One feature family per branch/worktree.
 - Open one draft PR per completed feature family.
@@ -25,9 +26,9 @@ review.
 
 | Feature | Branch | Owner | Status | PR | Notes |
 | --- | --- | --- | --- | --- | --- |
-| Assign / unassign assignees | `codex/assignee-actions` | Agent A | Todo | - | Support issues and PRs through GitHub issue assignee APIs. |
-| Request / remove reviewers, including re-request review | `codex/reviewer-actions` | Agent B | Todo | - | PR-only review request management. |
-| Close / reopen issue and PR reopen | `codex/state-actions` | Agent C | Todo | - | Existing PR close flow should expand to issue close/reopen and PR reopen. |
+| Assign / unassign assignees | `codex/assignee-actions` | Harvey | In progress | - | Support issues and PRs through GitHub issue assignee APIs. |
+| Request / remove reviewers, including re-request review | `codex/reviewer-actions` | Huygens | In progress | - | PR-only review request management. |
+| Close / reopen issue and PR reopen | `codex/state-actions` | Russell | In progress | - | Existing PR close flow should expand to issue close/reopen and PR reopen. |
 | Edit title / body | `codex/edit-title-body` | Later wave | Todo | - | Needs a focused editor flow for current issue/PR metadata. |
 | Change milestone | `codex/milestone-actions` | Later wave | Todo | - | Needs milestone list/prefix selection plus clear/remove. |
 | Quick state/search filters in TUI | `codex/search-filter-shortcuts` | Later wave | Todo | - | open/closed/merged/draft/all plus assignee/author/label filters. |
@@ -36,7 +37,7 @@ review.
 
 | Feature | Branch | Owner | Status | PR | Notes |
 | --- | --- | --- | --- | --- | --- |
-| Mark draft / ready for review | `codex/pr-draft-ready-actions` | Agent D | Todo | - | Add PR lifecycle actions and refresh details afterward. |
+| Mark draft / ready for review | `codex/pr-draft-ready-actions` | Chandrasekhar | In progress | - | Add PR lifecycle actions and refresh details afterward. |
 | Update branch | `codex/pr-update-branch` | Later wave | Todo | - | Use GitHub branch update API/CLI where available. |
 | Enable / disable auto-merge | `codex/pr-auto-merge-actions` | Later wave | Todo | - | Requires merge method choice and repository capability checks. |
 | Merge method selection: merge / squash / rebase | `codex/pr-merge-methods` | Later wave | Todo | - | Existing merge confirmation should expose method selection. |
@@ -48,7 +49,7 @@ review.
 
 | Agent | Scope | Worktree | Branch | Status |
 | --- | --- | --- | --- | --- |
-| Agent A | Assign / unassign assignees | `~/.codex/worktrees/ghr-assignee-actions` | `codex/assignee-actions` | Pending |
-| Agent B | Request / remove / re-request reviewers | `~/.codex/worktrees/ghr-reviewer-actions` | `codex/reviewer-actions` | Pending |
-| Agent C | Close / reopen issue and PR reopen | `~/.codex/worktrees/ghr-state-actions` | `codex/state-actions` | Pending |
-| Agent D | Mark draft / ready for review | `~/.codex/worktrees/ghr-pr-draft-ready-actions` | `codex/pr-draft-ready-actions` | Pending |
+| Harvey | Assign / unassign assignees | `~/.codex/worktrees/ghr-assignee-actions` | `codex/assignee-actions` | In progress |
+| Huygens | Request / remove / re-request reviewers | `~/.codex/worktrees/ghr-reviewer-actions` | `codex/reviewer-actions` | In progress |
+| Russell | Close / reopen issue and PR reopen | `~/.codex/worktrees/ghr-state-actions` | `codex/state-actions` | In progress |
+| Chandrasekhar | Mark draft / ready for review | `~/.codex/worktrees/ghr-pr-draft-ready-actions` | `codex/pr-draft-ready-actions` | In progress |

--- a/task.md
+++ b/task.md
@@ -29,21 +29,21 @@ review.
 | Assign / unassign assignees | `codex/assignee-actions` | Harvey | In review | [#17](https://github.com/chenyukang/ghr/pull/17) | Support issues and PRs through GitHub issue assignee APIs. |
 | Request / remove reviewers, including re-request review | `codex/reviewer-actions` | Huygens | In review | [#16](https://github.com/chenyukang/ghr/pull/16) | PR-only reviewer management; user reviewers only. |
 | Close / reopen issue and PR reopen | `codex/state-actions` | Russell | In review | [#14](https://github.com/chenyukang/ghr/pull/14) | Existing PR close flow expanded to issue close/reopen and PR reopen. |
-| Edit title / body | `codex/edit-title-body` | Later wave | Todo | - | Needs a focused editor flow for current issue/PR metadata. |
-| Change milestone | `codex/milestone-actions` | Later wave | Todo | - | Needs milestone list/prefix selection plus clear/remove. |
-| Quick state/search filters in TUI | `codex/search-filter-shortcuts` | Later wave | Todo | - | open/closed/merged/draft/all plus assignee/author/label filters. |
+| Edit title / body | `codex/edit-title-body` | Nietzsche | In progress | - | Needs a focused editor flow for current issue/PR metadata. |
+| Change milestone | `codex/milestone-actions` | Hegel | In progress | - | Needs milestone list/prefix selection plus clear/remove. |
+| Quick state/search filters in TUI | `codex/search-filter-shortcuts` | Hooke | In progress | - | open/closed/merged/draft/all plus assignee/author/label filters. |
 
 ## PR-only backlog
 
 | Feature | Branch | Owner | Status | PR | Notes |
 | --- | --- | --- | --- | --- | --- |
 | Mark draft / ready for review | `codex/pr-draft-ready-actions` | Chandrasekhar | In review | [#15](https://github.com/chenyukang/ghr/pull/15) | Add PR lifecycle actions and refresh details afterward. |
-| Update branch | `codex/pr-update-branch` | Later wave | Todo | - | Use GitHub branch update API/CLI where available. |
+| Update branch | `codex/pr-update-branch` | Boyle | In progress | - | Use GitHub branch update API/CLI where available. |
 | Enable / disable auto-merge | `codex/pr-auto-merge-actions` | Later wave | Todo | - | Requires merge method choice and repository capability checks. |
 | Merge method selection: merge / squash / rebase | `codex/pr-merge-methods` | Later wave | Todo | - | Existing merge confirmation should expose method selection. |
 | Full review submit flow: comment / request changes / approve, pending submit/discard | `codex/pr-review-submit-flow` | Later wave | Todo | - | Existing approve and inline comment flows are a starting point. |
 | Rerun failed checks | `codex/pr-rerun-checks` | Later wave | Todo | - | Needs check-suite/job discovery and a safe rerun action. |
-| Checkout PR locally | `codex/pr-checkout-local` | Later wave | Todo | - | Should run a local checkout command with a clear confirmation/status. |
+| Checkout PR locally | `codex/pr-checkout-local` | Cicero | In progress | - | Should run a local checkout command with a clear confirmation/status. |
 
 ## Agent queue
 
@@ -53,3 +53,8 @@ review.
 | Huygens | Request / remove / re-request reviewers | `~/.codex/worktrees/ghr-reviewer-actions` | `codex/reviewer-actions` | In review: [#16](https://github.com/chenyukang/ghr/pull/16) |
 | Russell | Close / reopen issue and PR reopen | `~/.codex/worktrees/ghr-state-actions` | `codex/state-actions` | In review: [#14](https://github.com/chenyukang/ghr/pull/14) |
 | Chandrasekhar | Mark draft / ready for review | `~/.codex/worktrees/ghr-pr-draft-ready-actions` | `codex/pr-draft-ready-actions` | In review: [#15](https://github.com/chenyukang/ghr/pull/15) |
+| Nietzsche | Edit title / body | `~/.codex/worktrees/ghr-edit-title-body` | `codex/edit-title-body` | In progress |
+| Hegel | Change milestone | `~/.codex/worktrees/ghr-milestone-actions` | `codex/milestone-actions` | In progress |
+| Hooke | Quick state/search filters | `~/.codex/worktrees/ghr-search-filter-shortcuts` | `codex/search-filter-shortcuts` | In progress |
+| Boyle | Update PR branch | `~/.codex/worktrees/ghr-pr-update-branch` | `codex/pr-update-branch` | In progress |
+| Cicero | Checkout PR locally | `~/.codex/worktrees/ghr-pr-checkout-local` | `codex/pr-checkout-local` | In progress |

--- a/task.md
+++ b/task.md
@@ -30,7 +30,7 @@ review.
 | Request / remove reviewers, including re-request review | `codex/reviewer-actions` | Huygens | In review | [#16](https://github.com/chenyukang/ghr/pull/16) | PR-only reviewer management; user reviewers only. |
 | Close / reopen issue and PR reopen | `codex/state-actions` | Russell | In review | [#14](https://github.com/chenyukang/ghr/pull/14) | Existing PR close flow expanded to issue close/reopen and PR reopen. |
 | Edit title / body | `codex/edit-title-body` | Nietzsche | In review | [#20](https://github.com/chenyukang/ghr/pull/20) | Uses existing editor dialog: `E`, then `t` or `b`, then `Ctrl+Enter`. |
-| Change milestone | `codex/milestone-actions` | Hegel | In progress | - | Needs milestone list/prefix selection plus clear/remove. |
+| Change milestone | `codex/milestone-actions` | Hegel | In review | [#22](https://github.com/chenyukang/ghr/pull/22) | Prefix milestone selection plus clear/remove; current milestone display depends on fetched metadata. |
 | Quick state/search filters in TUI | `codex/search-filter-shortcuts` | Hooke | In progress | - | open/closed/merged/draft/all plus assignee/author/label filters. |
 
 ## PR-only backlog
@@ -54,7 +54,7 @@ review.
 | Russell | Close / reopen issue and PR reopen | `~/.codex/worktrees/ghr-state-actions` | `codex/state-actions` | In review: [#14](https://github.com/chenyukang/ghr/pull/14) |
 | Chandrasekhar | Mark draft / ready for review | `~/.codex/worktrees/ghr-pr-draft-ready-actions` | `codex/pr-draft-ready-actions` | In review: [#15](https://github.com/chenyukang/ghr/pull/15) |
 | Nietzsche | Edit title / body | `~/.codex/worktrees/ghr-edit-title-body` | `codex/edit-title-body` | In review: [#20](https://github.com/chenyukang/ghr/pull/20) |
-| Hegel | Change milestone | `~/.codex/worktrees/ghr-milestone-actions` | `codex/milestone-actions` | In progress |
+| Hegel | Change milestone | `~/.codex/worktrees/ghr-milestone-actions` | `codex/milestone-actions` | In review: [#22](https://github.com/chenyukang/ghr/pull/22) |
 | Hooke | Quick state/search filters | `~/.codex/worktrees/ghr-search-filter-shortcuts` | `codex/search-filter-shortcuts` | In progress |
 | Boyle | Update PR branch | `~/.codex/worktrees/ghr-pr-update-branch` | `codex/pr-update-branch` | In review: [#18](https://github.com/chenyukang/ghr/pull/18) |
 | Cicero | Checkout PR locally | `~/.codex/worktrees/ghr-pr-checkout-local` | `codex/pr-checkout-local` | In review: [#19](https://github.com/chenyukang/ghr/pull/19) |

--- a/task.md
+++ b/task.md
@@ -1,0 +1,54 @@
+# ghr feature backlog
+
+This tracker records the remaining high-value GitHub workflow gaps and the
+branches/PRs used to implement them. Each implementation branch should stay
+focused on one feature family and open a draft PR when the feature is ready for
+review.
+
+## Working model
+
+- Tracker branch: `codex/ghr-feature-roadmap`
+- Implementation branches start from `main`.
+- One feature family per branch/worktree.
+- Open one draft PR per completed feature family.
+- Update this file after each feature PR is opened or blocked.
+
+## Status legend
+
+- `Todo`: not started
+- `In progress`: branch/worktree assigned
+- `In review`: draft PR opened
+- `Blocked`: needs a product/API decision or external dependency
+- `Done`: merged or otherwise complete
+
+## Highest priority
+
+| Feature | Branch | Owner | Status | PR | Notes |
+| --- | --- | --- | --- | --- | --- |
+| Assign / unassign assignees | `codex/assignee-actions` | Agent A | Todo | - | Support issues and PRs through GitHub issue assignee APIs. |
+| Request / remove reviewers, including re-request review | `codex/reviewer-actions` | Agent B | Todo | - | PR-only review request management. |
+| Close / reopen issue and PR reopen | `codex/state-actions` | Agent C | Todo | - | Existing PR close flow should expand to issue close/reopen and PR reopen. |
+| Edit title / body | `codex/edit-title-body` | Later wave | Todo | - | Needs a focused editor flow for current issue/PR metadata. |
+| Change milestone | `codex/milestone-actions` | Later wave | Todo | - | Needs milestone list/prefix selection plus clear/remove. |
+| Quick state/search filters in TUI | `codex/search-filter-shortcuts` | Later wave | Todo | - | open/closed/merged/draft/all plus assignee/author/label filters. |
+
+## PR-only backlog
+
+| Feature | Branch | Owner | Status | PR | Notes |
+| --- | --- | --- | --- | --- | --- |
+| Mark draft / ready for review | `codex/pr-draft-ready-actions` | Agent D | Todo | - | Add PR lifecycle actions and refresh details afterward. |
+| Update branch | `codex/pr-update-branch` | Later wave | Todo | - | Use GitHub branch update API/CLI where available. |
+| Enable / disable auto-merge | `codex/pr-auto-merge-actions` | Later wave | Todo | - | Requires merge method choice and repository capability checks. |
+| Merge method selection: merge / squash / rebase | `codex/pr-merge-methods` | Later wave | Todo | - | Existing merge confirmation should expose method selection. |
+| Full review submit flow: comment / request changes / approve, pending submit/discard | `codex/pr-review-submit-flow` | Later wave | Todo | - | Existing approve and inline comment flows are a starting point. |
+| Rerun failed checks | `codex/pr-rerun-checks` | Later wave | Todo | - | Needs check-suite/job discovery and a safe rerun action. |
+| Checkout PR locally | `codex/pr-checkout-local` | Later wave | Todo | - | Should run a local checkout command with a clear confirmation/status. |
+
+## Agent queue
+
+| Agent | Scope | Worktree | Branch | Status |
+| --- | --- | --- | --- | --- |
+| Agent A | Assign / unassign assignees | `~/.codex/worktrees/ghr-assignee-actions` | `codex/assignee-actions` | Pending |
+| Agent B | Request / remove / re-request reviewers | `~/.codex/worktrees/ghr-reviewer-actions` | `codex/reviewer-actions` | Pending |
+| Agent C | Close / reopen issue and PR reopen | `~/.codex/worktrees/ghr-state-actions` | `codex/state-actions` | Pending |
+| Agent D | Mark draft / ready for review | `~/.codex/worktrees/ghr-pr-draft-ready-actions` | `codex/pr-draft-ready-actions` | Pending |

--- a/task.md
+++ b/task.md
@@ -38,7 +38,7 @@ review.
 | Feature | Branch | Owner | Status | PR | Notes |
 | --- | --- | --- | --- | --- | --- |
 | Mark draft / ready for review | `codex/pr-draft-ready-actions` | Chandrasekhar | In review | [#15](https://github.com/chenyukang/ghr/pull/15) | Add PR lifecycle actions and refresh details afterward. |
-| Update branch | `codex/pr-update-branch` | Boyle | In progress | - | Use GitHub branch update API/CLI where available. |
+| Update branch | `codex/pr-update-branch` | Boyle | In review | [#18](https://github.com/chenyukang/ghr/pull/18) | Use GitHub branch update API/CLI where available. |
 | Enable / disable auto-merge | `codex/pr-auto-merge-actions` | Later wave | Todo | - | Requires merge method choice and repository capability checks. |
 | Merge method selection: merge / squash / rebase | `codex/pr-merge-methods` | Later wave | Todo | - | Existing merge confirmation should expose method selection. |
 | Full review submit flow: comment / request changes / approve, pending submit/discard | `codex/pr-review-submit-flow` | Later wave | Todo | - | Existing approve and inline comment flows are a starting point. |
@@ -56,5 +56,5 @@ review.
 | Nietzsche | Edit title / body | `~/.codex/worktrees/ghr-edit-title-body` | `codex/edit-title-body` | In progress |
 | Hegel | Change milestone | `~/.codex/worktrees/ghr-milestone-actions` | `codex/milestone-actions` | In progress |
 | Hooke | Quick state/search filters | `~/.codex/worktrees/ghr-search-filter-shortcuts` | `codex/search-filter-shortcuts` | In progress |
-| Boyle | Update PR branch | `~/.codex/worktrees/ghr-pr-update-branch` | `codex/pr-update-branch` | In progress |
+| Boyle | Update PR branch | `~/.codex/worktrees/ghr-pr-update-branch` | `codex/pr-update-branch` | In review: [#18](https://github.com/chenyukang/ghr/pull/18) |
 | Cicero | Checkout PR locally | `~/.codex/worktrees/ghr-pr-checkout-local` | `codex/pr-checkout-local` | In progress |

--- a/task.md
+++ b/task.md
@@ -31,7 +31,7 @@ review.
 | Close / reopen issue and PR reopen | `codex/state-actions` | Russell | In review | [#14](https://github.com/chenyukang/ghr/pull/14) | Existing PR close flow expanded to issue close/reopen and PR reopen. |
 | Edit title / body | `codex/edit-title-body` | Nietzsche | In review | [#20](https://github.com/chenyukang/ghr/pull/20) | Uses existing editor dialog: `E`, then `t` or `b`, then `Ctrl+Enter`. |
 | Change milestone | `codex/milestone-actions` | Hegel | In review | [#22](https://github.com/chenyukang/ghr/pull/22) | Prefix milestone selection plus clear/remove; current milestone display depends on fetched metadata. |
-| Quick state/search filters in TUI | `codex/search-filter-shortcuts` | Hooke | In progress | - | open/closed/merged/draft/all plus assignee/author/label filters. |
+| Quick state/search filters in TUI | `codex/search-filter-shortcuts` | Hooke | In review | [#21](https://github.com/chenyukang/ghr/pull/21) | open/closed/merged/draft/all plus assignee/author/label filters; labels with spaces are not grouped. |
 
 ## PR-only backlog
 
@@ -55,6 +55,6 @@ review.
 | Chandrasekhar | Mark draft / ready for review | `~/.codex/worktrees/ghr-pr-draft-ready-actions` | `codex/pr-draft-ready-actions` | In review: [#15](https://github.com/chenyukang/ghr/pull/15) |
 | Nietzsche | Edit title / body | `~/.codex/worktrees/ghr-edit-title-body` | `codex/edit-title-body` | In review: [#20](https://github.com/chenyukang/ghr/pull/20) |
 | Hegel | Change milestone | `~/.codex/worktrees/ghr-milestone-actions` | `codex/milestone-actions` | In review: [#22](https://github.com/chenyukang/ghr/pull/22) |
-| Hooke | Quick state/search filters | `~/.codex/worktrees/ghr-search-filter-shortcuts` | `codex/search-filter-shortcuts` | In progress |
+| Hooke | Quick state/search filters | `~/.codex/worktrees/ghr-search-filter-shortcuts` | `codex/search-filter-shortcuts` | In review: [#21](https://github.com/chenyukang/ghr/pull/21) |
 | Boyle | Update PR branch | `~/.codex/worktrees/ghr-pr-update-branch` | `codex/pr-update-branch` | In review: [#18](https://github.com/chenyukang/ghr/pull/18) |
 | Cicero | Checkout PR locally | `~/.codex/worktrees/ghr-pr-checkout-local` | `codex/pr-checkout-local` | In review: [#19](https://github.com/chenyukang/ghr/pull/19) |

--- a/task.md
+++ b/task.md
@@ -28,7 +28,7 @@ review.
 | --- | --- | --- | --- | --- | --- |
 | Assign / unassign assignees | `codex/assignee-actions` | Harvey | In progress | - | Support issues and PRs through GitHub issue assignee APIs. |
 | Request / remove reviewers, including re-request review | `codex/reviewer-actions` | Huygens | In progress | - | PR-only review request management. |
-| Close / reopen issue and PR reopen | `codex/state-actions` | Russell | In progress | - | Existing PR close flow should expand to issue close/reopen and PR reopen. |
+| Close / reopen issue and PR reopen | `codex/state-actions` | Russell | In review | [#14](https://github.com/chenyukang/ghr/pull/14) | Existing PR close flow expanded to issue close/reopen and PR reopen. |
 | Edit title / body | `codex/edit-title-body` | Later wave | Todo | - | Needs a focused editor flow for current issue/PR metadata. |
 | Change milestone | `codex/milestone-actions` | Later wave | Todo | - | Needs milestone list/prefix selection plus clear/remove. |
 | Quick state/search filters in TUI | `codex/search-filter-shortcuts` | Later wave | Todo | - | open/closed/merged/draft/all plus assignee/author/label filters. |
@@ -37,7 +37,7 @@ review.
 
 | Feature | Branch | Owner | Status | PR | Notes |
 | --- | --- | --- | --- | --- | --- |
-| Mark draft / ready for review | `codex/pr-draft-ready-actions` | Chandrasekhar | In progress | - | Add PR lifecycle actions and refresh details afterward. |
+| Mark draft / ready for review | `codex/pr-draft-ready-actions` | Chandrasekhar | In review | [#15](https://github.com/chenyukang/ghr/pull/15) | Add PR lifecycle actions and refresh details afterward. |
 | Update branch | `codex/pr-update-branch` | Later wave | Todo | - | Use GitHub branch update API/CLI where available. |
 | Enable / disable auto-merge | `codex/pr-auto-merge-actions` | Later wave | Todo | - | Requires merge method choice and repository capability checks. |
 | Merge method selection: merge / squash / rebase | `codex/pr-merge-methods` | Later wave | Todo | - | Existing merge confirmation should expose method selection. |
@@ -51,5 +51,5 @@ review.
 | --- | --- | --- | --- | --- |
 | Harvey | Assign / unassign assignees | `~/.codex/worktrees/ghr-assignee-actions` | `codex/assignee-actions` | In progress |
 | Huygens | Request / remove / re-request reviewers | `~/.codex/worktrees/ghr-reviewer-actions` | `codex/reviewer-actions` | In progress |
-| Russell | Close / reopen issue and PR reopen | `~/.codex/worktrees/ghr-state-actions` | `codex/state-actions` | In progress |
-| Chandrasekhar | Mark draft / ready for review | `~/.codex/worktrees/ghr-pr-draft-ready-actions` | `codex/pr-draft-ready-actions` | In progress |
+| Russell | Close / reopen issue and PR reopen | `~/.codex/worktrees/ghr-state-actions` | `codex/state-actions` | In review: [#14](https://github.com/chenyukang/ghr/pull/14) |
+| Chandrasekhar | Mark draft / ready for review | `~/.codex/worktrees/ghr-pr-draft-ready-actions` | `codex/pr-draft-ready-actions` | In review: [#15](https://github.com/chenyukang/ghr/pull/15) |

--- a/task.md
+++ b/task.md
@@ -26,7 +26,7 @@ review.
 
 | Feature | Branch | Owner | Status | PR | Notes |
 | --- | --- | --- | --- | --- | --- |
-| Assign / unassign assignees | `codex/assignee-actions` | Harvey | In progress | - | Support issues and PRs through GitHub issue assignee APIs. |
+| Assign / unassign assignees | `codex/assignee-actions` | Harvey | In review | [#17](https://github.com/chenyukang/ghr/pull/17) | Support issues and PRs through GitHub issue assignee APIs. |
 | Request / remove reviewers, including re-request review | `codex/reviewer-actions` | Huygens | In review | [#16](https://github.com/chenyukang/ghr/pull/16) | PR-only reviewer management; user reviewers only. |
 | Close / reopen issue and PR reopen | `codex/state-actions` | Russell | In review | [#14](https://github.com/chenyukang/ghr/pull/14) | Existing PR close flow expanded to issue close/reopen and PR reopen. |
 | Edit title / body | `codex/edit-title-body` | Later wave | Todo | - | Needs a focused editor flow for current issue/PR metadata. |
@@ -49,7 +49,7 @@ review.
 
 | Agent | Scope | Worktree | Branch | Status |
 | --- | --- | --- | --- | --- |
-| Harvey | Assign / unassign assignees | `~/.codex/worktrees/ghr-assignee-actions` | `codex/assignee-actions` | In progress |
+| Harvey | Assign / unassign assignees | `~/.codex/worktrees/ghr-assignee-actions` | `codex/assignee-actions` | In review: [#17](https://github.com/chenyukang/ghr/pull/17) |
 | Huygens | Request / remove / re-request reviewers | `~/.codex/worktrees/ghr-reviewer-actions` | `codex/reviewer-actions` | In review: [#16](https://github.com/chenyukang/ghr/pull/16) |
 | Russell | Close / reopen issue and PR reopen | `~/.codex/worktrees/ghr-state-actions` | `codex/state-actions` | In review: [#14](https://github.com/chenyukang/ghr/pull/14) |
 | Chandrasekhar | Mark draft / ready for review | `~/.codex/worktrees/ghr-pr-draft-ready-actions` | `codex/pr-draft-ready-actions` | In review: [#15](https://github.com/chenyukang/ghr/pull/15) |

--- a/task.md
+++ b/task.md
@@ -43,7 +43,7 @@ review.
 | Merge method selection: merge / squash / rebase | `codex/pr-merge-methods` | Later wave | Todo | - | Existing merge confirmation should expose method selection. |
 | Full review submit flow: comment / request changes / approve, pending submit/discard | `codex/pr-review-submit-flow` | Later wave | Todo | - | Existing approve and inline comment flows are a starting point. |
 | Rerun failed checks | `codex/pr-rerun-checks` | Later wave | Todo | - | Needs check-suite/job discovery and a safe rerun action. |
-| Checkout PR locally | `codex/pr-checkout-local` | Cicero | In progress | - | Should run a local checkout command with a clear confirmation/status. |
+| Checkout PR locally | `codex/pr-checkout-local` | Cicero | In review | [#19](https://github.com/chenyukang/ghr/pull/19) | Should run a local checkout command with a clear confirmation/status. |
 
 ## Agent queue
 
@@ -57,4 +57,4 @@ review.
 | Hegel | Change milestone | `~/.codex/worktrees/ghr-milestone-actions` | `codex/milestone-actions` | In progress |
 | Hooke | Quick state/search filters | `~/.codex/worktrees/ghr-search-filter-shortcuts` | `codex/search-filter-shortcuts` | In progress |
 | Boyle | Update PR branch | `~/.codex/worktrees/ghr-pr-update-branch` | `codex/pr-update-branch` | In review: [#18](https://github.com/chenyukang/ghr/pull/18) |
-| Cicero | Checkout PR locally | `~/.codex/worktrees/ghr-pr-checkout-local` | `codex/pr-checkout-local` | In progress |
+| Cicero | Checkout PR locally | `~/.codex/worktrees/ghr-pr-checkout-local` | `codex/pr-checkout-local` | In review: [#19](https://github.com/chenyukang/ghr/pull/19) |

--- a/task.md
+++ b/task.md
@@ -41,7 +41,7 @@ review.
 | Update branch | `codex/pr-update-branch` | Boyle | In review | [#18](https://github.com/chenyukang/ghr/pull/18) | Use GitHub branch update API/CLI where available. |
 | Enable / disable auto-merge | `codex/pr-auto-merge-actions` | Ramanujan | In review | [#24](https://github.com/chenyukang/ghr/pull/24) | Uses repo allowed merge policy preference: merge, squash, then rebase. |
 | Merge method selection: merge / squash / rebase | `codex/pr-merge-methods` | Newton | In review | [#23](https://github.com/chenyukang/ghr/pull/23) | Existing merge confirmation exposes merge/squash/rebase selection. |
-| Full review submit flow: comment / request changes / approve, pending submit/discard | `codex/pr-review-submit-flow` | Kierkegaard | In progress | - | Existing approve and inline comment flows are a starting point. |
+| Full review submit flow: comment / request changes / approve, pending submit/discard | `codex/pr-review-submit-flow` | Kierkegaard | In review | [#26](https://github.com/chenyukang/ghr/pull/26) | Inline review comments still post immediately; pending review tracking is local to the current session. |
 | Rerun failed checks | `codex/pr-rerun-checks` | James | In review | [#25](https://github.com/chenyukang/ghr/pull/25) | Reruns failed GitHub Actions runs; external/status-only checks are reported as not rerunnable. |
 | Checkout PR locally | `codex/pr-checkout-local` | Cicero | In review | [#19](https://github.com/chenyukang/ghr/pull/19) | Should run a local checkout command with a clear confirmation/status. |
 
@@ -60,5 +60,5 @@ review.
 | Cicero | Checkout PR locally | `~/.codex/worktrees/ghr-pr-checkout-local` | `codex/pr-checkout-local` | In review: [#19](https://github.com/chenyukang/ghr/pull/19) |
 | Ramanujan | Enable / disable auto-merge | `~/.codex/worktrees/ghr-pr-auto-merge-actions` | `codex/pr-auto-merge-actions` | In review: [#24](https://github.com/chenyukang/ghr/pull/24) |
 | Newton | Merge method selection | `~/.codex/worktrees/ghr-pr-merge-methods` | `codex/pr-merge-methods` | In review: [#23](https://github.com/chenyukang/ghr/pull/23) |
-| Kierkegaard | Full PR review submit flow | `~/.codex/worktrees/ghr-pr-review-submit-flow` | `codex/pr-review-submit-flow` | In progress |
+| Kierkegaard | Full PR review submit flow | `~/.codex/worktrees/ghr-pr-review-submit-flow` | `codex/pr-review-submit-flow` | In review: [#26](https://github.com/chenyukang/ghr/pull/26) |
 | James | Rerun failed checks | `~/.codex/worktrees/ghr-pr-rerun-checks` | `codex/pr-rerun-checks` | In review: [#25](https://github.com/chenyukang/ghr/pull/25) |


### PR DESCRIPTION
## Summary

Adds a top-level `task.md` that tracks the remaining high-priority ghr workflow gaps, planned implementation branches, agent ownership, and status for each feature family.

## Notes

This PR is intentionally scoped to the tracker. Implementation PRs will branch from `main` and the tracker branch will be updated as each feature PR opens or gets blocked.

## Validation

- Not run; documentation-only change.