### PR TITLE
[codex] add PR auto-merge actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ Press `?` in the TUI for the live shortcut reference. The status bar also change
 | `M` | Open a merge confirmation for the selected PR |
 | `C` | Open a close confirmation for the selected PR |
 | `A` | Open an approve confirmation for the selected PR |
+| `E` | Open an enable auto-merge confirmation for the selected PR |
+| `D` | Open a disable auto-merge confirmation for the selected PR |
 | `y` / `Enter` | Confirm the current PR action in the confirmation dialog |
 | `Ctrl+Enter` | Send or update a comment from the comment dialog |
 | `r` | Refresh from GitHub |

--- a/src/app.rs
+++ b/src/app.rs
@@ -30,8 +30,9 @@ use tracing::warn;
 use crate::config::Config;
 use crate::dirs::Paths;
 use crate::github::{
-    PullRequestReviewCommentTarget, approve_pull_request, close_pull_request, edit_issue_comment,
-    edit_pull_request_review_comment, fetch_comments, fetch_pull_request_action_hints,
+    PullRequestReviewCommentTarget, approve_pull_request, close_pull_request,
+    disable_pull_request_auto_merge, edit_issue_comment, edit_pull_request_review_comment,
+    enable_pull_request_auto_merge, fetch_comments, fetch_pull_request_action_hints,
     fetch_pull_request_diff, mark_notification_thread_read, merge_pull_request, post_issue_comment,
     post_pull_request_review_comment, post_pull_request_review_reply, refresh_dashboard,
     refresh_dashboard_with_progress, refresh_section_page, search_global,
@@ -247,6 +248,8 @@ enum PrAction {
     Merge,
     Close,
     Approve,
+    EnableAutoMerge,
+    DisableAutoMerge,
 }
 
 #[derive(Debug, Clone)]
@@ -1077,6 +1080,12 @@ fn start_pr_action(
                 PrAction::Approve => approve_pull_request(&item.repo, number)
                     .await
                     .map_err(|error| error.to_string()),
+                PrAction::EnableAutoMerge => enable_pull_request_auto_merge(&item.repo, number)
+                    .await
+                    .map_err(|error| error.to_string()),
+                PrAction::DisableAutoMerge => disable_pull_request_auto_merge(&item.repo, number)
+                    .await
+                    .map_err(|error| error.to_string()),
             },
             None => Err("selected item has no pull request number".to_string()),
         };
