### PR TITLE
[codex] add local PR checkout action

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 - Fuzzy filtering in every loaded list with `/`, plus repo-scoped GitHub search with `S`.
 - Details pane with rendered Markdown, clickable links, fenced code blocks with lightweight Rust and plain/log highlighting, descriptions, comments, review comments, labels, action hints, and check summaries.
 - PR diff mode with a changed-file list, per-file diff rendering, inline review comments, and review ranges.
-- Comment, reply, edit, merge, close, and approve flows from inside the TUI.
+- Comment, reply, edit, merge, close, approve, and local PR checkout flows from inside the TUI.
 - Unread notification handling with local cache updates and GitHub read-state sync.
 - Mouse support for tabs, lists, links, comments, scrolling, text selection mode, and split resizing.
 - UI state persistence under `~/.ghr`, including focus, selected item, scroll position, split ratio, and diff mode.
@@ -77,6 +77,7 @@ Press `?` in the TUI for the live shortcut reference. The status bar also change
 | `M` | Open a merge confirmation for the selected PR |
 | `C` | Open a close confirmation for the selected PR |
 | `A` | Open an approve confirmation for the selected PR |
+| `X` | Open a confirmation to run `gh pr checkout <number> --repo <owner/repo>` from the current working directory |
 | `y` / `Enter` | Confirm the current PR action in the confirmation dialog |
 | `Ctrl+Enter` | Send or update a comment from the comment dialog |
 | `r` | Refresh from GitHub |
@@ -87,6 +88,11 @@ Diff review ranges:
 - Press `m` on a diff line to begin a range, move the highlight, then press `e` to end it.
 - Press `c` after ending a range to post an inline review comment for the selected range.
 - A single mouse click begins or moves a range; a double click ends it.
+
+Local PR checkout:
+
+- Press `X` on a pull request in the list or Details pane, then confirm with `y` or `Enter`.
+- Checkout runs from the directory where `ghr` was launched. GitHub CLI and GitHub are the source of truth for the target repository and branch, so launching `ghr` outside the intended local repository can make `gh pr checkout` fail or mutate a different checkout.
 
 Mouse behavior:
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Press `?` in the TUI for the live shortcut reference. The status bar also change
 | `M` | Open a merge confirmation for the selected PR |
 | `C` | Open a close confirmation for the selected PR |
 | `A` | Open an approve confirmation for the selected PR |
-| `X` | Open a confirmation to run `gh pr checkout <number> --repo <owner/repo>` from the current working directory |
+| `X` | Open a confirmation to run `gh pr checkout <number> --repo <owner/repo>` from the matching local checkout |
 | `y` / `Enter` | Confirm the current PR action in the confirmation dialog |
 | `Ctrl+Enter` | Send or update a comment from the comment dialog |
 | `r` | Refresh from GitHub |
@@ -92,7 +92,19 @@ Diff review ranges:
 Local PR checkout:
 
 - Press `X` on a pull request in the list or Details pane, then confirm with `y` or `Enter`.
-- Checkout runs from the directory where `ghr` was launched. GitHub CLI and GitHub are the source of truth for the target repository and branch, so launching `ghr` outside the intended local repository can make `gh pr checkout` fail or mutate a different checkout.
+- Pull request Details show the remote branch when GitHub provides it.
+- Checkout runs from the matching local repository directory. Set `local_dir` on a repo entry to make the target explicit:
+
+```toml
+[[repos]]
+name = "Rust"
+repo = "rust-lang/rust"
+local_dir = "~/code/rust"
+show_prs = true
+show_issues = true
+```
+
+- If `local_dir` is not set, `ghr` tries the directory where it was launched when that directory has a GitHub remote for the pull request repository. If neither path matches, `ghr` shows a hint instead of running checkout.
 
 Mouse behavior:
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet};
 use std::io;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::{Duration, Instant};
 
@@ -28,7 +29,7 @@ use tokio::process::Command as TokioCommand;
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use tracing::warn;
 