@@ -1287,6 +1296,8 @@ fn handle_key_in_area(
             KeyCode::Char('M') => app.start_pr_action_dialog(PrAction::Merge),
             KeyCode::Char('C') => app.start_pr_action_dialog(PrAction::Close),
             KeyCode::Char('A') => app.start_pr_action_dialog(PrAction::Approve),
+            KeyCode::Char('E') => app.start_pr_action_dialog(PrAction::EnableAutoMerge),
+            KeyCode::Char('D') => app.start_pr_action_dialog(PrAction::DisableAutoMerge),
             KeyCode::Char('a') => app.start_new_comment_dialog(),
             KeyCode::Enter => {
                 app.focus_details();
@@ -1308,6 +1319,8 @@ fn handle_key_in_area(
             KeyCode::Char('M') => app.start_pr_action_dialog(PrAction::Merge),
             KeyCode::Char('C') => app.start_pr_action_dialog(PrAction::Close),
             KeyCode::Char('A') => app.start_pr_action_dialog(PrAction::Approve),
+            KeyCode::Char('E') => app.start_pr_action_dialog(PrAction::EnableAutoMerge),
+            KeyCode::Char('D') => app.start_pr_action_dialog(PrAction::DisableAutoMerge),
             KeyCode::Char('c') if app.details_mode == DetailsMode::Diff => {
                 app.start_review_comment_dialog()
             }
@@ -1440,6 +1453,8 @@ fn handle_diff_file_list_key(app: &mut AppState, key: KeyEvent, area: Option<Rec
         KeyCode::Char('M') => app.start_pr_action_dialog(PrAction::Merge),
         KeyCode::Char('C') => app.start_pr_action_dialog(PrAction::Close),
         KeyCode::Char('A') => app.start_pr_action_dialog(PrAction::Approve),
+        KeyCode::Char('E') => app.start_pr_action_dialog(PrAction::EnableAutoMerge),
+        KeyCode::Char('D') => app.start_pr_action_dialog(PrAction::DisableAutoMerge),
         KeyCode::Enter => app.focus_details(),
         _ => {}
     }
@@ -2679,7 +2694,7 @@ fn push_footer_focus_shortcuts(spans: &mut Vec<Span<'static>>, app: &AppState) {
                 push_footer_pair(spans, "enter", "diff", Color::Cyan);
                 push_footer_pair(spans, "c", "inline", Color::LightBlue);
                 push_footer_pair(spans, "a", "comment", Color::LightBlue);
-                push_footer_pair(spans, "M/C/A", "pr action", Color::LightMagenta);
+                push_footer_pair(spans, "M/C/A/E/D", "pr action", Color::LightMagenta);
             } else {
                 push_footer_context(spans, "List", "items");
                 push_footer_pair(spans, "j/k", "move", Color::Cyan);
@@ -2693,7 +2708,7 @@ fn push_footer_focus_shortcuts(spans: &mut Vec<Span<'static>>, app: &AppState) {
                 }
                 push_footer_pair(spans, "v", "diff", Color::LightMagenta);
                 push_footer_pair(spans, "a", "comment", Color::LightBlue);
-                push_footer_pair(spans, "M/C/A", "pr action", Color::LightMagenta);
+                push_footer_pair(spans, "M/C/A/E/D", "pr action", Color::LightMagenta);
             }
         }
         FocusTarget::Details => {
@@ -2717,7 +2732,7 @@ fn push_footer_focus_shortcuts(spans: &mut Vec<Span<'static>>, app: &AppState) {
                 push_footer_pair(spans, "e", "end", Color::Yellow);
                 push_footer_pair(spans, "c", "inline", Color::LightBlue);
                 push_footer_pair(spans, "a", "comment", Color::LightBlue);
-                push_footer_pair(spans, "M/C/A", "pr action", Color::LightMagenta);
+                push_footer_pair(spans, "M/C/A/E/D", "pr action", Color::LightMagenta);
             } else {
                 push_footer_pair(spans, "v", "diff", Color::LightMagenta);
                 push_footer_pair(spans, "/", "search", Color::Yellow);
@@ -2726,7 +2741,7 @@ fn push_footer_focus_shortcuts(spans: &mut Vec<Span<'static>>, app: &AppState) {
                 push_footer_pair(spans, "c/a", "comment", Color::LightBlue);
                 push_footer_pair(spans, "R", "reply", Color::LightBlue);
                 push_footer_pair(spans, "e", "edit", Color::LightBlue);
-                push_footer_pair(spans, "M/C/A", "pr action", Color::LightMagenta);
+                push_footer_pair(spans, "M/C/A/E/D", "pr action", Color::LightMagenta);
             }
             push_footer_pair(spans, "esc", "List", Color::Cyan);
         }
@@ -3033,11 +3048,15 @@ fn draw_pr_action_dialog(
         PrAction::Merge => "merge",
         PrAction::Close => "close",
         PrAction::Approve => "approve",
+        PrAction::EnableAutoMerge => "enable auto-merge for",
+        PrAction::DisableAutoMerge => "disable auto-merge for",
     };
     let prompt = match dialog.action {
         PrAction::Merge => "Merge this pull request on GitHub?",
         PrAction::Close => "Close this pull request on GitHub?",
         PrAction::Approve => "Approve this pull request on GitHub?",
+        PrAction::EnableAutoMerge => "Enable auto-merge for this pull request on GitHub?",
+        PrAction::DisableAutoMerge => "Disable auto-merge for this pull request on GitHub?",
     };
     let status = if running {
         "working...".to_string()
@@ -3067,6 +3086,8 @@ fn draw_pr_action_dialog(
                 PrAction::Merge => "Merge Pull Request",
                 PrAction::Close => "Close Pull Request",
                 PrAction::Approve => "Approve Pull Request",
+                PrAction::EnableAutoMerge => "Enable Auto-Merge",
+                PrAction::DisableAutoMerge => "Disable Auto-Merge",
             },
             Style::default()
                 .fg(Color::Yellow)
@@ -3505,6 +3526,8 @@ fn help_dialog_content() -> Vec<Line<'static>> {
         help_key_line("M", "open PR merge confirmation"),
         help_key_line("C", "open PR close confirmation"),
         help_key_line("A", "open PR approve confirmation"),
+        help_key_line("E", "open PR enable auto-merge confirmation"),
+        help_key_line("D", "open PR disable auto-merge confirmation"),
         help_key_line("a", "add a new issue or PR comment"),
         Line::from(""),
         help_heading("Diff Files"),
@@ -3542,6 +3565,8 @@ fn help_dialog_content() -> Vec<Line<'static>> {
         help_key_line("M", "open PR merge confirmation"),
         help_key_line("C", "open PR close confirmation"),
         help_key_line("A", "open PR approve confirmation"),
+        help_key_line("E", "open PR enable auto-merge confirmation"),
+        help_key_line("D", "open PR disable auto-merge confirmation"),
         help_key_line("o", "open selected item in browser"),
         Line::from(""),
         help_heading("Pull Request Confirmation"),
@@ -7590,11 +7615,18 @@ impl AppState {
                 match result {
                     Ok(()) => {
                         self.details_stale.insert(item_id.clone());
+                        self.action_hints.remove(&item_id);
                         self.mark_item_after_pr_action(&item_id, action);
                         self.status = match action {
                             PrAction::Merge => "pull request merged; refreshing".to_string(),
                             PrAction::Close => "pull request closed; refreshing".to_string(),
                             PrAction::Approve => "pull request approved; refreshing".to_string(),
+                            PrAction::EnableAutoMerge => {
+                                "pull request auto-merge enabled; refreshing".to_string()
+                            }
+                            PrAction::DisableAutoMerge => {
+                                "pull request auto-merge disabled; refreshing".to_string()
+                            }
                         };
                         self.message_dialog = Some(success_message_dialog(
                             pr_action_success_title(action),
@@ -7764,7 +7796,7 @@ impl AppState {
                 match action {
                     PrAction::Merge => item.state = Some("merged".to_string()),
                     PrAction::Close => item.state = Some("closed".to_string()),
-                    PrAction::Approve => {}
+                    PrAction::Approve | PrAction::EnableAutoMerge | PrAction::DisableAutoMerge => {}
                 }
             }
         }
@@ -9087,6 +9119,8 @@ impl AppState {
             PrAction::Merge => "confirm pull request merge".to_string(),
             PrAction::Close => "confirm pull request close".to_string(),
             PrAction::Approve => "confirm pull request approval".to_string(),
+            PrAction::EnableAutoMerge => "confirm pull request auto-merge enable".to_string(),
+            PrAction::DisableAutoMerge => "confirm pull request auto-merge disable".to_string(),
         };
     }
 
@@ -9138,6 +9172,8 @@ impl AppState {
             PrAction::Merge => "merging pull request".to_string(),
             PrAction::Close => "closing pull request".to_string(),
             PrAction::Approve => "approving pull request".to_string(),
+            PrAction::EnableAutoMerge => "enabling pull request auto-merge".to_string(),
+            PrAction::DisableAutoMerge => "disabling pull request auto-merge".to_string(),
         };
         submit(item, action);
     }
@@ -12149,6 +12185,8 @@ diff --git a/src/github.rs b/src/github.rs
         assert!(text.contains("drag split border"));
         assert!(text.contains("open PR merge confirmation"));
         assert!(text.contains("open PR close confirmation"));
+        assert!(text.contains("open PR enable auto-merge confirmation"));
+        assert!(text.contains("open PR disable auto-merge confirmation"));
         assert!(text.contains("run the confirmed PR action"));
         assert!(text.contains("search PRs and issues in the current repo"));
         assert!(text.contains("terminal text selection"));
@@ -12261,7 +12299,7 @@ diff --git a/src/github.rs b/src/github.rs
         );
         assert!(text.contains("/ search"));
         assert!(text.contains("v diff"));
-        assert!(text.contains("M/C/A pr action"));
+        assert!(text.contains("M/C/A/E/D pr action"));
         assert!(
             text.contains(
                 "| 1-4 focus  ? help  S repo  r refresh  o open  m text-select  q quit |"
@@ -12280,7 +12318,7 @@ diff --git a/src/github.rs b/src/github.rs
         app.focus_ghr();
         let ghr = footer_line(&app, &paths).to_string();
         assert!(ghr.contains("ghr tabs  tab/h/l switch  j/enter Sections  esc List"));
-        assert!(!ghr.contains("M/C/A pr action"));
+        assert!(!ghr.contains("M/C/A/E/D pr action"));
 
         app.focus_sections();
         let sections = footer_line(&app, &paths).to_string();
@@ -12298,7 +12336,9 @@ diff --git a/src/github.rs b/src/github.rs
         app.focus_details();
         let diff = footer_line(&app, &paths).to_string();
         assert!(diff.contains("Details diff  j/k line  n/p page  g/G top/bottom"));
-        assert!(diff.contains("[ ] file  m begin  e end  c inline  a comment  M/C/A pr action"));
+        assert!(
+            diff.contains("[ ] file  m begin  e end  c inline  a comment  M/C/A/E/D pr action")
+        );
         assert!(!diff.contains("m text-select"));
         assert!(diff.contains("q back"));
         assert!(!diff.contains("q quit"));
@@ -14146,6 +14186,66 @@ diff --git a/src/github.rs b/src/github.rs
     }
 
     #[test]
+    fn capital_e_key_opens_enable_auto_merge_confirmation_for_pull_request() {
+        let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let config = Config::default();
+        let store = SnapshotStore::new(std::path::PathBuf::from("/tmp/ghr-test-unused.db"));
+
+        assert!(!handle_key(
+            &mut app,
+            key(KeyCode::Char('E')),
+            &config,
+            &store,
+            &tx
+        ));
+
+        let dialog = app.pr_action_dialog.as_ref().expect("enable dialog");
+        assert_eq!(dialog.action, PrAction::EnableAutoMerge);
+        assert_eq!(dialog.item.id, "1");
+        assert_eq!(app.status, "confirm pull request auto-merge enable");
+    }
+
+    #[test]
+    fn capital_d_key_opens_disable_auto_merge_confirmation_for_pull_request_details() {
+        let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let config = Config::default();
+        let store = SnapshotStore::new(std::path::PathBuf::from("/tmp/ghr-test-unused.db"));
+        app.focus_details();
+
+        assert!(!handle_key(
+            &mut app,
+            key(KeyCode::Char('D')),
+            &config,
+            &store,
+            &tx
+        ));
+
+        let dialog = app.pr_action_dialog.as_ref().expect("disable dialog");
+        assert_eq!(dialog.action, PrAction::DisableAutoMerge);
+        assert_eq!(dialog.item.id, "1");
+        assert_eq!(app.status, "confirm pull request auto-merge disable");
+    }
+
+    #[test]
+    fn auto_merge_action_dialog_prompt_is_clear() {
+        let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
+        app.start_pr_action_dialog(PrAction::EnableAutoMerge);
+        let backend = ratatui::backend::TestBackend::new(100, 30);
+        let mut terminal = Terminal::new(backend).expect("test terminal");
+        let paths = test_paths();
+
+        terminal
+            .draw(|frame| draw(frame, &app, &paths))
+            .expect("draw");
+
+        let rendered = buffer_lines(terminal.backend().buffer()).join("\n");
+        assert!(rendered.contains("Enable auto-merge for this pull request on GitHub?"));
+        assert!(rendered.contains("y/Enter: yes, enable auto-merge for PR"));
+    }
+
+    #[test]
     fn pr_action_confirmation_submits_selected_action() {
         let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
         app.start_pr_action_dialog(PrAction::Approve);
@@ -14209,6 +14309,40 @@ diff --git a/src/github.rs b/src/github.rs
     }
 
     #[test]
+    fn auto_merge_action_rejects_non_pull_request() {
+        let mut item = work_item("1", "rust-lang/rust", 1, "Compiler diagnostics", None);
+        item.kind = ItemKind::Issue;
+        item.url = "https://github.com/rust-lang/rust/issues/1".to_string();
+        let section = SectionSnapshot {
+            key: "issues:test".to_string(),
+            kind: SectionKind::Issues,
+            title: "Test".to_string(),
+            filters: String::new(),
+            items: vec![item],
+            total_count: None,
+            page: 1,
+            page_size: 0,
+            refreshed_at: None,
+            error: None,
+        };
+        let mut app = AppState::new(SectionKind::Issues, vec![section]);
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let config = Config::default();
+        let store = SnapshotStore::new(std::path::PathBuf::from("/tmp/ghr-test-unused.db"));
+
+        assert!(!handle_key(
+            &mut app,
+            key(KeyCode::Char('E')),
+            &config,
+            &store,
+            &tx
+        ));
+
+        assert!(app.pr_action_dialog.is_none());
+        assert_eq!(app.status, "selected item is not a pull request");
+    }
+
+    #[test]
     fn pr_action_finished_marks_item_state_and_closes_dialog() {
         let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
         app.start_pr_action_dialog(PrAction::Merge);
@@ -14250,6 +14384,58 @@ diff --git a/src/github.rs b/src/github.rs
         let dialog = app.message_dialog.as_ref().expect("success dialog");
         assert_eq!(dialog.title, "Pull Request Approved");
         assert!(dialog.auto_close_at.is_some());
+    }
+
+    #[test]
+    fn auto_merge_action_finished_refreshes_details_and_action_hints() {
+        let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
+        app.action_hints.insert(
+            "1".to_string(),
+            ActionHintState::Loaded(ActionHints {
+                labels: vec!["Auto-mergeable".to_string()],
+                checks: None,
+                note: None,
+            }),
+        );
+        app.start_pr_action_dialog(PrAction::EnableAutoMerge);
+        app.pr_action_running = true;
+
+        app.handle_msg(AppMsg::PrActionFinished {
+            item_id: "1".to_string(),
+            action: PrAction::EnableAutoMerge,
+            result: Ok(()),
+        });
+
+        assert!(app.pr_action_dialog.is_none());
+        assert!(!app.pr_action_running);
+        assert_eq!(app.sections[0].items[0].state.as_deref(), Some("open"));
+        assert!(app.details_stale.contains("1"));
+        assert!(!app.action_hints.contains_key("1"));
+        assert_eq!(app.status, "pull request auto-merge enabled; refreshing");
+        let dialog = app.message_dialog.as_ref().expect("success dialog");
+        assert_eq!(dialog.title, "Auto-Merge Enabled");
+        assert!(dialog.auto_close_at.is_some());
+    }
+
+    #[test]
+    fn auto_merge_action_failure_reports_action_specific_status() {
+        let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
+        app.start_pr_action_dialog(PrAction::DisableAutoMerge);
+        app.pr_action_running = true;
+
+        app.handle_msg(AppMsg::PrActionFinished {
+            item_id: "1".to_string(),
+            action: PrAction::DisableAutoMerge,
+            result: Err("auto-merge is already disabled for owner/repo#1".to_string()),
+        });
+
+        assert!(app.pr_action_dialog.is_none());
+        assert!(!app.pr_action_running);
+        assert_eq!(app.status, "pull request auto-merge disable failed");
+        let dialog = app.message_dialog.as_ref().expect("message dialog");
+        assert_eq!(dialog.title, "Disable Auto-Merge Failed");
+        assert!(dialog.body.contains("auto-merge is already disabled"));
+        assert!(dialog.auto_close_at.is_none());
     }
 
     #[test]
@@ -14583,6 +14769,32 @@ diff --git a/src/github.rs b/src/github.rs
         assert!(matches!(
             app.pr_action_dialog.as_ref().map(|dialog| dialog.action),
             Some(PrAction::Merge)
+        ));
+
+        app.pr_action_dialog = None;
+        assert!(!handle_key(
+            &mut app,
+            key(KeyCode::Char('E')),
+            &config,
+            &store,
+            &tx
+        ));
+        assert!(matches!(
+            app.pr_action_dialog.as_ref().map(|dialog| dialog.action),
+            Some(PrAction::EnableAutoMerge)
+        ));
+
+        app.pr_action_dialog = None;
+        assert!(!handle_key(
+            &mut app,
+            key(KeyCode::Char('D')),
+            &config,
+            &store,
+            &tx
+        ));
+        assert!(matches!(
+            app.pr_action_dialog.as_ref().map(|dialog| dialog.action),
+            Some(PrAction::DisableAutoMerge)
         ));
     }
 

--- a/src/app/status.rs
+++ b/src/app/status.rs
@@ -84,6 +84,8 @@ pub(super) fn pr_action_success_title(action: PrAction) -> &'static str {
         PrAction::Merge => "Pull Request Merged",
         PrAction::Close => "Pull Request Closed",
         PrAction::Approve => "Pull Request Approved",
+        PrAction::EnableAutoMerge => "Auto-Merge Enabled",
+        PrAction::DisableAutoMerge => "Auto-Merge Disabled",
     }
 }
 
@@ -92,6 +94,8 @@ pub(super) fn pr_action_success_body(action: PrAction) -> &'static str {
         PrAction::Merge => "GitHub accepted the merge. Refreshing details.",
         PrAction::Close => "GitHub accepted the close action. Refreshing details.",
         PrAction::Approve => "GitHub accepted the approval. Refreshing details.",
+        PrAction::EnableAutoMerge => "GitHub enabled auto-merge. Refreshing details.",
+        PrAction::DisableAutoMerge => "GitHub disabled auto-merge. Refreshing details.",
     }
 }
 
@@ -100,6 +104,8 @@ pub(super) fn pr_action_error_title(action: PrAction) -> &'static str {
         PrAction::Merge => "Merge Failed",
         PrAction::Close => "Close Failed",
         PrAction::Approve => "Approve Failed",
+        PrAction::EnableAutoMerge => "Enable Auto-Merge Failed",
+        PrAction::DisableAutoMerge => "Disable Auto-Merge Failed",
     }
 }
 