-use crate::config::Config;
+use crate::config::{Config, github_repo_from_remote_url};
 use crate::dirs::Paths;
 use crate::github::{
     PullRequestReviewCommentTarget, approve_pull_request, close_pull_request, edit_issue_comment,
@@ -39,8 +40,8 @@ use crate::github::{
     with_background_github_priority,
 };
 use crate::model::{
-    ActionHints, CheckSummary, CommentPreview, ItemKind, SectionKind, SectionSnapshot, WorkItem,
-    builtin_view_key, configured_sections, global_search_view_key,
+    ActionHints, CheckSummary, CommentPreview, ItemKind, PullRequestBranch, SectionKind,
+    SectionSnapshot, WorkItem, builtin_view_key, configured_sections, global_search_view_key,
     mark_notification_read_in_section, merge_cached_sections, merge_refreshed_sections,
     section_counts, section_view_key,
 };
@@ -258,12 +259,20 @@ enum PrAction {
 struct PrActionDialog {
     item: WorkItem,
     action: PrAction,
+    checkout: Option<PrCheckoutPlan>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct PrCheckoutResult {
     command: String,
+    directory: PathBuf,
     output: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PrCheckoutPlan {
+    directory: PathBuf,
+    branch: Option<PullRequestBranch>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1071,6 +1080,7 @@ fn start_review_comment_submit(
 fn start_pr_action(
     item: WorkItem,
     action: PrAction,
+    checkout: Option<PrCheckoutPlan>,
     config: Config,
     store: SnapshotStore,
     tx: UnboundedSender<AppMsg>,
@@ -1078,7 +1088,13 @@ fn start_pr_action(
     tokio::spawn(async move {
         let item_id = item.id.clone();
         if action == PrAction::Checkout {
-            let result = run_pr_checkout(item).await;
+            let Some(checkout) = checkout else {
+                let _ = tx.send(AppMsg::PrCheckoutFinished {
+                    result: Err("missing local checkout target".to_string()),
+                });
+                return;
+            };
+            let result = run_pr_checkout(item, checkout.directory).await;
             let _ = tx.send(AppMsg::PrCheckoutFinished { result });
             return;
         }
@@ -1128,7 +1144,10 @@ fn start_pr_action(
     });
 }
 
-async fn run_pr_checkout(item: WorkItem) -> std::result::Result<PrCheckoutResult, String> {
+async fn run_pr_checkout(
+    item: WorkItem,
+    directory: PathBuf,
+) -> std::result::Result<PrCheckoutResult, String> {
     let number = item
         .number
         .ok_or_else(|| "selected item has no pull request number".to_string())?;
@@ -1136,6 +1155,7 @@ async fn run_pr_checkout(item: WorkItem) -> std::result::Result<PrCheckoutResult
     let command = pr_checkout_command_display(&args);
     let output = TokioCommand::new("gh")
         .env("GH_PROMPT_DISABLED", "1")
+        .current_dir(&directory)
         .args(&args)
         .output()
         .await
@@ -1143,12 +1163,12 @@ async fn run_pr_checkout(item: WorkItem) -> std::result::Result<PrCheckoutResult
             if error.kind() == io::ErrorKind::NotFound {
                 format!(
                     "GitHub CLI `gh` is required for local checkout. Install it, run `gh auth login`, then retry.\n\n{}\n\nTried: {command}",
-                    checkout_cwd_notice(),
+                    checkout_directory_notice(&directory),
                 )
             } else {
                 format!(
                     "failed to run {command}: {error}\n\n{}",
-                    checkout_cwd_notice(),
+                    checkout_directory_notice(&directory),
                 )
             }
         })?;
@@ -1163,7 +1183,7 @@ async fn run_pr_checkout(item: WorkItem) -> std::result::Result<PrCheckoutResult
         return Err(format!(
             "{} failed.\n\n{}\n\n{}",
             command,
-            checkout_cwd_notice(),
+            checkout_directory_notice(&directory),
             truncate_text(&detail, 900),
         ));
     }
@@ -1173,7 +1193,11 @@ async fn run_pr_checkout(item: WorkItem) -> std::result::Result<PrCheckoutResult
     } else {
         truncate_text(&output_text, 900)
     };
-    Ok(PrCheckoutResult { command, output })
+    Ok(PrCheckoutResult {
+        command,
+        directory,
+        output,
+    })
 }
 
 fn pr_checkout_command_args(repository: &str, number: u64) -> Vec<String> {
@@ -1201,13 +1225,144 @@ fn command_output_text(stdout: &[u8], stderr: &[u8]) -> String {
     }
 }
 
-fn checkout_cwd_notice() -> String {
-    let cwd = std::env::current_dir()
-        .map(|path| path.display().to_string())
-        .unwrap_or_else(|_| "<unknown>".to_string());
-    format!(
-        "Checkout runs from the current working directory ({cwd}). GitHub CLI and GitHub are the source of truth for which repository and branch are checked out."
-    )
+fn checkout_directory_notice(directory: &Path) -> String {
+    format!("Checkout runs from {}.", directory.display())
+}
+
+fn resolve_pr_checkout_directory(
+    config: &Config,
+    repository: &str,
+) -> std::result::Result<PathBuf, String> {
+    if let Some(directory) = configured_local_dir_for_repo(config, repository) {
+        ensure_directory_tracks_repo(&directory, repository).map_err(|error| {
+            format!(
+                "Configured local_dir for {repository} cannot be used.\n\n{error}\n\nSet [[repos]].local_dir to a checkout whose git remote points at {repository}."
+            )
+        })?;
+        return Ok(directory);
+    }
+
+    let cwd = std::env::current_dir().map_err(|error| {
+        format!(
+            "Could not inspect the current working directory for {repository}: {error}\n\nSet [[repos]].local_dir for this repository."
+        )
+    })?;
+    ensure_directory_tracks_repo(&cwd, repository).map_err(|error| {
+        format!(
+            "No local checkout found for {repository}.\n\n{error}\n\nLaunch ghr inside a checkout whose git remote points at {repository}, or set [[repos]].local_dir for this repository."
+        )
+    })?;
+    Ok(cwd)
+}
+
+fn configured_local_dir_for_repo(config: &Config, repository: &str) -> Option<PathBuf> {
+    config
+        .repos
+        .iter()
+        .find(|repo| repo.repo.eq_ignore_ascii_case(repository))
+        .and_then(|repo| repo.local_dir.as_deref())
+        .map(str::trim)
+        .filter(|local_dir| !local_dir.is_empty())
+        .map(expand_user_path)
+}
+
+fn expand_user_path(value: &str) -> PathBuf {
+    if value == "~" {
+        return home_dir().unwrap_or_else(|| PathBuf::from(value));
+    }
+    if let Some(rest) = value.strip_prefix("~/")
+        && let Some(home) = home_dir()
+    {
+        return home.join(rest);
+    }
+    PathBuf::from(value)
+}
+
+fn home_dir() -> Option<PathBuf> {
+    std::env::var_os("HOME")
+        .filter(|home| !home.is_empty())
+        .map(PathBuf::from)
+        .or_else(::dirs::home_dir)
+}
+
+fn ensure_directory_tracks_repo(
+    directory: &Path,
+    repository: &str,
+) -> std::result::Result<(), String> {
+    if !directory.is_dir() {
+        return Err(format!("{} is not a directory.", directory.display()));
+    }
+    let remotes = git_remotes_for_directory(directory)?;
+    if remotes
+        .iter()
+        .any(|(_, repo)| repo.eq_ignore_ascii_case(repository))
+    {
+        return Ok(());
+    }
+
+    let remote_list = if remotes.is_empty() {
+        "no GitHub remotes found".to_string()
+    } else {
+        remotes
+            .iter()
+            .map(|(remote, repo)| format!("{remote} -> {repo}"))
+            .collect::<Vec<_>>()
+            .join(", ")
+    };
+    Err(format!(
+        "{} does not track {repository}; found {remote_list}.",
+        directory.display()
+    ))
+}
+
+fn git_remotes_for_directory(
+    directory: &Path,
+) -> std::result::Result<Vec<(String, String)>, String> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(directory)
+        .arg("remote")
+        .output()
+        .map_err(|error| {
+            format!(
+                "failed to run git remote in {}: {error}",
+                directory.display()
+            )
+        })?;
+    if !output.status.success() {
+        return Err(format!(
+            "{} is not a usable git checkout: {}",
+            directory.display(),
+            command_output_text(&output.stdout, &output.stderr)
+        ));
+    }
+
+    let mut remotes = Vec::new();
+    let names = String::from_utf8_lossy(&output.stdout);
+    for remote in names
+        .lines()
+        .map(str::trim)
+        .filter(|remote| !remote.is_empty())
+    {
+        if let Some(repo) = git_remote_repo(directory, remote) {
+            remotes.push((remote.to_string(), repo));
+        }
+    }
+    Ok(remotes)
+}
+
+fn git_remote_repo(directory: &Path, remote: &str) -> Option<String> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(directory)
+        .args(["remote", "get-url", remote])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let url = String::from_utf8(output.stdout).ok()?;
+    github_repo_from_remote_url(url.trim())
 }
 
 #[cfg(test)]
@@ -1349,7 +1504,7 @@ fn handle_key_in_area(
             _ => {}
         },
         FocusTarget::List if app.details_mode == DetailsMode::Diff => {
-            handle_diff_file_list_key(app, key, area)
+            handle_diff_file_list_key(app, key, config, area)
         }
         FocusTarget::List => match key.code {
             KeyCode::Esc if !app.search_query.is_empty() => app.clear_search(),
@@ -1387,7 +1542,7 @@ fn handle_key_in_area(
             KeyCode::Char('M') => app.start_pr_action_dialog(PrAction::Merge),
             KeyCode::Char('C') => app.start_pr_action_dialog(PrAction::Close),
             KeyCode::Char('A') => app.start_pr_action_dialog(PrAction::Approve),
-            KeyCode::Char('X') => app.start_pr_action_dialog(PrAction::Checkout),
+            KeyCode::Char('X') => app.start_pr_checkout_dialog(config),
             KeyCode::Char('a') => app.start_new_comment_dialog(),
             KeyCode::Enter => {
                 app.focus_details();
@@ -1409,7 +1564,7 @@ fn handle_key_in_area(
             KeyCode::Char('M') => app.start_pr_action_dialog(PrAction::Merge),
             KeyCode::Char('C') => app.start_pr_action_dialog(PrAction::Close),
             KeyCode::Char('A') => app.start_pr_action_dialog(PrAction::Approve),
-            KeyCode::Char('X') => app.start_pr_action_dialog(PrAction::Checkout),
+            KeyCode::Char('X') => app.start_pr_checkout_dialog(config),
             KeyCode::Char('c') if app.details_mode == DetailsMode::Diff => {
                 app.start_review_comment_dialog()
             }
@@ -1502,7 +1657,12 @@ fn handle_mouse_or_mark_key(app: &mut AppState, key: KeyEvent) -> bool {
     true
 }
 
-fn handle_diff_file_list_key(app: &mut AppState, key: KeyEvent, area: Option<Rect>) {
+fn handle_diff_file_list_key(
+    app: &mut AppState,
+    key: KeyEvent,
+    config: &Config,
+    area: Option<Rect>,
+) {
     match key.code {
         KeyCode::Esc => app.focus_details(),
         KeyCode::Char('c') => app.start_review_comment_dialog(),
@@ -1542,7 +1702,7 @@ fn handle_diff_file_list_key(app: &mut AppState, key: KeyEvent, area: Option<Rec
         KeyCode::Char('M') => app.start_pr_action_dialog(PrAction::Merge),
         KeyCode::Char('C') => app.start_pr_action_dialog(PrAction::Close),
         KeyCode::Char('A') => app.start_pr_action_dialog(PrAction::Approve),
-        KeyCode::Char('X') => app.start_pr_action_dialog(PrAction::Checkout),
+        KeyCode::Char('X') => app.start_pr_checkout_dialog(config),
         KeyCode::Enter => app.focus_details(),
         _ => {}
     }
@@ -3161,12 +3321,27 @@ fn draw_pr_action_dialog(
         key_value_line("pull request", number),
         key_value_line("title", dialog.item.title.clone()),
         if dialog.action == PrAction::Checkout {
-            Line::from("Runs gh pr checkout from the current working directory.")
+            key_value_line(
+                "local dir",
+                dialog
+                    .checkout
+                    .as_ref()
+                    .map(|checkout| checkout.directory.display().to_string())
+                    .unwrap_or_else(|| "-".to_string()),
+            )
         } else {
             Line::from("")
         },
         if dialog.action == PrAction::Checkout {
-            Line::from("GitHub CLI and GitHub are the source of truth.")
+            key_value_line(
+                "remote branch",
+                dialog
+                    .checkout
+                    .as_ref()
+                    .and_then(|checkout| checkout.branch.as_ref())
+                    .map(pull_request_branch_label)
+                    .unwrap_or_else(|| "unavailable".to_string()),
+            )
         } else {
             Line::from("")
         },
@@ -3671,7 +3846,7 @@ fn help_dialog_content() -> Vec<Line<'static>> {
         help_key_line("y / Enter", "run the confirmed PR action"),
         help_key_line(
             "X action",
-            "runs gh pr checkout from the current working directory",
+            "runs gh pr checkout from the matching local checkout",
         ),
         help_key_line("Esc", "cancel PR action"),
         Line::from(""),
@@ -4690,6 +4865,10 @@ fn build_conversation_document(app: &AppState, width: u16) -> DetailsDocument {
     }
     if matches!(item.kind, ItemKind::PullRequest) {
         let (action_text, note) = action_hint_text(app.action_hints.get(&item.id));
+        secondary_meta.push((
+            "branch",
+            branch_hint_segments(app.action_hints.get(&item.id)),
+        ));
         secondary_meta.push(("action", vec![DetailSegment::raw(action_text)]));
         secondary_meta.push((
             "checks",
@@ -6086,6 +6265,22 @@ fn action_hint_text(state: Option<&ActionHintState>) -> (String, Option<String>)
             Some(format!("Failed to load action hints: {error}")),
         ),
     }
+}
+
+fn branch_hint_segments(state: Option<&ActionHintState>) -> Vec<DetailSegment> {
+    match state {
+        Some(ActionHintState::Loaded(hints)) => hints
+            .head
+            .as_ref()
+            .map(|branch| vec![DetailSegment::raw(pull_request_branch_label(branch))])
+            .unwrap_or_else(|| vec![DetailSegment::raw("unavailable")]),
+        Some(ActionHintState::Loading) | None => vec![DetailSegment::raw("loading...")],
+        Some(ActionHintState::Error(_)) => vec![DetailSegment::raw("unavailable")],
+    }
+}
+
+fn pull_request_branch_label(branch: &PullRequestBranch) -> String {
+    format!("{}:{}", branch.repository, branch.branch)
 }
 
 fn check_hint_segments(state: Option<&ActionHintState>) -> Vec<DetailSegment> {
@@ -7757,7 +7952,7 @@ impl AppState {
                             format!(
                                 "{}\n\n{}\n\n{}",
                                 result.command,
-                                checkout_cwd_notice(),
+                                checkout_directory_notice(&result.directory),
                                 result.output
                             ),
                         ));
@@ -9243,7 +9438,11 @@ impl AppState {
         self.search_active = false;
         self.global_search_active = false;
         self.comment_search_active = false;
-        self.pr_action_dialog = Some(PrActionDialog { item, action });
+        self.pr_action_dialog = Some(PrActionDialog {
+            item,
+            action,
+            checkout: None,
+        });
         self.pr_action_running = false;
         self.status = match action {
             PrAction::Merge => "confirm pull request merge".to_string(),
@@ -9253,6 +9452,44 @@ impl AppState {
         };
     }
 
+    fn start_pr_checkout_dialog(&mut self, config: &Config) {
+        let Some(item) = self.current_item().cloned() else {
+            self.status = "nothing selected".to_string();
+            return;
+        };
+        if item.kind != ItemKind::PullRequest || item.number.is_none() {
+            self.status = "selected item is not a pull request".to_string();
+            return;
+        }
+
+        let directory = match resolve_pr_checkout_directory(config, &item.repo) {
+            Ok(directory) => directory,
+            Err(error) => {
+                self.message_dialog = Some(message_dialog("Checkout Unavailable", error));
+                self.status = "pull request checkout unavailable".to_string();
+                return;
+            }
+        };
+        let branch = self
+            .action_hints
+            .get(&item.id)
+            .and_then(|state| match state {
+                ActionHintState::Loaded(hints) => hints.head.clone(),
+                _ => None,
+            });
+
+        self.search_active = false;
+        self.global_search_active = false;
+        self.comment_search_active = false;
+        self.pr_action_dialog = Some(PrActionDialog {
+            item,
+            action: PrAction::Checkout,
+            checkout: Some(PrCheckoutPlan { directory, branch }),
+        });
+        self.pr_action_running = false;
+        self.status = "confirm local pull request checkout".to_string();
+    }
+
     fn handle_pr_action_dialog_key(
         &mut self,
         key: KeyEvent,
@@ -9260,14 +9497,21 @@ impl AppState {
         store: &SnapshotStore,
         tx: &UnboundedSender<AppMsg>,
     ) {
-        self.handle_pr_action_dialog_key_with_submit(key, |item, action| {
-            start_pr_action(item, action, config.clone(), store.clone(), tx.clone());
+        self.handle_pr_action_dialog_key_with_submit(key, |item, action, checkout| {
+            start_pr_action(
+                item,
+                action,
+                checkout,
+                config.clone(),
+                store.clone(),
+                tx.clone(),
+            );
         });
     }
 
     fn handle_pr_action_dialog_key_with_submit<F>(&mut self, key: KeyEvent, mut submit: F)
     where
-        F: FnMut(WorkItem, PrAction),
+        F: FnMut(WorkItem, PrAction, Option<PrCheckoutPlan>),
     {
         if self.pr_action_running {
             self.status = "pull request action already running".to_string();
@@ -9290,12 +9534,13 @@ impl AppState {
 
     fn submit_pr_action<F>(&mut self, action: PrAction, submit: &mut F)
     where
-        F: FnMut(WorkItem, PrAction),
+        F: FnMut(WorkItem, PrAction, Option<PrCheckoutPlan>),
     {
         let Some(dialog) = &self.pr_action_dialog else {
             return;
         };
         let item = dialog.item.clone();
+        let checkout = dialog.checkout.clone();
         self.pr_action_running = true;
         self.status = match action {
             PrAction::Merge => "merging pull request".to_string(),
@@ -9303,7 +9548,7 @@ impl AppState {
             PrAction::Approve => "approving pull request".to_string(),
             PrAction::Checkout => "checking out pull request locally".to_string(),
         };
-        submit(item, action);
+        submit(item, action, checkout);
     }
 
     fn start_new_comment_dialog(&mut self) {
@@ -13233,6 +13478,10 @@ diff --git a/src/github.rs b/src/github.rs
                     incomplete: false,
                 }),
                 note: Some("Merge blocked: checks pending".to_string()),
+                head: Some(PullRequestBranch {
+                    repository: "chenyukang/ghr".to_string(),
+                    branch: "feature/checks".to_string(),
+                }),
             }),
         );
 
@@ -13244,7 +13493,11 @@ diff --git a/src/github.rs b/src/github.rs
             .join("\n");
 
         assert!(rendered.contains("action: Approvable, Mergeable"));
-        assert!(rendered.contains("checks: 10 pass, 2 fail, 1 pending"));
+        assert!(rendered.contains("checks:"));
+        assert!(rendered.contains("10 pass"));
+        assert!(rendered.contains("2 fail"));
+        assert!(rendered.contains("1 pending"));
+        assert!(rendered.contains("branch: chenyukang/ghr:feature/checks"));
         assert!(rendered.contains("action note: Merge blocked: checks pending"));
     }
 
@@ -14311,9 +14564,9 @@ diff --git a/src/github.rs b/src/github.rs
 
     #[test]
     fn capital_x_key_opens_checkout_confirmation_for_pull_request_list() {
-        let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
+        let mut app = AppState::new(SectionKind::PullRequests, vec![checkout_test_section()]);
         let (tx, _rx) = mpsc::unbounded_channel();
-        let config = Config::default();
+        let config = checkout_test_config();
         let store = SnapshotStore::new(std::path::PathBuf::from("/tmp/ghr-test-unused.db"));
 
         assert!(!handle_key(
@@ -14326,17 +14579,30 @@ diff --git a/src/github.rs b/src/github.rs
 
         let dialog = app.pr_action_dialog.as_ref().expect("checkout dialog");
         assert_eq!(dialog.action, PrAction::Checkout);
-        assert_eq!(dialog.item.id, "1");
+        assert_eq!(dialog.item.id, "checkout-pr");
+        assert!(dialog.checkout.is_some());
         assert_eq!(app.status, "confirm local pull request checkout");
     }
 
     #[test]
     fn capital_x_key_opens_checkout_confirmation_for_pull_request_details() {
-        let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
+        let mut app = AppState::new(SectionKind::PullRequests, vec![checkout_test_section()]);
         let (tx, _rx) = mpsc::unbounded_channel();
-        let config = Config::default();
+        let config = checkout_test_config();
         let store = SnapshotStore::new(std::path::PathBuf::from("/tmp/ghr-test-unused.db"));
         app.focus_details();
+        app.action_hints.insert(
+            "checkout-pr".to_string(),
+            ActionHintState::Loaded(ActionHints {
+                labels: Vec::new(),
+                checks: None,
+                note: None,
+                head: Some(PullRequestBranch {
+                    repository: "chenyukang/ghr".to_string(),
+                    branch: "codex/pr-checkout-local".to_string(),
+                }),
+            }),
+        );
 
         assert!(!handle_key(
             &mut app,
@@ -14348,23 +14614,39 @@ diff --git a/src/github.rs b/src/github.rs
 
         let dialog = app.pr_action_dialog.as_ref().expect("checkout dialog");
         assert_eq!(dialog.action, PrAction::Checkout);
-        assert_eq!(dialog.item.id, "1");
+        assert_eq!(dialog.item.id, "checkout-pr");
+        assert_eq!(
+            dialog
+                .checkout
+                .as_ref()
+                .and_then(|checkout| checkout.branch.as_ref())
+                .map(pull_request_branch_label)
+                .as_deref(),
+            Some("chenyukang/ghr:codex/pr-checkout-local")
+        );
         assert_eq!(app.status, "confirm local pull request checkout");
     }
 
     #[test]
     fn checkout_confirmation_submits_selected_action() {
-        let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
-        app.start_pr_action_dialog(PrAction::Checkout);
+        let mut app = AppState::new(SectionKind::PullRequests, vec![checkout_test_section()]);
+        let config = checkout_test_config();
+        app.start_pr_checkout_dialog(&config);
         let mut submitted = None;
 
-        app.handle_pr_action_dialog_key_with_submit(key(KeyCode::Enter), |item, action| {
-            submitted = Some((item.id, action));
-        });
+        app.handle_pr_action_dialog_key_with_submit(
+            key(KeyCode::Enter),
+            |item, action, checkout| {
+                submitted = Some((item.id, action, checkout));
+            },
+        );
 
         assert!(app.pr_action_running);
         assert_eq!(app.status, "checking out pull request locally");
-        assert_eq!(submitted, Some(("1".to_string(), PrAction::Checkout)));
+        assert!(matches!(
+            submitted,
+            Some((id, PrAction::Checkout, Some(_))) if id == "checkout-pr"
+        ));
     }
 
     #[test]
@@ -14393,7 +14675,7 @@ diff --git a/src/github.rs b/src/github.rs
         app.start_pr_action_dialog(PrAction::Approve);
         let mut submitted = None;
 
-        app.handle_pr_action_dialog_key_with_submit(key(KeyCode::Enter), |item, action| {
+        app.handle_pr_action_dialog_key_with_submit(key(KeyCode::Enter), |item, action, _| {
             submitted = Some((item.id, action));
         });
 
@@ -14407,7 +14689,7 @@ diff --git a/src/github.rs b/src/github.rs
         let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
         app.start_pr_action_dialog(PrAction::Merge);
 
-        app.handle_pr_action_dialog_key_with_submit(key(KeyCode::Esc), |_item, _action| {
+        app.handle_pr_action_dialog_key_with_submit(key(KeyCode::Esc), |_item, _action, _| {
             panic!("escape should not submit the action");
         });
 
@@ -14561,6 +14843,7 @@ diff --git a/src/github.rs b/src/github.rs
         app.handle_msg(AppMsg::PrCheckoutFinished {
             result: Ok(PrCheckoutResult {
                 command: "gh pr checkout 1 --repo rust-lang/rust".to_string(),
+                directory: PathBuf::from("/tmp/rust"),
                 output: "Switched to branch 'diagnostics'".to_string(),
             }),
         });
@@ -14575,7 +14858,7 @@ diff --git a/src/github.rs b/src/github.rs
                 .body
                 .contains("gh pr checkout 1 --repo rust-lang/rust")
         );
-        assert!(dialog.body.contains("current working directory"));
+        assert!(dialog.body.contains("Checkout runs from /tmp/rust."));
         assert!(dialog.body.contains("Switched to branch"));
         assert!(dialog.auto_close_at.is_none());
     }
@@ -14588,7 +14871,7 @@ diff --git a/src/github.rs b/src/github.rs
 
         app.handle_msg(AppMsg::PrCheckoutFinished {
             result: Err(
-                "gh pr checkout 1 --repo rust-lang/rust failed.\n\nCheckout runs from the current working directory (/tmp). GitHub CLI and GitHub are the source of truth.\n\nfatal: not a git repository"
+                "gh pr checkout 1 --repo rust-lang/rust failed.\n\nCheckout runs from /tmp.\n\nfatal: not a git repository"
                     .to_string(),
             ),
         });
@@ -14598,7 +14881,7 @@ diff --git a/src/github.rs b/src/github.rs
         assert_eq!(app.status, "pull request checkout failed");
         let dialog = app.message_dialog.as_ref().expect("message dialog");
         assert_eq!(dialog.title, "Checkout Failed");
-        assert!(dialog.body.contains("current working directory"));
+        assert!(dialog.body.contains("Checkout runs from /tmp."));
         assert!(dialog.body.contains("fatal: not a git repository"));
         assert!(dialog.auto_close_at.is_none());
     }
@@ -15422,12 +15705,14 @@ diff --git a/src/github.rs b/src/github.rs
         config.repos.push(crate::config::RepoConfig {
             name: "runnel".to_string(),
             repo: "chenyukang/runnel".to_string(),
+            local_dir: None,
             show_prs: true,
             show_issues: true,
         });
         config.repos.push(crate::config::RepoConfig {
             name: "Fiber".to_string(),
             repo: "nervosnetwork/fiber".to_string(),
+            local_dir: None,
             show_prs: true,
             show_issues: true,
         });
@@ -16691,6 +16976,81 @@ diff --git a/d.rs b/d.rs
             refreshed_at: None,
             error: None,
         }
+    }
+
+    fn checkout_test_section() -> SectionSnapshot {
+        SectionSnapshot {
+            key: "pull_requests:checkout".to_string(),
+            kind: SectionKind::PullRequests,
+            title: "Checkout".to_string(),
+            filters: String::new(),
+            items: vec![work_item(
+                "checkout-pr",
+                "chenyukang/ghr",
+                19,
+                "Add local PR checkout",
+                None,
+            )],
+            total_count: None,
+            page: 1,
+            page_size: 0,
+            refreshed_at: None,
+            error: None,
+        }
+    }
+
+    fn checkout_test_config() -> Config {
+        let local_dir = checkout_test_repo_dir();
+        let mut config = Config::default();
+        config.repos.push(crate::config::RepoConfig {
+            name: "ghr".to_string(),
+            repo: "chenyukang/ghr".to_string(),
+            local_dir: Some(local_dir.display().to_string()),
+            show_prs: true,
+            show_issues: true,
+        });
+        config
+    }
+
+    fn checkout_test_repo_dir() -> PathBuf {
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time")
+            .as_nanos();
+        let dir =
+            std::env::temp_dir().join(format!("ghr-checkout-test-{}-{unique}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("create checkout test dir");
+
+        let init = Command::new("git")
+            .arg("-C")
+            .arg(&dir)
+            .args(["init", "-q"])
+            .output()
+            .expect("run git init");
+        assert!(
+            init.status.success(),
+            "git init failed: {}",
+            command_output_text(&init.stdout, &init.stderr)
+        );
+
+        let remote = Command::new("git")
+            .arg("-C")
+            .arg(&dir)
+            .args([
+                "remote",
+                "add",
+                "origin",
+                "https://github.com/chenyukang/ghr.git",
+            ])
+            .output()
+            .expect("run git remote add");
+        assert!(
+            remote.status.success(),
+            "git remote add failed: {}",
+            command_output_text(&remote.stdout, &remote.stderr)
+        );
+
+        dir
     }
 
     fn many_items_section(count: u64) -> SectionSnapshot {

--- a/src/app.rs
+++ b/src/app.rs
@@ -315,6 +315,7 @@ const COMMENT_DIALOG_MIN_EDITOR_HEIGHT: u16 = 4;
 const COMMENT_DIALOG_EDITOR_PADDING_LINES: u16 = 1;
 const COMMENT_DIALOG_FALLBACK_EDITOR_HEIGHT: u16 = 10;
 const COMMENT_DIALOG_FALLBACK_EDITOR_WIDTH: u16 = 48;
+const PR_ACTION_REMOTE_BRANCH_LINE: u16 = 6;
 const COMMENT_LEFT_PADDING: usize = 2;
 const COMMENT_RIGHT_PADDING: usize = 4;
 const COMMENT_COLLAPSE_MIN_LINES: usize = 36;
@@ -1761,7 +1762,12 @@ fn handle_mouse_with_sync(
     if app.message_dialog.is_some() {
         return false;
     }
-    if app.pr_action_dialog.is_some() {
+    if let Some(dialog) = &app.pr_action_dialog {
+        if matches!(mouse.kind, MouseEventKind::Down(MouseButton::Left))
+            && let Some(url) = pr_action_dialog_link_at(dialog, area, mouse.column, mouse.row)
+        {
+            app.open_url(&url);
+        }
         return false;
     }
     if let Some(dialog) = &app.comment_dialog {
@@ -3286,12 +3292,7 @@ fn draw_pr_action_dialog(
     running: bool,
     area: Rect,
 ) {
-    let dialog_height = if dialog.action == PrAction::Checkout {
-        14
-    } else {
-        12
-    };
-    let dialog_area = centered_rect(66, dialog_height, area);
+    let dialog_area = pr_action_dialog_area(dialog, area);
     let number = dialog
         .item
         .number
@@ -3333,14 +3334,11 @@ fn draw_pr_action_dialog(
             Line::from("")
         },
         if dialog.action == PrAction::Checkout {
-            key_value_line(
-                "remote branch",
+            remote_branch_line(
                 dialog
                     .checkout
                     .as_ref()
-                    .and_then(|checkout| checkout.branch.as_ref())
-                    .map(pull_request_branch_label)
-                    .unwrap_or_else(|| "unavailable".to_string()),
+                    .and_then(|checkout| checkout.branch.as_ref()),
             )
         } else {
             Line::from("")
@@ -3375,6 +3373,54 @@ fn draw_pr_action_dialog(
 
     frame.render_widget(Clear, dialog_area);
     frame.render_widget(paragraph, dialog_area);
+}
+
+fn pr_action_dialog_area(dialog: &PrActionDialog, area: Rect) -> Rect {
+    let dialog_height = if dialog.action == PrAction::Checkout {
+        14
+    } else {
+        12
+    };
+    centered_rect(66, dialog_height, area)
+}
+
+fn remote_branch_line(branch: Option<&PullRequestBranch>) -> Line<'static> {
+    let Some(branch) = branch else {
+        return key_value_line("remote branch", "unavailable".to_string());
+    };
+    Line::from(vec![
+        Span::styled("remote branch: ", Style::default().fg(Color::Gray)),
+        Span::styled(pull_request_branch_label(branch), link_style()),
+    ])
+}
+
+fn pr_action_dialog_link_at(
+    dialog: &PrActionDialog,
+    area: Rect,
+    column: u16,
+    row: u16,
+) -> Option<String> {
+    if dialog.action != PrAction::Checkout {
+        return None;
+    }
+    let branch = dialog
+        .checkout
+        .as_ref()
+        .and_then(|checkout| checkout.branch.as_ref())?;
+    let dialog_area = pr_action_dialog_area(dialog, area);
+    let inner = block_inner(dialog_area);
+    if !rect_contains(inner, column, row) {
+        return None;
+    }
+    let content_row = row.saturating_sub(inner.y);
+    if content_row != PR_ACTION_REMOTE_BRANCH_LINE {
+        return None;
+    }
+    let label = pull_request_branch_label(branch);
+    let start = display_width("remote branch: ") as u16;
+    let end = start.saturating_add(display_width(&label) as u16);
+    let clicked = column.saturating_sub(inner.x);
+    (clicked >= start && clicked < end).then(|| pull_request_branch_url(branch))
 }
 
 fn draw_message_dialog(frame: &mut Frame<'_>, dialog: &MessageDialog, area: Rect) {
@@ -4285,13 +4331,16 @@ impl DetailsBuilder {
     }
 
     fn push_key_value(&mut self, key: &str, value: impl Into<String>) {
-        self.push_wrapped_limited(
-            vec![
-                DetailSegment::styled(format!("{key}: "), Style::default().fg(Color::Gray)),
-                DetailSegment::raw(value.into()),
-            ],
-            1,
-        );
+        self.push_styled_key_value(key, vec![DetailSegment::raw(value.into())]);
+    }
+
+    fn push_styled_key_value(&mut self, key: &str, value: Vec<DetailSegment>) {
+        let mut segments = vec![DetailSegment::styled(
+            format!("{key}: "),
+            Style::default().fg(Color::Gray),
+        )];
+        segments.extend(value);
+        self.push_wrapped_limited(segments, 1);
     }
 
     fn push_link_value(&mut self, key: &str, url: &str) {
@@ -4847,6 +4896,7 @@ fn build_conversation_document(app: &AppState, width: u16) -> DetailsDocument {
     ]);
 
     let mut secondary_meta = Vec::new();
+    let mut action_meta = Vec::new();
     let mut action_note = None;
     if let Some(author) = useful_meta_value(item.author.as_deref()) {
         secondary_meta.push((
@@ -4864,13 +4914,13 @@ fn build_conversation_document(app: &AppState, width: u16) -> DetailsDocument {
         secondary_meta.push(("reason", vec![DetailSegment::raw(reason.to_string())]));
     }
     if matches!(item.kind, ItemKind::PullRequest) {
-        let (action_text, note) = action_hint_text(app.action_hints.get(&item.id));
+        let (action_segments, note) = action_hint_segments(app.action_hints.get(&item.id));
         secondary_meta.push((
             "branch",
             branch_hint_segments(app.action_hints.get(&item.id)),
         ));
-        secondary_meta.push(("action", vec![DetailSegment::raw(action_text)]));
-        secondary_meta.push((
+        action_meta.push(("action", action_segments));
+        action_meta.push((
             "checks",
             check_hint_segments(app.action_hints.get(&item.id)),
         ));
@@ -4879,8 +4929,11 @@ fn build_conversation_document(app: &AppState, width: u16) -> DetailsDocument {
     if !secondary_meta.is_empty() {
         builder.push_meta_line(secondary_meta);
     }
+    if !action_meta.is_empty() {
+        builder.push_meta_line(action_meta);
+    }
     if let Some(note) = action_note {
-        builder.push_key_value("action note", note);
+        builder.push_styled_key_value("action note", action_note_segments(&note));
     }
     builder.push_link_value("url", &item.url);
 
@@ -6249,22 +6302,61 @@ fn comment_right_padding(selected: bool) -> usize {
     COMMENT_RIGHT_PADDING + usize::from(selected)
 }
 
-fn action_hint_text(state: Option<&ActionHintState>) -> (String, Option<String>) {
+fn action_hint_segments(state: Option<&ActionHintState>) -> (Vec<DetailSegment>, Option<String>) {
     match state {
         Some(ActionHintState::Loaded(hints)) => {
-            let text = if hints.labels.is_empty() {
-                "-".to_string()
+            let segments = if hints.labels.is_empty() {
+                vec![DetailSegment::raw("-")]
             } else {
-                hints.labels.join(", ")
+                action_label_segments(&hints.labels)
             };
-            (text, hints.note.clone())
+            (segments, hints.note.clone())
         }
-        Some(ActionHintState::Loading) | None => ("loading...".to_string(), None),
+        Some(ActionHintState::Loading) | None => (vec![DetailSegment::raw("loading...")], None),
         Some(ActionHintState::Error(error)) => (
-            "unavailable".to_string(),
+            vec![DetailSegment::raw("unavailable")],
             Some(format!("Failed to load action hints: {error}")),
         ),
     }
+}
+
+fn action_label_segments(labels: &[String]) -> Vec<DetailSegment> {
+    let mut segments = Vec::new();
+    for label in labels {
+        if !segments.is_empty() {
+            segments.push(DetailSegment::raw(", "));
+        }
+        let style = if label == "Mergeable" {
+            Style::default().fg(Color::LightGreen)
+        } else {
+            Style::default()
+        };
+        segments.push(DetailSegment::styled(label, style));
+    }
+    segments
+}
+
+fn action_note_segments(note: &str) -> Vec<DetailSegment> {
+    const CONFLICTS: &str = "merge conflicts must be resolved";
+    let mut segments = Vec::new();
+    let mut rest = note;
+    while let Some(index) = rest.find(CONFLICTS) {
+        if index > 0 {
+            segments.push(DetailSegment::raw(rest[..index].to_string()));
+        }
+        segments.push(DetailSegment::styled(
+            CONFLICTS,
+            log_error_style().add_modifier(Modifier::BOLD),
+        ));
+        rest = &rest[index + CONFLICTS.len()..];
+    }
+    if !rest.is_empty() {
+        segments.push(DetailSegment::raw(rest.to_string()));
+    }
+    if segments.is_empty() {
+        segments.push(DetailSegment::raw(note.to_string()));
+    }
+    segments
 }
 
 fn branch_hint_segments(state: Option<&ActionHintState>) -> Vec<DetailSegment> {
@@ -6281,6 +6373,13 @@ fn branch_hint_segments(state: Option<&ActionHintState>) -> Vec<DetailSegment> {
 
 fn pull_request_branch_label(branch: &PullRequestBranch) -> String {
     format!("{}:{}", branch.repository, branch.branch)
+}
+
+fn pull_request_branch_url(branch: &PullRequestBranch) -> String {
+    format!(
+        "https://github.com/{}/tree/{}",
+        branch.repository, branch.branch
+    )
 }
 
 fn check_hint_segments(state: Option<&ActionHintState>) -> Vec<DetailSegment> {
@@ -13485,12 +13584,12 @@ diff --git a/src/github.rs b/src/github.rs
             }),
         );
 
-        let rendered = build_details_document(&app, 120)
+        let lines = build_details_document(&app, 120)
             .lines
             .iter()
             .map(|line| line.to_string())
-            .collect::<Vec<_>>()
-            .join("\n");
+            .collect::<Vec<_>>();
+        let rendered = lines.join("\n");
 
         assert!(rendered.contains("action: Approvable, Mergeable"));
         assert!(rendered.contains("checks:"));
@@ -13499,6 +13598,18 @@ diff --git a/src/github.rs b/src/github.rs
         assert!(rendered.contains("1 pending"));
         assert!(rendered.contains("branch: chenyukang/ghr:feature/checks"));
         assert!(rendered.contains("action note: Merge blocked: checks pending"));
+        let branch_line = lines
+            .iter()
+            .position(|line| line.contains("branch: chenyukang/ghr:feature/checks"))
+            .expect("branch line");
+        let action_line = lines
+            .iter()
+            .position(|line| line.contains("action: Approvable, Mergeable"))
+            .expect("action line");
+        assert!(
+            action_line > branch_line,
+            "action/checks should start on a new line"
+        );
     }
 
     #[test]
@@ -13518,6 +13629,45 @@ diff --git a/src/github.rs b/src/github.rs
             .expect("failed check segment");
         assert_eq!(failed.style.fg, Some(Color::LightRed));
         assert!(failed.style.add_modifier.contains(Modifier::BOLD));
+    }
+
+    #[test]
+    fn mergeable_action_label_is_rendered_green() {
+        let segments = action_label_segments(&["Approvable".to_string(), "Mergeable".to_string()]);
+
+        let approvable = segments
+            .iter()
+            .find(|segment| segment.text == "Approvable")
+            .expect("approvable segment");
+        assert_eq!(approvable.style, Style::default());
+
+        let mergeable = segments
+            .iter()
+            .find(|segment| segment.text == "Mergeable")
+            .expect("mergeable segment");
+        assert_eq!(mergeable.style.fg, Some(Color::LightGreen));
+    }
+
+    #[test]
+    fn merge_conflict_action_note_is_rendered_red() {
+        let segments =
+            action_note_segments("Merge blocked: draft; merge conflicts must be resolved");
+
+        let conflict = segments
+            .iter()
+            .find(|segment| segment.text == "merge conflicts must be resolved")
+            .expect("conflict segment");
+        assert_eq!(conflict.style.fg, Some(Color::LightRed));
+        assert!(conflict.style.add_modifier.contains(Modifier::BOLD));
+
+        let rendered = segments
+            .iter()
+            .map(|segment| segment.text.as_str())
+            .collect::<String>();
+        assert_eq!(
+            rendered,
+            "Merge blocked: draft; merge conflicts must be resolved"
+        );
     }
 
     #[test]
@@ -14625,6 +14775,42 @@ diff --git a/src/github.rs b/src/github.rs
             Some("chenyukang/ghr:codex/pr-checkout-local")
         );
         assert_eq!(app.status, "confirm local pull request checkout");
+    }
+
+    #[test]
+    fn checkout_confirmation_remote_branch_is_clickable() {
+        let mut app = AppState::new(SectionKind::PullRequests, vec![checkout_test_section()]);
+        let config = checkout_test_config();
+        app.action_hints.insert(
+            "checkout-pr".to_string(),
+            ActionHintState::Loaded(ActionHints {
+                labels: Vec::new(),
+                checks: None,
+                note: None,
+                head: Some(PullRequestBranch {
+                    repository: "chenyukang/ghr".to_string(),
+                    branch: "codex/pr-checkout-local".to_string(),
+                }),
+            }),
+        );
+        app.start_pr_checkout_dialog(&config);
+        let dialog = app.pr_action_dialog.as_ref().expect("checkout dialog");
+        let area = Rect::new(0, 0, 120, 40);
+        let inner = block_inner(pr_action_dialog_area(dialog, area));
+        let branch_column = inner
+            .x
+            .saturating_add(display_width("remote branch: ") as u16)
+            .saturating_add(1);
+        let branch_row = inner.y.saturating_add(PR_ACTION_REMOTE_BRANCH_LINE);
+
+        assert_eq!(
+            pr_action_dialog_link_at(dialog, area, branch_column, branch_row).as_deref(),
+            Some("https://github.com/chenyukang/ghr/tree/codex/pr-checkout-local")
+        );
+        assert_eq!(
+            pr_action_dialog_link_at(dialog, area, branch_column.saturating_sub(2), branch_row),
+            None
+        );
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -24,6 +24,7 @@ use ratatui::widgets::{
     Wrap,
 };
 use ratatui::{Frame, Terminal};
+use tokio::process::Command as TokioCommand;
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use tracing::warn;
 
@@ -110,6 +111,9 @@ enum AppMsg {
         item_id: String,
         action: PrAction,
         result: std::result::Result<(), String>,
+    },
+    PrCheckoutFinished {
+        result: std::result::Result<PrCheckoutResult, String>,
     },
     NotificationReadFinished {
         thread_id: String,
@@ -247,12 +251,19 @@ enum PrAction {
     Merge,
     Close,
     Approve,
+    Checkout,
 }
 
 #[derive(Debug, Clone)]
 struct PrActionDialog {
     item: WorkItem,
     action: PrAction,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PrCheckoutResult {
+    command: String,
+    output: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1066,6 +1077,12 @@ fn start_pr_action(
 ) {
     tokio::spawn(async move {
         let item_id = item.id.clone();
+        if action == PrAction::Checkout {
+            let result = run_pr_checkout(item).await;
+            let _ = tx.send(AppMsg::PrCheckoutFinished { result });
+            return;
+        }
+
         let result = match item.number {
             Some(number) => match action {
                 PrAction::Merge => merge_pull_request(&item.repo, number)
@@ -1077,6 +1094,7 @@ fn start_pr_action(
                 PrAction::Approve => approve_pull_request(&item.repo, number)
                     .await
                     .map_err(|error| error.to_string()),
+                PrAction::Checkout => unreachable!("checkout is handled before remote PR actions"),
             },
             None => Err("selected item has no pull request number".to_string()),
         };
@@ -1108,6 +1126,88 @@ fn start_pr_action(
             });
         }
     });
+}
+
+async fn run_pr_checkout(item: WorkItem) -> std::result::Result<PrCheckoutResult, String> {
+    let number = item
+        .number
+        .ok_or_else(|| "selected item has no pull request number".to_string())?;
+    let args = pr_checkout_command_args(&item.repo, number);
+    let command = pr_checkout_command_display(&args);
+    let output = TokioCommand::new("gh")
+        .env("GH_PROMPT_DISABLED", "1")
+        .args(&args)
+        .output()
+        .await
+        .map_err(|error| {
+            if error.kind() == io::ErrorKind::NotFound {
+                format!(
+                    "GitHub CLI `gh` is required for local checkout. Install it, run `gh auth login`, then retry.\n\n{}\n\nTried: {command}",
+                    checkout_cwd_notice(),
+                )
+            } else {
+                format!(
+                    "failed to run {command}: {error}\n\n{}",
+                    checkout_cwd_notice(),
+                )
+            }
+        })?;
+
+    let output_text = command_output_text(&output.stdout, &output.stderr);
+    if !output.status.success() {
+        let detail = if output_text.is_empty() {
+            "gh did not return any output".to_string()
+        } else {
+            output_text
+        };
+        return Err(format!(
+            "{} failed.\n\n{}\n\n{}",
+            command,
+            checkout_cwd_notice(),
+            truncate_text(&detail, 900),
+        ));
+    }
+
+    let output = if output_text.is_empty() {
+        "gh pr checkout completed successfully.".to_string()
+    } else {
+        truncate_text(&output_text, 900)
+    };
+    Ok(PrCheckoutResult { command, output })
+}
+
+fn pr_checkout_command_args(repository: &str, number: u64) -> Vec<String> {
+    vec![
+        "pr".to_string(),
+        "checkout".to_string(),
+        number.to_string(),
+        "--repo".to_string(),
+        repository.to_string(),
+    ]
+}
+
+fn pr_checkout_command_display(args: &[String]) -> String {
+    format!("gh {}", args.join(" "))
+}
+
+fn command_output_text(stdout: &[u8], stderr: &[u8]) -> String {
+    let stdout = String::from_utf8_lossy(stdout).trim().to_string();
+    let stderr = String::from_utf8_lossy(stderr).trim().to_string();
+    match (stdout.is_empty(), stderr.is_empty()) {
+        (true, true) => String::new(),
+        (false, true) => stdout,
+        (true, false) => stderr,
+        (false, false) => format!("{stdout}\n{stderr}"),
+    }
+}
+
+fn checkout_cwd_notice() -> String {
+    let cwd = std::env::current_dir()
+        .map(|path| path.display().to_string())
+        .unwrap_or_else(|_| "<unknown>".to_string());
+    format!(
+        "Checkout runs from the current working directory ({cwd}). GitHub CLI and GitHub are the source of truth for which repository and branch are checked out."
+    )
 }
 
 #[cfg(test)]
@@ -1287,6 +1387,7 @@ fn handle_key_in_area(
             KeyCode::Char('M') => app.start_pr_action_dialog(PrAction::Merge),
             KeyCode::Char('C') => app.start_pr_action_dialog(PrAction::Close),
             KeyCode::Char('A') => app.start_pr_action_dialog(PrAction::Approve),
+            KeyCode::Char('X') => app.start_pr_action_dialog(PrAction::Checkout),
             KeyCode::Char('a') => app.start_new_comment_dialog(),
             KeyCode::Enter => {
                 app.focus_details();
@@ -1308,6 +1409,7 @@ fn handle_key_in_area(
             KeyCode::Char('M') => app.start_pr_action_dialog(PrAction::Merge),
             KeyCode::Char('C') => app.start_pr_action_dialog(PrAction::Close),
             KeyCode::Char('A') => app.start_pr_action_dialog(PrAction::Approve),
+            KeyCode::Char('X') => app.start_pr_action_dialog(PrAction::Checkout),
             KeyCode::Char('c') if app.details_mode == DetailsMode::Diff => {
                 app.start_review_comment_dialog()
             }
@@ -1440,6 +1542,7 @@ fn handle_diff_file_list_key(app: &mut AppState, key: KeyEvent, area: Option<Rec
         KeyCode::Char('M') => app.start_pr_action_dialog(PrAction::Merge),
         KeyCode::Char('C') => app.start_pr_action_dialog(PrAction::Close),
         KeyCode::Char('A') => app.start_pr_action_dialog(PrAction::Approve),
+        KeyCode::Char('X') => app.start_pr_action_dialog(PrAction::Checkout),
         KeyCode::Enter => app.focus_details(),
         _ => {}
     }
@@ -2679,7 +2782,7 @@ fn push_footer_focus_shortcuts(spans: &mut Vec<Span<'static>>, app: &AppState) {
                 push_footer_pair(spans, "enter", "diff", Color::Cyan);
                 push_footer_pair(spans, "c", "inline", Color::LightBlue);
                 push_footer_pair(spans, "a", "comment", Color::LightBlue);
-                push_footer_pair(spans, "M/C/A", "pr action", Color::LightMagenta);
+                push_footer_pair(spans, "M/C/A/X", "pr action", Color::LightMagenta);
             } else {
                 push_footer_context(spans, "List", "items");
                 push_footer_pair(spans, "j/k", "move", Color::Cyan);
@@ -2693,7 +2796,7 @@ fn push_footer_focus_shortcuts(spans: &mut Vec<Span<'static>>, app: &AppState) {
                 }
                 push_footer_pair(spans, "v", "diff", Color::LightMagenta);
                 push_footer_pair(spans, "a", "comment", Color::LightBlue);
-                push_footer_pair(spans, "M/C/A", "pr action", Color::LightMagenta);
+                push_footer_pair(spans, "M/C/A/X", "pr action", Color::LightMagenta);
             }
         }
         FocusTarget::Details => {
@@ -2717,7 +2820,7 @@ fn push_footer_focus_shortcuts(spans: &mut Vec<Span<'static>>, app: &AppState) {
                 push_footer_pair(spans, "e", "end", Color::Yellow);
                 push_footer_pair(spans, "c", "inline", Color::LightBlue);
                 push_footer_pair(spans, "a", "comment", Color::LightBlue);
-                push_footer_pair(spans, "M/C/A", "pr action", Color::LightMagenta);
+                push_footer_pair(spans, "M/C/A/X", "pr action", Color::LightMagenta);
             } else {
                 push_footer_pair(spans, "v", "diff", Color::LightMagenta);
                 push_footer_pair(spans, "/", "search", Color::Yellow);
@@ -2726,7 +2829,7 @@ fn push_footer_focus_shortcuts(spans: &mut Vec<Span<'static>>, app: &AppState) {
                 push_footer_pair(spans, "c/a", "comment", Color::LightBlue);
                 push_footer_pair(spans, "R", "reply", Color::LightBlue);
                 push_footer_pair(spans, "e", "edit", Color::LightBlue);
-                push_footer_pair(spans, "M/C/A", "pr action", Color::LightMagenta);
+                push_footer_pair(spans, "M/C/A/X", "pr action", Color::LightMagenta);
             }
             push_footer_pair(spans, "esc", "List", Color::Cyan);
         }
@@ -3023,7 +3126,12 @@ fn draw_pr_action_dialog(
     running: bool,
     area: Rect,
 ) {
-    let dialog_area = centered_rect(66, 12, area);
+    let dialog_height = if dialog.action == PrAction::Checkout {
+        14
+    } else {
+        12
+    };
+    let dialog_area = centered_rect(66, dialog_height, area);
     let number = dialog
         .item
         .number
@@ -3033,11 +3141,13 @@ fn draw_pr_action_dialog(
         PrAction::Merge => "merge",
         PrAction::Close => "close",
         PrAction::Approve => "approve",
+        PrAction::Checkout => "checkout",
     };
     let prompt = match dialog.action {
         PrAction::Merge => "Merge this pull request on GitHub?",
         PrAction::Close => "Close this pull request on GitHub?",
         PrAction::Approve => "Approve this pull request on GitHub?",
+        PrAction::Checkout => "Checkout this pull request locally?",
     };
     let status = if running {
         "working...".to_string()
@@ -3050,6 +3160,16 @@ fn draw_pr_action_dialog(
         key_value_line("repo", dialog.item.repo.clone()),
         key_value_line("pull request", number),
         key_value_line("title", dialog.item.title.clone()),
+        if dialog.action == PrAction::Checkout {
+            Line::from("Runs gh pr checkout from the current working directory.")
+        } else {
+            Line::from("")
+        },
+        if dialog.action == PrAction::Checkout {
+            Line::from("GitHub CLI and GitHub are the source of truth.")
+        } else {
+            Line::from("")
+        },
         Line::from(""),
         Line::from(vec![Span::styled(
             status,
@@ -3067,6 +3187,7 @@ fn draw_pr_action_dialog(
                 PrAction::Merge => "Merge Pull Request",
                 PrAction::Close => "Close Pull Request",
                 PrAction::Approve => "Approve Pull Request",
+                PrAction::Checkout => "Checkout Pull Request Locally",
             },
             Style::default()
                 .fg(Color::Yellow)
@@ -3505,6 +3626,7 @@ fn help_dialog_content() -> Vec<Line<'static>> {
         help_key_line("M", "open PR merge confirmation"),
         help_key_line("C", "open PR close confirmation"),
         help_key_line("A", "open PR approve confirmation"),
+        help_key_line("X", "open local PR checkout confirmation"),
         help_key_line("a", "add a new issue or PR comment"),
         Line::from(""),
         help_heading("Diff Files"),
@@ -3542,10 +3664,15 @@ fn help_dialog_content() -> Vec<Line<'static>> {
         help_key_line("M", "open PR merge confirmation"),
         help_key_line("C", "open PR close confirmation"),
         help_key_line("A", "open PR approve confirmation"),
+        help_key_line("X", "open local PR checkout confirmation"),
         help_key_line("o", "open selected item in browser"),
         Line::from(""),
         help_heading("Pull Request Confirmation"),
         help_key_line("y / Enter", "run the confirmed PR action"),
+        help_key_line(
+            "X action",
+            "runs gh pr checkout from the current working directory",
+        ),
         help_key_line("Esc", "cancel PR action"),
         Line::from(""),
         help_heading("Repo Search"),
@@ -7595,6 +7722,7 @@ impl AppState {
                             PrAction::Merge => "pull request merged; refreshing".to_string(),
                             PrAction::Close => "pull request closed; refreshing".to_string(),
                             PrAction::Approve => "pull request approved; refreshing".to_string(),
+                            PrAction::Checkout => "pull request checked out locally".to_string(),
                         };
                         self.message_dialog = Some(success_message_dialog(
                             pr_action_success_title(action),
@@ -7615,6 +7743,39 @@ impl AppState {
                             self.message_dialog = None;
                         }
                         self.status = pr_action_error_status(action).to_string();
+                    }
+                }
+            }
+            AppMsg::PrCheckoutFinished { result } => {
+                self.pr_action_running = false;
+                self.pr_action_dialog = None;
+                match result {
+                    Ok(result) => {
+                        self.status = "pull request checked out locally".to_string();
+                        self.message_dialog = Some(message_dialog(
+                            pr_action_success_title(PrAction::Checkout),
+                            format!(
+                                "{}\n\n{}\n\n{}",
+                                result.command,
+                                checkout_cwd_notice(),
+                                result.output
+                            ),
+                        ));
+                    }
+                    Err(error) => {
+                        let setup_dialog = setup_dialog_from_error(&error);
+                        if self.setup_dialog.is_none() {
+                            self.setup_dialog = setup_dialog;
+                        }
+                        if setup_dialog.is_none() {
+                            self.message_dialog = Some(message_dialog(
+                                pr_action_error_title(PrAction::Checkout),
+                                pr_action_error_body(&error),
+                            ));
+                        } else {
+                            self.message_dialog = None;
+                        }
+                        self.status = pr_action_error_status(PrAction::Checkout).to_string();
                     }
                 }
             }
@@ -7765,6 +7926,7 @@ impl AppState {
                     PrAction::Merge => item.state = Some("merged".to_string()),
                     PrAction::Close => item.state = Some("closed".to_string()),
                     PrAction::Approve => {}
+                    PrAction::Checkout => {}
                 }
             }
         }
@@ -9087,6 +9249,7 @@ impl AppState {
             PrAction::Merge => "confirm pull request merge".to_string(),
             PrAction::Close => "confirm pull request close".to_string(),
             PrAction::Approve => "confirm pull request approval".to_string(),
+            PrAction::Checkout => "confirm local pull request checkout".to_string(),
         };
     }
 
@@ -9138,6 +9301,7 @@ impl AppState {
             PrAction::Merge => "merging pull request".to_string(),
             PrAction::Close => "closing pull request".to_string(),
             PrAction::Approve => "approving pull request".to_string(),
+            PrAction::Checkout => "checking out pull request locally".to_string(),
         };
         submit(item, action);
     }
@@ -12261,7 +12425,7 @@ diff --git a/src/github.rs b/src/github.rs
         );
         assert!(text.contains("/ search"));
         assert!(text.contains("v diff"));
-        assert!(text.contains("M/C/A pr action"));
+        assert!(text.contains("M/C/A/X pr action"));
         assert!(
             text.contains(
                 "| 1-4 focus  ? help  S repo  r refresh  o open  m text-select  q quit |"
@@ -12280,7 +12444,7 @@ diff --git a/src/github.rs b/src/github.rs
         app.focus_ghr();
         let ghr = footer_line(&app, &paths).to_string();
         assert!(ghr.contains("ghr tabs  tab/h/l switch  j/enter Sections  esc List"));
-        assert!(!ghr.contains("M/C/A pr action"));
+        assert!(!ghr.contains("M/C/A/X pr action"));
 
         app.focus_sections();
         let sections = footer_line(&app, &paths).to_string();
@@ -12298,7 +12462,7 @@ diff --git a/src/github.rs b/src/github.rs
         app.focus_details();
         let diff = footer_line(&app, &paths).to_string();
         assert!(diff.contains("Details diff  j/k line  n/p page  g/G top/bottom"));
-        assert!(diff.contains("[ ] file  m begin  e end  c inline  a comment  M/C/A pr action"));
+        assert!(diff.contains("[ ] file  m begin  e end  c inline  a comment  M/C/A/X pr action"));
         assert!(!diff.contains("m text-select"));
         assert!(diff.contains("q back"));
         assert!(!diff.contains("q quit"));
@@ -14146,6 +14310,84 @@ diff --git a/src/github.rs b/src/github.rs
     }
 
     #[test]
+    fn capital_x_key_opens_checkout_confirmation_for_pull_request_list() {
+        let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let config = Config::default();
+        let store = SnapshotStore::new(std::path::PathBuf::from("/tmp/ghr-test-unused.db"));
+
+        assert!(!handle_key(
+            &mut app,
+            key(KeyCode::Char('X')),
+            &config,
+            &store,
+            &tx
+        ));
+
+        let dialog = app.pr_action_dialog.as_ref().expect("checkout dialog");
+        assert_eq!(dialog.action, PrAction::Checkout);
+        assert_eq!(dialog.item.id, "1");
+        assert_eq!(app.status, "confirm local pull request checkout");
+    }
+
+    #[test]
+    fn capital_x_key_opens_checkout_confirmation_for_pull_request_details() {
+        let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let config = Config::default();
+        let store = SnapshotStore::new(std::path::PathBuf::from("/tmp/ghr-test-unused.db"));
+        app.focus_details();
+
+        assert!(!handle_key(
+            &mut app,
+            key(KeyCode::Char('X')),
+            &config,
+            &store,
+            &tx
+        ));
+
+        let dialog = app.pr_action_dialog.as_ref().expect("checkout dialog");
+        assert_eq!(dialog.action, PrAction::Checkout);
+        assert_eq!(dialog.item.id, "1");
+        assert_eq!(app.status, "confirm local pull request checkout");
+    }
+
+    #[test]
+    fn checkout_confirmation_submits_selected_action() {
+        let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
+        app.start_pr_action_dialog(PrAction::Checkout);
+        let mut submitted = None;
+
+        app.handle_pr_action_dialog_key_with_submit(key(KeyCode::Enter), |item, action| {
+            submitted = Some((item.id, action));
+        });
+
+        assert!(app.pr_action_running);
+        assert_eq!(app.status, "checking out pull request locally");
+        assert_eq!(submitted, Some(("1".to_string(), PrAction::Checkout)));
+    }
+
+    #[test]
+    fn pr_checkout_command_construction_uses_repo_and_number() {
+        let args = pr_checkout_command_args("rust-lang/rust", 123);
+
+        assert_eq!(
+            args,
+            vec![
+                "pr".to_string(),
+                "checkout".to_string(),
+                "123".to_string(),
+                "--repo".to_string(),
+                "rust-lang/rust".to_string(),
+            ]
+        );
+        assert_eq!(
+            pr_checkout_command_display(&args),
+            "gh pr checkout 123 --repo rust-lang/rust"
+        );
+    }
+
+    #[test]
     fn pr_action_confirmation_submits_selected_action() {
         let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
         app.start_pr_action_dialog(PrAction::Approve);
@@ -14199,6 +14441,40 @@ diff --git a/src/github.rs b/src/github.rs
         assert!(!handle_key(
             &mut app,
             key(KeyCode::Char('M')),
+            &config,
+            &store,
+            &tx
+        ));
+
+        assert!(app.pr_action_dialog.is_none());
+        assert_eq!(app.status, "selected item is not a pull request");
+    }
+
+    #[test]
+    fn checkout_rejects_non_pull_request() {
+        let mut item = work_item("1", "rust-lang/rust", 1, "Compiler diagnostics", None);
+        item.kind = ItemKind::Issue;
+        item.url = "https://github.com/rust-lang/rust/issues/1".to_string();
+        let section = SectionSnapshot {
+            key: "issues:test".to_string(),
+            kind: SectionKind::Issues,
+            title: "Test".to_string(),
+            filters: String::new(),
+            items: vec![item],
+            total_count: None,
+            page: 1,
+            page_size: 0,
+            refreshed_at: None,
+            error: None,
+        };
+        let mut app = AppState::new(SectionKind::Issues, vec![section]);
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let config = Config::default();
+        let store = SnapshotStore::new(std::path::PathBuf::from("/tmp/ghr-test-unused.db"));
+
+        assert!(!handle_key(
+            &mut app,
+            key(KeyCode::Char('X')),
             &config,
             &store,
             &tx
@@ -14273,6 +14549,57 @@ diff --git a/src/github.rs b/src/github.rs
         let dialog = app.message_dialog.as_ref().expect("message dialog");
         assert_eq!(dialog.title, "Merge Failed");
         assert!(dialog.body.contains("review approval required"));
+        assert!(dialog.auto_close_at.is_none());
+    }
+
+    #[test]
+    fn pr_checkout_finished_shows_success_output() {
+        let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
+        app.start_pr_action_dialog(PrAction::Checkout);
+        app.pr_action_running = true;
+
+        app.handle_msg(AppMsg::PrCheckoutFinished {
+            result: Ok(PrCheckoutResult {
+                command: "gh pr checkout 1 --repo rust-lang/rust".to_string(),
+                output: "Switched to branch 'diagnostics'".to_string(),
+            }),
+        });
+
+        assert!(app.pr_action_dialog.is_none());
+        assert!(!app.pr_action_running);
+        assert_eq!(app.status, "pull request checked out locally");
+        let dialog = app.message_dialog.as_ref().expect("success dialog");
+        assert_eq!(dialog.title, "Pull Request Checked Out");
+        assert!(
+            dialog
+                .body
+                .contains("gh pr checkout 1 --repo rust-lang/rust")
+        );
+        assert!(dialog.body.contains("current working directory"));
+        assert!(dialog.body.contains("Switched to branch"));
+        assert!(dialog.auto_close_at.is_none());
+    }
+
+    #[test]
+    fn pr_checkout_failure_opens_message_dialog() {
+        let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
+        app.start_pr_action_dialog(PrAction::Checkout);
+        app.pr_action_running = true;
+
+        app.handle_msg(AppMsg::PrCheckoutFinished {
+            result: Err(
+                "gh pr checkout 1 --repo rust-lang/rust failed.\n\nCheckout runs from the current working directory (/tmp). GitHub CLI and GitHub are the source of truth.\n\nfatal: not a git repository"
+                    .to_string(),
+            ),
+        });
+
+        assert!(app.pr_action_dialog.is_none());
+        assert!(!app.pr_action_running);
+        assert_eq!(app.status, "pull request checkout failed");
+        let dialog = app.message_dialog.as_ref().expect("message dialog");
+        assert_eq!(dialog.title, "Checkout Failed");
+        assert!(dialog.body.contains("current working directory"));
+        assert!(dialog.body.contains("fatal: not a git repository"));
         assert!(dialog.auto_close_at.is_none());
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -68,8 +68,9 @@ use layout::{body_area, body_areas};
 use search::{filtered_indices, fuzzy_score};
 use status::{
     comment_pending_dialog, compact_error_label, message_dialog, operation_error_body,
-    pr_action_error_body, pr_action_error_status, pr_action_error_title, pr_action_success_body,
-    pr_action_success_title, refresh_error_status, setup_dialog_from_error, success_message_dialog,
+    persistent_success_message_dialog, pr_action_error_body, pr_action_error_status,
+    pr_action_error_title, pr_action_success_body, pr_action_success_title, refresh_error_status,
+    setup_dialog_from_error, success_message_dialog,
 };
 use text::{display_width, normalize_text, truncate_inline, truncate_text};
 
@@ -279,7 +280,15 @@ struct PrCheckoutPlan {
 struct MessageDialog {
     title: String,
     body: String,
+    kind: MessageDialogKind,
     auto_close_at: Option<Instant>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MessageDialogKind {
+    Info,
+    Success,
+    Error,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -3431,11 +3440,7 @@ fn draw_message_dialog(frame: &mut Frame<'_>, dialog: &MessageDialog, area: Rect
         "Enter/Esc: close"
     };
     let text = format!("{}\n\n{footer}", dialog.body);
-    let accent = if dialog.auto_close_at.is_some() {
-        Color::LightGreen
-    } else {
-        Color::LightRed
-    };
+    let accent = message_dialog_accent(dialog);
     let block = Block::default()
         .borders(Borders::ALL)
         .border_style(Style::default().fg(accent))
@@ -3451,6 +3456,14 @@ fn draw_message_dialog(frame: &mut Frame<'_>, dialog: &MessageDialog, area: Rect
 
     frame.render_widget(Clear, dialog_area);
     frame.render_widget(paragraph, dialog_area);
+}
+
+fn message_dialog_accent(dialog: &MessageDialog) -> Color {
+    match dialog.kind {
+        MessageDialogKind::Info => Color::Yellow,
+        MessageDialogKind::Success => Color::LightGreen,
+        MessageDialogKind::Error => Color::LightRed,
+    }
 }
 
 fn draw_global_search_loading_dialog(frame: &mut Frame<'_>, app: &AppState, area: Rect) {
@@ -8046,7 +8059,7 @@ impl AppState {
                 match result {
                     Ok(result) => {
                         self.status = "pull request checked out locally".to_string();
-                        self.message_dialog = Some(message_dialog(
+                        self.message_dialog = Some(persistent_success_message_dialog(
                             pr_action_success_title(PrAction::Checkout),
                             format!(
                                 "{}\n\n{}\n\n{}",
@@ -14971,6 +14984,8 @@ diff --git a/src/github.rs b/src/github.rs
         assert_eq!(app.status, "pull request merged; refreshing");
         let dialog = app.message_dialog.as_ref().expect("success dialog");
         assert_eq!(dialog.title, "Pull Request Merged");
+        assert_eq!(dialog.kind, MessageDialogKind::Success);
+        assert_eq!(message_dialog_accent(dialog), Color::LightGreen);
         assert!(dialog.auto_close_at.is_some());
     }
 
@@ -14993,6 +15008,8 @@ diff --git a/src/github.rs b/src/github.rs
         assert_eq!(app.status, "pull request approved; refreshing");
         let dialog = app.message_dialog.as_ref().expect("success dialog");
         assert_eq!(dialog.title, "Pull Request Approved");
+        assert_eq!(dialog.kind, MessageDialogKind::Success);
+        assert_eq!(message_dialog_accent(dialog), Color::LightGreen);
         assert!(dialog.auto_close_at.is_some());
     }
 
@@ -15017,6 +15034,8 @@ diff --git a/src/github.rs b/src/github.rs
         let dialog = app.message_dialog.as_ref().expect("message dialog");
         assert_eq!(dialog.title, "Merge Failed");
         assert!(dialog.body.contains("review approval required"));
+        assert_eq!(dialog.kind, MessageDialogKind::Error);
+        assert_eq!(message_dialog_accent(dialog), Color::LightRed);
         assert!(dialog.auto_close_at.is_none());
     }
 
@@ -15046,6 +15065,8 @@ diff --git a/src/github.rs b/src/github.rs
         );
         assert!(dialog.body.contains("Checkout runs from /tmp/rust."));
         assert!(dialog.body.contains("Switched to branch"));
+        assert_eq!(dialog.kind, MessageDialogKind::Success);
+        assert_eq!(message_dialog_accent(dialog), Color::LightGreen);
         assert!(dialog.auto_close_at.is_none());
     }
 
@@ -15069,6 +15090,8 @@ diff --git a/src/github.rs b/src/github.rs
         assert_eq!(dialog.title, "Checkout Failed");
         assert!(dialog.body.contains("Checkout runs from /tmp."));
         assert!(dialog.body.contains("fatal: not a git repository"));
+        assert_eq!(dialog.kind, MessageDialogKind::Error);
+        assert_eq!(message_dialog_accent(dialog), Color::LightRed);
         assert!(dialog.auto_close_at.is_none());
     }
 
@@ -15099,6 +15122,7 @@ diff --git a/src/github.rs b/src/github.rs
         app.message_dialog = Some(MessageDialog {
             title: "Comment Posted".to_string(),
             body: "ok".to_string(),
+            kind: MessageDialogKind::Success,
             auto_close_at: Some(deadline),
         });
 
@@ -15120,6 +15144,14 @@ diff --git a/src/github.rs b/src/github.rs
         let dialog = app.message_dialog.as_ref().expect("blocking dialog");
         assert_eq!(dialog.title, "Comment Failed");
         assert!(dialog.auto_close_at.is_none());
+    }
+
+    #[test]
+    fn pending_message_dialog_is_not_error_colored() {
+        let dialog = comment_pending_dialog(&PendingCommentMode::Post);
+
+        assert_eq!(dialog.kind, MessageDialogKind::Info);
+        assert_ne!(message_dialog_accent(&dialog), Color::LightRed);
     }
 
     #[test]

--- a/src/app/status.rs
+++ b/src/app/status.rs
@@ -84,6 +84,7 @@ pub(super) fn pr_action_success_title(action: PrAction) -> &'static str {
         PrAction::Merge => "Pull Request Merged",
         PrAction::Close => "Pull Request Closed",
         PrAction::Approve => "Pull Request Approved",
+        PrAction::Checkout => "Pull Request Checked Out",
     }
 }
 
@@ -92,6 +93,7 @@ pub(super) fn pr_action_success_body(action: PrAction) -> &'static str {
         PrAction::Merge => "GitHub accepted the merge. Refreshing details.",
         PrAction::Close => "GitHub accepted the close action. Refreshing details.",
         PrAction::Approve => "GitHub accepted the approval. Refreshing details.",
+        PrAction::Checkout => "GitHub CLI checked out the pull request locally.",
     }
 }
 
@@ -100,6 +102,7 @@ pub(super) fn pr_action_error_title(action: PrAction) -> &'static str {
         PrAction::Merge => "Merge Failed",
         PrAction::Close => "Close Failed",
         PrAction::Approve => "Approve Failed",
+        PrAction::Checkout => "Checkout Failed",
     }
 }
 
@@ -108,6 +111,7 @@ pub(super) fn pr_action_error_status(action: PrAction) -> &'static str {
         PrAction::Merge => "pull request merge failed",
         PrAction::Close => "pull request close failed",
         PrAction::Approve => "pull request approval failed",
+        PrAction::Checkout => "pull request checkout failed",
     }
 }
 

--- a/src/app/status.rs
+++ b/src/app/status.rs
@@ -1,8 +1,8 @@
 use std::time::Instant;
 
 use super::{
-    MessageDialog, PendingCommentMode, PrAction, SUCCESS_DIALOG_AUTO_CLOSE, SetupDialog,
-    text::truncate_inline,
+    MessageDialog, MessageDialogKind, PendingCommentMode, PrAction, SUCCESS_DIALOG_AUTO_CLOSE,
+    SetupDialog, text::truncate_inline,
 };
 
 pub(super) fn refresh_error_status(count: usize, first_error: Option<&str>) -> String {
@@ -64,6 +64,7 @@ pub(super) fn message_dialog(title: impl Into<String>, body: impl Into<String>) 
     MessageDialog {
         title: title.into(),
         body: body.into(),
+        kind: MessageDialogKind::Error,
         auto_close_at: None,
     }
 }
@@ -75,7 +76,29 @@ pub(super) fn success_message_dialog(
     MessageDialog {
         title: title.into(),
         body: body.into(),
+        kind: MessageDialogKind::Success,
         auto_close_at: Some(Instant::now() + SUCCESS_DIALOG_AUTO_CLOSE),
+    }
+}
+
+pub(super) fn persistent_success_message_dialog(
+    title: impl Into<String>,
+    body: impl Into<String>,
+) -> MessageDialog {
+    MessageDialog {
+        title: title.into(),
+        body: body.into(),
+        kind: MessageDialogKind::Success,
+        auto_close_at: None,
+    }
+}
+
+fn info_message_dialog(title: impl Into<String>, body: impl Into<String>) -> MessageDialog {
+    MessageDialog {
+        title: title.into(),
+        body: body.into(),
+        kind: MessageDialogKind::Info,
+        auto_close_at: None,
     }
 }
 
@@ -130,19 +153,19 @@ pub(super) fn operation_error_body(error: &str) -> String {
 
 pub(super) fn comment_pending_dialog(mode: &PendingCommentMode) -> MessageDialog {
     match mode {
-        PendingCommentMode::Post => message_dialog(
+        PendingCommentMode::Post => info_message_dialog(
             "Posting Comment",
             "Waiting for GitHub to accept the comment...",
         ),
-        PendingCommentMode::ReviewReply { .. } => message_dialog(
+        PendingCommentMode::ReviewReply { .. } => info_message_dialog(
             "Posting Review Reply",
             "Waiting for GitHub to accept the review reply...",
         ),
-        PendingCommentMode::Edit { .. } => message_dialog(
+        PendingCommentMode::Edit { .. } => info_message_dialog(
             "Updating Comment",
             "Waiting for GitHub to accept the update...",
         ),
-        PendingCommentMode::Review { .. } => message_dialog(
+        PendingCommentMode::Review { .. } => info_message_dialog(
             "Posting Review Comment",
             "Waiting for GitHub to accept the review comment...",
         ),

--- a/src/config.rs
+++ b/src/config.rs
@@ -46,6 +46,8 @@ pub struct SearchSection {
 pub struct RepoConfig {
     pub name: String,
     pub repo: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub local_dir: Option<String>,
     pub show_prs: bool,
     pub show_issues: bool,
 }
@@ -109,12 +111,19 @@ impl Config {
             RepoConfig {
                 name,
                 repo,
+                local_dir: current_dir_for_config(),
                 show_prs: true,
                 show_issues: true,
             },
         );
         true
     }
+}
+
+fn current_dir_for_config() -> Option<String> {
+    std::env::current_dir()
+        .ok()
+        .map(|path| path.display().to_string())
 }
 
 fn current_github_repo() -> Option<String> {
@@ -165,7 +174,7 @@ fn git_output<const N: usize>(args: [&str; N]) -> Option<String> {
     String::from_utf8(output.stdout).ok()
 }
 
-fn github_repo_from_remote_url(url: &str) -> Option<String> {
+pub(crate) fn github_repo_from_remote_url(url: &str) -> Option<String> {
     let path = if let Some(path) = url.strip_prefix("git@github.com:") {
         path
     } else if let Some(path) = url.strip_prefix("ssh://git@github.com/") {
@@ -294,6 +303,7 @@ impl Default for RepoConfig {
         Self {
             name: String::new(),
             repo: String::new(),
+            local_dir: None,
             show_prs: true,
             show_issues: true,
         }
@@ -371,6 +381,7 @@ mod tests {
         assert_eq!(config.repos.len(), 1);
         assert_eq!(config.repos[0].name, "ghr");
         assert_eq!(config.repos[0].repo, "chenyukang/ghr");
+        assert!(config.repos[0].local_dir.is_some());
         assert!(config.repos[0].show_prs);
         assert!(config.repos[0].show_issues);
 
@@ -384,6 +395,7 @@ mod tests {
         config.repos.push(RepoConfig {
             name: "ghr".to_string(),
             repo: "someone-else/ghr".to_string(),
+            local_dir: None,
             show_prs: true,
             show_issues: true,
         });
@@ -399,6 +411,7 @@ mod tests {
         config.repos.push(RepoConfig {
             name: "Fiber".to_string(),
             repo: "nervosnetwork/fiber".to_string(),
+            local_dir: None,
             show_prs: true,
             show_issues: true,
         });
@@ -465,6 +478,7 @@ mod tests {
             [[repos]]
             name = "fiber"
             repo = "nervosnetwork/fiber"
+            local_dir = "~/code/fiber"
             show_prs = true
             show_issues = true
 
@@ -497,6 +511,7 @@ mod tests {
         assert_eq!(config.exclude_repos, vec!["nervosnetwork/archive-*"]);
         assert_eq!(config.repos[0].name, "fiber");
         assert_eq!(config.repos[0].repo, "nervosnetwork/fiber");
+        assert_eq!(config.repos[0].local_dir.as_deref(), Some("~/code/fiber"));
         assert!(config.repos[0].show_prs);
         assert!(config.repos[0].show_issues);
         assert_eq!(config.pr_sections[0].title, "Assigned to Me");

--- a/src/github.rs
+++ b/src/github.rs
@@ -14,9 +14,9 @@ use tracing::{info, warn};
 
 use crate::config::{Config, SearchSection};
 use crate::model::{
-    ActionHints, CheckSummary, CommentPreview, ItemKind, ReviewCommentPreview, SectionKind,
-    SectionSnapshot, WorkItem, builtin_view_key, global_search_view_key, repo_section_filters,
-    repo_view_key,
+    ActionHints, CheckSummary, CommentPreview, ItemKind, PullRequestBranch, ReviewCommentPreview,
+    SectionKind, SectionSnapshot, WorkItem, builtin_view_key, global_search_view_key,
+    repo_section_filters, repo_view_key,
 };
 
 static VIEWER_LOGIN: OnceCell<String> = OnceCell::const_new();
@@ -220,6 +220,8 @@ struct PullRequestActionRepositoryRaw {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct PullRequestActionRaw {
+    head_ref_name: Option<String>,
+    head_repository: Option<PullRequestHeadRepositoryRaw>,
     is_draft: Option<bool>,
     merge_state_status: Option<String>,
     review_decision: Option<String>,
@@ -231,6 +233,12 @@ struct PullRequestActionRaw {
     viewer_can_update_branch: Option<bool>,
     viewer_did_author: Option<bool>,
     viewer_latest_review: Option<PullRequestViewerReviewRaw>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PullRequestHeadRepositoryRaw {
+    name_with_owner: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -871,6 +879,10 @@ query($owner: String!, $name: String!, $number: Int!) {
   repository(owner: $owner, name: $name) {
     pullRequest(number: $number) {
       state
+      headRefName
+      headRepository {
+        nameWithOwner
+      }
       isDraft
       mergeStateStatus
       reviewDecision
@@ -1508,12 +1520,32 @@ fn pull_request_action_hints(pr: &PullRequestActionRaw) -> ActionHints {
     } else {
         Some(format!("Merge blocked: {}", blockers.join("; ")))
     };
+    let head = pull_request_branch(pr);
 
     ActionHints {
         labels,
         checks,
         note,
+        head,
     }
+}
+
+fn pull_request_branch(pr: &PullRequestActionRaw) -> Option<PullRequestBranch> {
+    let branch = pr
+        .head_ref_name
+        .as_deref()
+        .map(str::trim)
+        .filter(|branch| !branch.is_empty())?;
+    let repository = pr
+        .head_repository
+        .as_ref()
+        .map(|repository| repository.name_with_owner.trim())
+        .filter(|repository| !repository.is_empty())?;
+
+    Some(PullRequestBranch {
+        repository: repository.to_string(),
+        branch: branch.to_string(),
+    })
 }
 
 fn pull_request_action_blockers(pr: &PullRequestActionRaw) -> Vec<String> {
@@ -2279,6 +2311,10 @@ mod tests {
     #[test]
     fn action_hints_show_approvable_when_review_is_needed() {
         let hints = pull_request_action_hints(&PullRequestActionRaw {
+            head_ref_name: Some("feature/diagnostics".to_string()),
+            head_repository: Some(PullRequestHeadRepositoryRaw {
+                name_with_owner: "rust-lang/rust".to_string(),
+            }),
             is_draft: Some(false),
             merge_state_status: Some("BLOCKED".to_string()),
             review_decision: Some("REVIEW_REQUIRED".to_string()),
@@ -2325,11 +2361,20 @@ mod tests {
         let note = hints.note.expect("blocked PR should explain why");
         assert!(note.contains("review approval required"));
         assert!(note.contains("checks failing"));
+        assert_eq!(
+            hints.head,
+            Some(PullRequestBranch {
+                repository: "rust-lang/rust".to_string(),
+                branch: "feature/diagnostics".to_string(),
+            })
+        );
     }
 
     #[test]
     fn action_hints_show_mergeable_when_pr_is_ready_and_viewer_can_merge() {
         let hints = pull_request_action_hints(&PullRequestActionRaw {
+            head_ref_name: None,
+            head_repository: None,
             is_draft: Some(false),
             merge_state_status: Some("CLEAN".to_string()),
             review_decision: Some("APPROVED".to_string()),

--- a/src/model.rs
+++ b/src/model.rs
@@ -87,6 +87,13 @@ pub struct ActionHints {
     pub labels: Vec<String>,
     pub checks: Option<CheckSummary>,
     pub note: Option<String>,
+    pub head: Option<PullRequestBranch>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PullRequestBranch {
+    pub repository: String,
+    pub branch: String,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -400,6 +407,7 @@ mod tests {
         config.repos.push(crate::config::RepoConfig {
             name: "fiber".to_string(),
             repo: "nervosnetwork/fiber".to_string(),
+            local_dir: None,
             show_prs: true,
             show_issues: true,
         });


### PR DESCRIPTION
## Summary
- add confirmed `X` PR checkout action for list, details, and diff file views
- run `gh pr checkout <number> --repo <owner/repo>` from the current working directory and show concise success/failure output
- document the shortcut and cwd/source-of-truth behavior

## Tests
- rtk cargo fmt
- rtk cargo test