@@ -108,6 +114,8 @@ pub(super) fn pr_action_error_status(action: PrAction) -> &'static str {
         PrAction::Merge => "pull request merge failed",
         PrAction::Close => "pull request close failed",
         PrAction::Approve => "pull request approval failed",
+        PrAction::EnableAutoMerge => "pull request auto-merge enable failed",
+        PrAction::DisableAutoMerge => "pull request auto-merge disable failed",
     }
 }
 

--- a/src/github.rs
+++ b/src/github.rs
@@ -202,6 +202,21 @@ struct PullRequestCheckRaw {
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+struct PullRequestAutoMergeStatusRaw {
+    auto_merge_request: Option<serde_json::Value>,
+    is_draft: Option<bool>,
+    state: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RepositoryMergeMethodsRaw {
+    allow_merge_commit: Option<bool>,
+    allow_rebase_merge: Option<bool>,
+    allow_squash_merge: Option<bool>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct PullRequestActionGraphQlRaw {
     data: PullRequestActionDataRaw,
 }
@@ -220,6 +235,7 @@ struct PullRequestActionRepositoryRaw {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct PullRequestActionRaw {
+    auto_merge_request: Option<serde_json::Value>,
     is_draft: Option<bool>,
     merge_state_status: Option<String>,
     review_decision: Option<String>,
@@ -871,6 +887,9 @@ query($owner: String!, $name: String!, $number: Int!) {
   repository(owner: $owner, name: $name) {
     pullRequest(number: $number) {
       state
+      autoMergeRequest {
+        enabledAt
+      }
       isDraft
       mergeStateStatus
       reviewDecision
@@ -1057,16 +1076,19 @@ pub async fn edit_pull_request_review_comment(
 
 pub async fn merge_pull_request(repository: &str, number: u64) -> Result<()> {
     ensure_pull_request_can_merge(repository, number).await?;
-    run_gh_json(&[
+    run_gh_json(&merge_pull_request_args(repository, number)).await?;
+    Ok(())
+}
+
+fn merge_pull_request_args(repository: &str, number: u64) -> Vec<String> {
+    vec![
         "pr".to_string(),
         "merge".to_string(),
         number.to_string(),
         "--repo".to_string(),
         repository.to_string(),
         "--merge".to_string(),
-    ])
-    .await?;
-    Ok(())
+    ]
 }
 
 async fn ensure_pull_request_can_merge(repository: &str, number: u64) -> Result<()> {
@@ -1098,6 +1120,172 @@ pub async fn close_pull_request(repository: &str, number: u64) -> Result<()> {
     ])
     .await?;
     Ok(())
+}
+
+pub async fn enable_pull_request_auto_merge(repository: &str, number: u64) -> Result<()> {
+    ensure_pull_request_auto_merge_can_enable(repository, number).await?;
+    let method = auto_merge_method_flag(repository).await?;
+    run_gh_json(&enable_pull_request_auto_merge_args(
+        repository, number, method,
+    ))
+    .await?;
+    Ok(())
+}
+
+fn enable_pull_request_auto_merge_args(
+    repository: &str,
+    number: u64,
+    method: &'static str,
+) -> Vec<String> {
+    vec![
+        "pr".to_string(),
+        "merge".to_string(),
+        number.to_string(),
+        "--repo".to_string(),
+        repository.to_string(),
+        method.to_string(),
+        "--auto".to_string(),
+    ]
+}
+
+async fn auto_merge_method_flag(repository: &str) -> Result<&'static str> {
+    let output = run_gh_json(&repository_merge_methods_args(repository)).await?;
+    let methods = serde_json::from_str::<RepositoryMergeMethodsRaw>(&output)
+        .with_context(|| format!("failed to parse merge methods for {repository}"))?;
+    repository_merge_method_flag(repository, &methods)
+}
+
+fn repository_merge_methods_args(repository: &str) -> Vec<String> {
+    vec![
+        "api".to_string(),
+        format!("repos/{repository}"),
+        "--jq".to_string(),
+        "{allow_merge_commit,allow_squash_merge,allow_rebase_merge}".to_string(),
+    ]
+}
+
+fn repository_merge_method_flag(
+    repository: &str,
+    methods: &RepositoryMergeMethodsRaw,
+) -> Result<&'static str> {
+    if methods.allow_merge_commit.unwrap_or(false) {
+        Ok("--merge")
+    } else if methods.allow_squash_merge.unwrap_or(false) {
+        Ok("--squash")
+    } else if methods.allow_rebase_merge.unwrap_or(false) {
+        Ok("--rebase")
+    } else {
+        bail!(
+            "cannot enable auto-merge for {repository}: repository does not allow merge, squash, or rebase merges"
+        );
+    }
+}
+
+pub async fn disable_pull_request_auto_merge(repository: &str, number: u64) -> Result<()> {
+    ensure_pull_request_auto_merge_can_disable(repository, number).await?;
+    run_gh_json(&disable_pull_request_auto_merge_args(repository, number)).await?;
+    Ok(())
+}
+
+fn disable_pull_request_auto_merge_args(repository: &str, number: u64) -> Vec<String> {
+    vec![
+        "pr".to_string(),
+        "merge".to_string(),
+        number.to_string(),
+        "--repo".to_string(),
+        repository.to_string(),
+        "--disable-auto".to_string(),
+    ]
+}
+
+async fn ensure_pull_request_auto_merge_can_enable(repository: &str, number: u64) -> Result<()> {
+    let status = fetch_pull_request_auto_merge_status(repository, number).await?;
+    if let Some(message) = pull_request_auto_merge_enable_blocker(repository, number, &status) {
+        bail!("{message}");
+    }
+    Ok(())
+}
+
+async fn ensure_pull_request_auto_merge_can_disable(repository: &str, number: u64) -> Result<()> {
+    let status = fetch_pull_request_auto_merge_status(repository, number).await?;
+    if let Some(message) = pull_request_auto_merge_disable_blocker(repository, number, &status) {
+        bail!("{message}");
+    }
+    Ok(())
+}
+
+async fn fetch_pull_request_auto_merge_status(
+    repository: &str,
+    number: u64,
+) -> Result<PullRequestAutoMergeStatusRaw> {
+    let output = run_gh_json(&pull_request_auto_merge_status_args(repository, number)).await?;
+    serde_json::from_str::<PullRequestAutoMergeStatusRaw>(&output)
+        .with_context(|| format!("failed to parse auto-merge status for {repository}#{number}"))
+}
+
+fn pull_request_auto_merge_status_args(repository: &str, number: u64) -> Vec<String> {
+    vec![
+        "pr".to_string(),
+        "view".to_string(),
+        number.to_string(),
+        "--repo".to_string(),
+        repository.to_string(),
+        "--json".to_string(),
+        "state,isDraft,autoMergeRequest".to_string(),
+    ]
+}
+
+fn pull_request_auto_merge_enable_blocker(
+    repository: &str,
+    number: u64,
+    status: &PullRequestAutoMergeStatusRaw,
+) -> Option<String> {
+    if let Some(message) =
+        pull_request_auto_merge_open_blocker(repository, number, status, "enable")
+    {
+        return Some(message);
+    }
+    if status.is_draft.unwrap_or(false) {
+        return Some(format!(
+            "cannot enable auto-merge for {repository}#{number}: pull request is a draft"
+        ));
+    }
+    if status.auto_merge_request.is_some() {
+        return Some(format!(
+            "auto-merge is already enabled for {repository}#{number}"
+        ));
+    }
+    None
+}
+
+fn pull_request_auto_merge_disable_blocker(
+    repository: &str,
+    number: u64,
+    status: &PullRequestAutoMergeStatusRaw,
+) -> Option<String> {
+    if let Some(message) =
+        pull_request_auto_merge_open_blocker(repository, number, status, "disable")
+    {
+        return Some(message);
+    }
+    if status.auto_merge_request.is_none() {
+        return Some(format!(
+            "auto-merge is already disabled for {repository}#{number}"
+        ));
+    }
+    None
+}
+
+fn pull_request_auto_merge_open_blocker(
+    repository: &str,
+    number: u64,
+    status: &PullRequestAutoMergeStatusRaw,
+    action: &str,
+) -> Option<String> {
+    let state = status.state.as_deref().unwrap_or("UNKNOWN");
+    (!state.eq_ignore_ascii_case("OPEN")).then(|| {
+        format!("cannot {action} auto-merge for {repository}#{number}: pull request is {state}")
+    })
 }
 
 pub async fn approve_pull_request(repository: &str, number: u64) -> Result<()> {
@@ -1477,11 +1665,16 @@ fn pull_request_action_hints(pr: &PullRequestActionRaw) -> ActionHints {
         .as_deref()
         .is_none_or(|state| state.eq_ignore_ascii_case("OPEN"));
     let draft = pr.is_draft.unwrap_or(false);
+    let auto_merge_enabled = pr.auto_merge_request.is_some();
     let did_author = pr.viewer_did_author.unwrap_or(false);
     let latest_review = pr
         .viewer_latest_review
         .as_ref()
         .and_then(|review| review.state.as_deref());
+
+    if open && auto_merge_enabled {
+        labels.push("Auto-merge on".to_string());
+    }
 
     if open
         && !draft
@@ -1495,7 +1688,7 @@ fn pull_request_action_hints(pr: &PullRequestActionRaw) -> ActionHints {
 
     if blockers.is_empty() && can_merge {
         labels.push("Mergeable".to_string());
-    } else if open && !draft && can_auto_merge {
+    } else if open && !draft && can_auto_merge && !auto_merge_enabled {
         labels.push("Auto-mergeable".to_string());
     }
 
@@ -2233,6 +2426,117 @@ mod tests {
     }
 
     #[test]
+    fn auto_merge_commands_use_non_interactive_gh_pr_merge_flags() {
+        assert_eq!(
+            enable_pull_request_auto_merge_args("owner/repo", 42, "--merge"),
+            vec![
+                "pr",
+                "merge",
+                "42",
+                "--repo",
+                "owner/repo",
+                "--merge",
+                "--auto"
+            ]
+        );
+        assert_eq!(
+            disable_pull_request_auto_merge_args("owner/repo", 42),
+            vec![
+                "pr",
+                "merge",
+                "42",
+                "--repo",
+                "owner/repo",
+                "--disable-auto"
+            ]
+        );
+        assert_eq!(
+            pull_request_auto_merge_status_args("owner/repo", 42),
+            vec![
+                "pr",
+                "view",
+                "42",
+                "--repo",
+                "owner/repo",
+                "--json",
+                "state,isDraft,autoMergeRequest"
+            ]
+        );
+        assert_eq!(
+            repository_merge_methods_args("owner/repo"),
+            vec![
+                "api",
+                "repos/owner/repo",
+                "--jq",
+                "{allow_merge_commit,allow_squash_merge,allow_rebase_merge}"
+            ]
+        );
+    }
+
+    #[test]
+    fn auto_merge_method_uses_allowed_repo_merge_policy() {
+        let merge = RepositoryMergeMethodsRaw {
+            allow_merge_commit: Some(true),
+            allow_squash_merge: Some(true),
+            allow_rebase_merge: Some(true),
+        };
+        assert_eq!(
+            repository_merge_method_flag("owner/repo", &merge).expect("merge allowed"),
+            "--merge"
+        );
+
+        let squash = RepositoryMergeMethodsRaw {
+            allow_merge_commit: Some(false),
+            allow_squash_merge: Some(true),
+            allow_rebase_merge: Some(true),
+        };
+        assert_eq!(
+            repository_merge_method_flag("owner/repo", &squash).expect("squash allowed"),
+            "--squash"
+        );
+
+        let none = RepositoryMergeMethodsRaw {
+            allow_merge_commit: Some(false),
+            allow_squash_merge: Some(false),
+            allow_rebase_merge: Some(false),
+        };
+        let error = repository_merge_method_flag("owner/repo", &none)
+            .expect_err("no merge methods should be rejected")
+            .to_string();
+        assert!(error.contains("repository does not allow merge"));
+    }
+
+    #[test]
+    fn auto_merge_preflight_rejects_closed_and_already_matching_state() {
+        let closed = PullRequestAutoMergeStatusRaw {
+            auto_merge_request: None,
+            is_draft: Some(false),
+            state: Some("MERGED".to_string()),
+        };
+        let error = pull_request_auto_merge_enable_blocker("owner/repo", 42, &closed)
+            .expect("merged PR should be rejected");
+        assert!(error.contains("pull request is MERGED"));
+
+        let enabled = PullRequestAutoMergeStatusRaw {
+            auto_merge_request: Some(serde_json::json!({ "enabledAt": "2026-05-04T00:00:00Z" })),
+            is_draft: Some(false),
+            state: Some("OPEN".to_string()),
+        };
+        let error = pull_request_auto_merge_enable_blocker("owner/repo", 42, &enabled)
+            .expect("already enabled PR should be rejected");
+        assert_eq!(error, "auto-merge is already enabled for owner/repo#42");
+
+        let disabled = PullRequestAutoMergeStatusRaw {
+            auto_merge_request: None,
+            is_draft: Some(false),
+            state: Some("OPEN".to_string()),
+        };
+        let error = pull_request_auto_merge_disable_blocker("owner/repo", 42, &disabled)
+            .expect("already disabled PR should be rejected");
+        assert_eq!(error, "auto-merge is already disabled for owner/repo#42");
+    }
+
+    #[test]
     fn merge_blocker_message_explains_review_and_checks() {
         let status = PullRequestMergeStatusRaw {
             is_draft: Some(false),
@@ -2279,6 +2583,7 @@ mod tests {
     #[test]
     fn action_hints_show_approvable_when_review_is_needed() {
         let hints = pull_request_action_hints(&PullRequestActionRaw {
+            auto_merge_request: None,
             is_draft: Some(false),
             merge_state_status: Some("BLOCKED".to_string()),
             review_decision: Some("REVIEW_REQUIRED".to_string()),
@@ -2330,6 +2635,7 @@ mod tests {
     #[test]
     fn action_hints_show_mergeable_when_pr_is_ready_and_viewer_can_merge() {
         let hints = pull_request_action_hints(&PullRequestActionRaw {
+            auto_merge_request: None,
             is_draft: Some(false),
             merge_state_status: Some("CLEAN".to_string()),
             review_decision: Some("APPROVED".to_string()),


### PR DESCRIPTION
## Summary
- Add confirmed PR actions for enabling and disabling auto-merge from list, details, and diff-file views.
- Use `gh pr view` preflight for open/draft/already-enabled/already-disabled states, then run `gh pr merge --auto` or `--disable-auto` with repo-allowed merge method flags.
- Refresh details/action hints after successful PR actions and document the new `E` / `D` shortcuts.

## Validation
- `rtk cargo fmt`
- `rtk cargo test`