### PR TITLE
[codex] Add PR failed-check rerun action

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 - Fuzzy filtering in every loaded list with `/`, plus repo-scoped GitHub search with `S`.
 - Details pane with rendered Markdown, clickable links, fenced code blocks with lightweight Rust and plain/log highlighting, descriptions, comments, review comments, labels, action hints, and check summaries.
 - PR diff mode with a changed-file list, per-file diff rendering, inline review comments, and review ranges.
-- Comment, reply, edit, merge, close, and approve flows from inside the TUI.
+- Comment, reply, edit, merge, close, approve, and rerun-failed-checks flows from inside the TUI.
 - Unread notification handling with local cache updates and GitHub read-state sync.
 - Mouse support for tabs, lists, links, comments, scrolling, text selection mode, and split resizing.
 - UI state persistence under `~/.ghr`, including focus, selected item, scroll position, split ratio, and diff mode.
@@ -77,6 +77,7 @@ Press `?` in the TUI for the live shortcut reference. The status bar also change
 | `M` | Open a merge confirmation for the selected PR |
 | `C` | Open a close confirmation for the selected PR |
 | `A` | Open an approve confirmation for the selected PR |
+| `F` | Rerun failed checks for the selected PR |
 | `y` / `Enter` | Confirm the current PR action in the confirmation dialog |
 | `Ctrl+Enter` | Send or update a comment from the comment dialog |
 | `r` | Refresh from GitHub |

--- a/src/app.rs
+++ b/src/app.rs
@@ -34,12 +34,12 @@ use crate::github::{
     edit_pull_request_review_comment, fetch_comments, fetch_pull_request_action_hints,
     fetch_pull_request_diff, mark_notification_thread_read, merge_pull_request, post_issue_comment,
     post_pull_request_review_comment, post_pull_request_review_reply, refresh_dashboard,
-    refresh_dashboard_with_progress, refresh_section_page, search_global,
-    with_background_github_priority,
+    refresh_dashboard_with_progress, refresh_section_page, rerun_failed_pull_request_checks,
+    search_global, with_background_github_priority,
 };
 use crate::model::{
-    ActionHints, CheckSummary, CommentPreview, ItemKind, SectionKind, SectionSnapshot, WorkItem,
-    builtin_view_key, configured_sections, global_search_view_key,
+    ActionHints, CheckSummary, CommentPreview, FailedCheckRunSummary, ItemKind, SectionKind,
+    SectionSnapshot, WorkItem, builtin_view_key, configured_sections, global_search_view_key,
     mark_notification_read_in_section, merge_cached_sections, merge_refreshed_sections,
     section_counts, section_view_key,
 };
@@ -247,12 +247,14 @@ enum PrAction {
     Merge,
     Close,
     Approve,
+    RerunFailedChecks,
 }
 
 #[derive(Debug, Clone)]
 struct PrActionDialog {
     item: WorkItem,
     action: PrAction,
+    summary: Vec<(&'static str, String)>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1077,6 +1079,9 @@ fn start_pr_action(
                 PrAction::Approve => approve_pull_request(&item.repo, number)
                     .await
                     .map_err(|error| error.to_string()),
+                PrAction::RerunFailedChecks => rerun_failed_pull_request_checks(&item.repo, number)
+                    .await
+                    .map_err(|error| error.to_string()),
             },
             None => Err("selected item has no pull request number".to_string()),
         };
@@ -1088,6 +1093,13 @@ fn start_pr_action(
         });
 
         if should_refresh {
+            if let Some(number) = item.number {
+                let item_id = item.id.clone();
+                let actions = fetch_pull_request_action_hints(&item.repo, number)
+                    .await
+                    .map_err(|error| error.to_string());
+                let _ = tx.send(AppMsg::ActionHintsLoaded { item_id, actions });
+            }
             let _ = tx.send(AppMsg::RefreshStarted);
             let sections = with_background_github_priority(refresh_dashboard(&config)).await;
             let mut save_error = None;
@@ -1287,6 +1299,7 @@ fn handle_key_in_area(
             KeyCode::Char('M') => app.start_pr_action_dialog(PrAction::Merge),
             KeyCode::Char('C') => app.start_pr_action_dialog(PrAction::Close),
             KeyCode::Char('A') => app.start_pr_action_dialog(PrAction::Approve),
+            KeyCode::Char('F') => app.start_pr_action_dialog(PrAction::RerunFailedChecks),
             KeyCode::Char('a') => app.start_new_comment_dialog(),
             KeyCode::Enter => {
                 app.focus_details();
@@ -1308,6 +1321,7 @@ fn handle_key_in_area(
             KeyCode::Char('M') => app.start_pr_action_dialog(PrAction::Merge),
             KeyCode::Char('C') => app.start_pr_action_dialog(PrAction::Close),
             KeyCode::Char('A') => app.start_pr_action_dialog(PrAction::Approve),
+            KeyCode::Char('F') => app.start_pr_action_dialog(PrAction::RerunFailedChecks),
             KeyCode::Char('c') if app.details_mode == DetailsMode::Diff => {
                 app.start_review_comment_dialog()
             }
@@ -1440,6 +1454,7 @@ fn handle_diff_file_list_key(app: &mut AppState, key: KeyEvent, area: Option<Rec
         KeyCode::Char('M') => app.start_pr_action_dialog(PrAction::Merge),
         KeyCode::Char('C') => app.start_pr_action_dialog(PrAction::Close),
         KeyCode::Char('A') => app.start_pr_action_dialog(PrAction::Approve),
+        KeyCode::Char('F') => app.start_pr_action_dialog(PrAction::RerunFailedChecks),
         KeyCode::Enter => app.focus_details(),
         _ => {}
     }
@@ -2679,7 +2694,7 @@ fn push_footer_focus_shortcuts(spans: &mut Vec<Span<'static>>, app: &AppState) {
                 push_footer_pair(spans, "enter", "diff", Color::Cyan);
                 push_footer_pair(spans, "c", "inline", Color::LightBlue);
                 push_footer_pair(spans, "a", "comment", Color::LightBlue);
-                push_footer_pair(spans, "M/C/A", "pr action", Color::LightMagenta);
+                push_footer_pair(spans, "M/C/A/F", "pr action", Color::LightMagenta);
             } else {
                 push_footer_context(spans, "List", "items");
                 push_footer_pair(spans, "j/k", "move", Color::Cyan);
@@ -2693,7 +2708,7 @@ fn push_footer_focus_shortcuts(spans: &mut Vec<Span<'static>>, app: &AppState) {
                 }
                 push_footer_pair(spans, "v", "diff", Color::LightMagenta);
                 push_footer_pair(spans, "a", "comment", Color::LightBlue);
-                push_footer_pair(spans, "M/C/A", "pr action", Color::LightMagenta);
+                push_footer_pair(spans, "M/C/A/F", "pr action", Color::LightMagenta);
             }
         }
         FocusTarget::Details => {
@@ -2717,7 +2732,7 @@ fn push_footer_focus_shortcuts(spans: &mut Vec<Span<'static>>, app: &AppState) {
                 push_footer_pair(spans, "e", "end", Color::Yellow);
                 push_footer_pair(spans, "c", "inline", Color::LightBlue);
                 push_footer_pair(spans, "a", "comment", Color::LightBlue);
-                push_footer_pair(spans, "M/C/A", "pr action", Color::LightMagenta);
+                push_footer_pair(spans, "M/C/A/F", "pr action", Color::LightMagenta);
             } else {
                 push_footer_pair(spans, "v", "diff", Color::LightMagenta);
                 push_footer_pair(spans, "/", "search", Color::Yellow);
@@ -2726,7 +2741,7 @@ fn push_footer_focus_shortcuts(spans: &mut Vec<Span<'static>>, app: &AppState) {
                 push_footer_pair(spans, "c/a", "comment", Color::LightBlue);
                 push_footer_pair(spans, "R", "reply", Color::LightBlue);
                 push_footer_pair(spans, "e", "edit", Color::LightBlue);
-                push_footer_pair(spans, "M/C/A", "pr action", Color::LightMagenta);
+                push_footer_pair(spans, "M/C/A/F", "pr action", Color::LightMagenta);
             }
             push_footer_pair(spans, "esc", "List", Color::Cyan);
         }
@@ -3033,23 +3048,30 @@ fn draw_pr_action_dialog(
         PrAction::Merge => "merge",
         PrAction::Close => "close",
         PrAction::Approve => "approve",
+        PrAction::RerunFailedChecks => "rerun failed checks for",
     };
     let prompt = match dialog.action {
         PrAction::Merge => "Merge this pull request on GitHub?",
         PrAction::Close => "Close this pull request on GitHub?",
         PrAction::Approve => "Approve this pull request on GitHub?",
+        PrAction::RerunFailedChecks => "Rerun failed GitHub Actions jobs for this pull request?",
     };
     let status = if running {
         "working...".to_string()
     } else {
         format!("y/Enter: yes, {action_label} PR    Esc: cancel")
     };
-    let lines = vec![
+    let mut lines = vec![
         Line::from(prompt),
         Line::from(""),
         key_value_line("repo", dialog.item.repo.clone()),
         key_value_line("pull request", number),
         key_value_line("title", dialog.item.title.clone()),
+    ];
+    for (key, value) in &dialog.summary {
+        lines.push(key_value_line(key, value.clone()));
+    }
+    lines.extend([
         Line::from(""),
         Line::from(vec![Span::styled(
             status,
@@ -3057,7 +3079,7 @@ fn draw_pr_action_dialog(
                 .fg(Color::Yellow)
                 .add_modifier(Modifier::BOLD),
         )]),
-    ];
+    ]);
     let block = Block::default()
         .borders(Borders::ALL)
         .border_style(Style::default().fg(Color::Yellow))
@@ -3067,6 +3089,7 @@ fn draw_pr_action_dialog(
                 PrAction::Merge => "Merge Pull Request",
                 PrAction::Close => "Close Pull Request",
                 PrAction::Approve => "Approve Pull Request",
+                PrAction::RerunFailedChecks => "Rerun Failed Checks",
             },
             Style::default()
                 .fg(Color::Yellow)
@@ -3505,6 +3528,7 @@ fn help_dialog_content() -> Vec<Line<'static>> {
         help_key_line("M", "open PR merge confirmation"),
         help_key_line("C", "open PR close confirmation"),
         help_key_line("A", "open PR approve confirmation"),
+        help_key_line("F", "rerun failed PR checks"),
         help_key_line("a", "add a new issue or PR comment"),
         Line::from(""),
         help_heading("Diff Files"),
@@ -3542,6 +3566,7 @@ fn help_dialog_content() -> Vec<Line<'static>> {
         help_key_line("M", "open PR merge confirmation"),
         help_key_line("C", "open PR close confirmation"),
         help_key_line("A", "open PR approve confirmation"),
+        help_key_line("F", "rerun failed PR checks"),
         help_key_line("o", "open selected item in browser"),
         Line::from(""),
         help_heading("Pull Request Confirmation"),
@@ -6015,6 +6040,20 @@ fn check_summary_segments(summary: &CheckSummary) -> Vec<DetailSegment> {
     segments
 }
 
+fn failed_check_runs_summary(runs: &[FailedCheckRunSummary]) -> String {
+    runs.iter()
+        .map(|run| {
+            let label = run
+                .workflow
+                .as_deref()
+                .filter(|workflow| !workflow.trim().is_empty())
+                .unwrap_or("Actions run");
+            format!("{label} #{} ({})", run.run_id, run.checks.join(", "))
+        })
+        .collect::<Vec<_>>()
+        .join("; ")
+}
+
 fn push_check_part(segments: &mut Vec<DetailSegment>, text: String, style: Style) {
     if !segments.is_empty() {
         segments.push(DetailSegment::raw(", "));
@@ -7595,6 +7634,9 @@ impl AppState {
                             PrAction::Merge => "pull request merged; refreshing".to_string(),
                             PrAction::Close => "pull request closed; refreshing".to_string(),
                             PrAction::Approve => "pull request approved; refreshing".to_string(),
+                            PrAction::RerunFailedChecks => {
+                                "failed checks rerun; refreshing".to_string()
+                            }
                         };
                         self.message_dialog = Some(success_message_dialog(
                             pr_action_success_title(action),
@@ -7765,6 +7807,7 @@ impl AppState {
                     PrAction::Merge => item.state = Some("merged".to_string()),
                     PrAction::Close => item.state = Some("closed".to_string()),
                     PrAction::Approve => {}
+                    PrAction::RerunFailedChecks => {}
                 }
             }
         }
@@ -9078,16 +9121,77 @@ impl AppState {
             self.status = "selected item is not a pull request".to_string();
             return;
         }
+        let summary = match self.pr_action_dialog_summary(&item, action) {
+            Ok(summary) => summary,
+            Err((title, body, status)) => {
+                self.status = status;
+                self.message_dialog = Some(message_dialog(title, body));
+                return;
+            }
+        };
         self.search_active = false;
         self.global_search_active = false;
         self.comment_search_active = false;
-        self.pr_action_dialog = Some(PrActionDialog { item, action });
+        self.pr_action_dialog = Some(PrActionDialog {
+            item,
+            action,
+            summary,
+        });
         self.pr_action_running = false;
         self.status = match action {
             PrAction::Merge => "confirm pull request merge".to_string(),
             PrAction::Close => "confirm pull request close".to_string(),
             PrAction::Approve => "confirm pull request approval".to_string(),
+            PrAction::RerunFailedChecks => "confirm failed check rerun".to_string(),
         };
+    }
+
+    fn pr_action_dialog_summary(
+        &self,
+        item: &WorkItem,
+        action: PrAction,
+    ) -> Result<Vec<(&'static str, String)>, (&'static str, String, String)> {
+        if action != PrAction::RerunFailedChecks {
+            return Ok(Vec::new());
+        }
+
+        match self.action_hints.get(&item.id) {
+            Some(ActionHintState::Loaded(hints)) => match &hints.checks {
+                Some(checks) if checks.failed == 0 => Err((
+                    "No Failed Checks",
+                    "This pull request has no failed checks in the latest loaded action hints. Refresh if checks changed.".to_string(),
+                    "no failed checks to rerun".to_string(),
+                )),
+                Some(checks) => {
+                    let mut summary =
+                        vec![("failed checks", format!("{} of {}", checks.failed, checks.total))];
+                    if hints.failed_check_runs.is_empty() {
+                        summary.push((
+                            "workflow runs",
+                            "not mapped in loaded hints; ghr will query latest PR checks before rerunning".to_string(),
+                        ));
+                    } else {
+                        summary.push((
+                            "workflow runs",
+                            failed_check_runs_summary(&hints.failed_check_runs),
+                        ));
+                    }
+                    Ok(summary)
+                }
+                None => Ok(vec![(
+                    "checks",
+                    "not loaded; ghr will query latest PR checks before rerunning".to_string(),
+                )]),
+            },
+            Some(ActionHintState::Loading) | None => Ok(vec![(
+                "checks",
+                "loading; ghr will query latest PR checks before rerunning".to_string(),
+            )]),
+            Some(ActionHintState::Error(error)) => Ok(vec![(
+                "checks",
+                format!("hints unavailable ({error}); ghr will query latest PR checks"),
+            )]),
+        }
     }
 
     fn handle_pr_action_dialog_key(
@@ -9138,6 +9242,7 @@ impl AppState {
             PrAction::Merge => "merging pull request".to_string(),
             PrAction::Close => "closing pull request".to_string(),
             PrAction::Approve => "approving pull request".to_string(),
+            PrAction::RerunFailedChecks => "rerunning failed checks".to_string(),
         };
         submit(item, action);
     }
@@ -12261,7 +12366,7 @@ diff --git a/src/github.rs b/src/github.rs
         );
         assert!(text.contains("/ search"));
         assert!(text.contains("v diff"));
-        assert!(text.contains("M/C/A pr action"));
+        assert!(text.contains("M/C/A/F pr action"));
         assert!(
             text.contains(
                 "| 1-4 focus  ? help  S repo  r refresh  o open  m text-select  q quit |"
@@ -12280,7 +12385,7 @@ diff --git a/src/github.rs b/src/github.rs
         app.focus_ghr();
         let ghr = footer_line(&app, &paths).to_string();
         assert!(ghr.contains("ghr tabs  tab/h/l switch  j/enter Sections  esc List"));
-        assert!(!ghr.contains("M/C/A pr action"));
+        assert!(!ghr.contains("M/C/A/F pr action"));
 
         app.focus_sections();
         let sections = footer_line(&app, &paths).to_string();
@@ -12298,7 +12403,7 @@ diff --git a/src/github.rs b/src/github.rs
         app.focus_details();
         let diff = footer_line(&app, &paths).to_string();
         assert!(diff.contains("Details diff  j/k line  n/p page  g/G top/bottom"));
-        assert!(diff.contains("[ ] file  m begin  e end  c inline  a comment  M/C/A pr action"));
+        assert!(diff.contains("[ ] file  m begin  e end  c inline  a comment  M/C/A/F pr action"));
         assert!(!diff.contains("m text-select"));
         assert!(diff.contains("q back"));
         assert!(!diff.contains("q quit"));
@@ -13068,6 +13173,7 @@ diff --git a/src/github.rs b/src/github.rs
                     total: 13,
                     incomplete: false,
                 }),
+                failed_check_runs: Vec::new(),
                 note: Some("Merge blocked: checks pending".to_string()),
             }),
         );
@@ -14146,6 +14252,52 @@ diff --git a/src/github.rs b/src/github.rs
     }
 
     #[test]
+    fn capital_f_key_opens_rerun_failed_checks_confirmation() {
+        let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
+        app.action_hints.insert(
+            "1".to_string(),
+            ActionHintState::Loaded(ActionHints {
+                checks: Some(CheckSummary {
+                    passed: 2,
+                    failed: 1,
+                    pending: 0,
+                    skipped: 0,
+                    total: 3,
+                    incomplete: false,
+                }),
+                failed_check_runs: vec![FailedCheckRunSummary {
+                    run_id: 123,
+                    workflow: Some("CI".to_string()),
+                    checks: vec!["test".to_string()],
+                }],
+                ..ActionHints::default()
+            }),
+        );
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let config = Config::default();
+        let store = SnapshotStore::new(std::path::PathBuf::from("/tmp/ghr-test-unused.db"));
+
+        assert!(!handle_key(
+            &mut app,
+            key(KeyCode::Char('F')),
+            &config,
+            &store,
+            &tx
+        ));
+
+        let dialog = app.pr_action_dialog.as_ref().expect("rerun dialog");
+        assert_eq!(dialog.action, PrAction::RerunFailedChecks);
+        assert_eq!(dialog.item.id, "1");
+        assert_eq!(app.status, "confirm failed check rerun");
+        assert!(
+            dialog
+                .summary
+                .iter()
+                .any(|(_, value)| value.contains("CI #123"))
+        );
+    }
+
+    #[test]
     fn pr_action_confirmation_submits_selected_action() {
         let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
         app.start_pr_action_dialog(PrAction::Approve);
@@ -14172,6 +14324,64 @@ diff --git a/src/github.rs b/src/github.rs
         assert!(app.pr_action_dialog.is_none());
         assert!(!app.pr_action_running);
         assert_eq!(app.status, "pull request action cancelled");
+    }
+
+    #[test]
+    fn rerun_failed_checks_rejects_pr_without_failed_checks() {
+        let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
+        app.action_hints.insert(
+            "1".to_string(),
+            ActionHintState::Loaded(ActionHints {
+                checks: Some(CheckSummary {
+                    passed: 3,
+                    failed: 0,
+                    pending: 0,
+                    skipped: 0,
+                    total: 3,
+                    incomplete: false,
+                }),
+                ..ActionHints::default()
+            }),
+        );
+
+        app.start_pr_action_dialog(PrAction::RerunFailedChecks);
+
+        assert!(app.pr_action_dialog.is_none());
+        assert_eq!(app.status, "no failed checks to rerun");
+        let dialog = app.message_dialog.as_ref().expect("message dialog");
+        assert_eq!(dialog.title, "No Failed Checks");
+    }
+
+    #[test]
+    fn rerun_failed_checks_confirmation_submits_action() {
+        let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
+        app.action_hints.insert(
+            "1".to_string(),
+            ActionHintState::Loaded(ActionHints {
+                checks: Some(CheckSummary {
+                    passed: 0,
+                    failed: 1,
+                    pending: 0,
+                    skipped: 0,
+                    total: 1,
+                    incomplete: false,
+                }),
+                ..ActionHints::default()
+            }),
+        );
+        app.start_pr_action_dialog(PrAction::RerunFailedChecks);
+        let mut submitted = None;
+
+        app.handle_pr_action_dialog_key_with_submit(key(KeyCode::Char('y')), |item, action| {
+            submitted = Some((item.id, action));
+        });
+
+        assert!(app.pr_action_running);
+        assert_eq!(app.status, "rerunning failed checks");
+        assert_eq!(
+            submitted,
+            Some(("1".to_string(), PrAction::RerunFailedChecks))
+        );
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -250,11 +250,14 @@ enum PrAction {
     RerunFailedChecks,
 }
 
+type PrActionDialogSummary = Vec<(&'static str, String)>;
+type PrActionDialogSummaryError = (&'static str, String, String);
+
 #[derive(Debug, Clone)]
 struct PrActionDialog {
     item: WorkItem,
     action: PrAction,
-    summary: Vec<(&'static str, String)>,
+    summary: PrActionDialogSummary,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -9150,7 +9153,7 @@ impl AppState {
         &self,
         item: &WorkItem,
         action: PrAction,
-    ) -> Result<Vec<(&'static str, String)>, (&'static str, String, String)> {
+    ) -> Result<PrActionDialogSummary, PrActionDialogSummaryError> {
         if action != PrAction::RerunFailedChecks {
             return Ok(Vec::new());
         }

--- a/src/app/status.rs
+++ b/src/app/status.rs
@@ -84,6 +84,7 @@ pub(super) fn pr_action_success_title(action: PrAction) -> &'static str {
         PrAction::Merge => "Pull Request Merged",
         PrAction::Close => "Pull Request Closed",
         PrAction::Approve => "Pull Request Approved",
+        PrAction::RerunFailedChecks => "Failed Checks Rerun",
     }
 }
 
@@ -92,6 +93,9 @@ pub(super) fn pr_action_success_body(action: PrAction) -> &'static str {
         PrAction::Merge => "GitHub accepted the merge. Refreshing details.",
         PrAction::Close => "GitHub accepted the close action. Refreshing details.",
         PrAction::Approve => "GitHub accepted the approval. Refreshing details.",
+        PrAction::RerunFailedChecks => {
+            "GitHub accepted the failed-check rerun request. Refreshing details."
+        }
     }
 }
 
@@ -100,6 +104,7 @@ pub(super) fn pr_action_error_title(action: PrAction) -> &'static str {
         PrAction::Merge => "Merge Failed",
         PrAction::Close => "Close Failed",
         PrAction::Approve => "Approve Failed",
+        PrAction::RerunFailedChecks => "Rerun Failed",
     }
 }
 
@@ -108,6 +113,7 @@ pub(super) fn pr_action_error_status(action: PrAction) -> &'static str {
         PrAction::Merge => "pull request merge failed",
         PrAction::Close => "pull request close failed",
         PrAction::Approve => "pull request approval failed",
+        PrAction::RerunFailedChecks => "failed check rerun failed",
     }
 }
 

--- a/src/github.rs
+++ b/src/github.rs
@@ -14,9 +14,9 @@ use tracing::{info, warn};
 
 use crate::config::{Config, SearchSection};
 use crate::model::{
-    ActionHints, CheckSummary, CommentPreview, ItemKind, ReviewCommentPreview, SectionKind,
-    SectionSnapshot, WorkItem, builtin_view_key, global_search_view_key, repo_section_filters,
-    repo_view_key,
+    ActionHints, CheckSummary, CommentPreview, FailedCheckRunSummary, ItemKind,
+    ReviewCommentPreview, SectionKind, SectionSnapshot, WorkItem, builtin_view_key,
+    global_search_view_key, repo_section_filters, repo_view_key,
 };
 
 static VIEWER_LOGIN: OnceCell<String> = OnceCell::const_new();
@@ -251,6 +251,9 @@ struct PullRequestCheckConnectionRaw {
 enum PullRequestCheckContextRaw {
     CheckRun {
         conclusion: Option<String>,
+        #[serde(rename = "detailsUrl")]
+        details_url: Option<String>,
+        name: Option<String>,
         status: Option<String>,
     },
     StatusContext {
@@ -263,6 +266,21 @@ enum PullRequestCheckContextRaw {
 #[derive(Debug, Deserialize)]
 struct PullRequestViewerReviewRaw {
     state: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PullRequestCheckStatusRaw {
+    bucket: Option<String>,
+    link: Option<String>,
+    name: Option<String>,
+    state: Option<String>,
+    workflow: Option<String>,
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+struct FailedCheckRunDiscovery {
+    runs: Vec<FailedCheckRunSummary>,
+    unmapped_failed_checks: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -889,8 +907,10 @@ query($owner: String!, $name: String!, $number: Int!) {
           nodes {
             __typename
             ... on CheckRun {
+              name
               status
               conclusion
+              detailsUrl
             }
             ... on StatusContext {
               state
@@ -923,6 +943,81 @@ query($owner: String!, $name: String!, $number: Int!) {
         .and_then(|repository| repository.pull_request)
         .ok_or_else(|| anyhow!("pull request {repository}#{number} was not found"))?;
     Ok(pull_request_action_hints(&pr))
+}
+
+pub async fn rerun_failed_pull_request_checks(repository: &str, number: u64) -> Result<()> {
+    let discovery = fetch_failed_check_runs_from_pr_checks(repository, number).await?;
+    if discovery.runs.is_empty() {
+        if discovery.unmapped_failed_checks.is_empty() {
+            bail!("no failed checks found for {repository}#{number}");
+        }
+        bail!(
+            "failed checks were found, but none linked to GitHub Actions workflow runs: {}",
+            discovery.unmapped_failed_checks.join(", ")
+        );
+    }
+
+    for run in &discovery.runs {
+        run_gh_json(&rerun_failed_check_run_args(repository, run.run_id)).await?;
+    }
+
+    Ok(())
+}
+
+async fn fetch_failed_check_runs_from_pr_checks(
+    repository: &str,
+    number: u64,
+) -> Result<FailedCheckRunDiscovery> {
+    let output = run_gh_pr_checks_json(&pr_checks_args(repository, number)).await?;
+    failed_check_runs_from_pr_checks_json(&output)
+        .with_context(|| format!("failed to parse PR checks for {repository}#{number}"))
+}
+
+fn pr_checks_args(repository: &str, number: u64) -> Vec<String> {
+    vec![
+        "pr".to_string(),
+        "checks".to_string(),
+        number.to_string(),
+        "--repo".to_string(),
+        repository.to_string(),
+        "--json".to_string(),
+        "name,state,bucket,workflow,link".to_string(),
+    ]
+}
+
+fn rerun_failed_check_run_args(repository: &str, run_id: u64) -> Vec<String> {
+    vec![
+        "run".to_string(),
+        "rerun".to_string(),
+        run_id.to_string(),
+        "--failed".to_string(),
+        "--repo".to_string(),
+        repository.to_string(),
+    ]
+}
+
+async fn run_gh_pr_checks_json(args: &[String]) -> Result<String> {
+    let output = Command::new("gh")
+        .env("GH_PROMPT_DISABLED", "1")
+        .args(args)
+        .output()
+        .await
+        .map_err(|error| {
+            if error.kind() == ErrorKind::NotFound {
+                anyhow!("{}", gh_missing_message(args))
+            } else {
+                anyhow!("failed to run gh {}: {error}", args.join(" "))
+            }
+        })?;
+
+    if !output.status.success() && output.stdout.is_empty() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        let message = if stderr.is_empty() { stdout } else { stderr };
+        bail!("{}", gh_failure_message(args, &message));
+    }
+
+    String::from_utf8(output.stdout).context("gh output was not UTF-8")
 }
 
 pub async fn fetch_pull_request_diff(repository: &str, number: u64) -> Result<String> {
@@ -1468,6 +1563,7 @@ fn pull_request_action_hints(pr: &PullRequestActionRaw) -> ActionHints {
         .status_check_rollup
         .as_ref()
         .map(check_summary_from_rollup);
+    let failed_check_runs = failed_check_runs_from_rollup(pr.status_check_rollup.as_ref());
     let can_update = pr.viewer_can_update.unwrap_or(false);
     let can_auto_merge = pr.viewer_can_enable_auto_merge.unwrap_or(false);
     let can_admin_merge = pr.viewer_can_merge_as_admin.unwrap_or(false);
@@ -1512,6 +1608,7 @@ fn pull_request_action_hints(pr: &PullRequestActionRaw) -> ActionHints {
     ActionHints {
         labels,
         checks,
+        failed_check_runs,
         note,
     }
 }
@@ -1587,9 +1684,9 @@ fn check_summary_from_rollup(rollup: &PullRequestStatusRollupRaw) -> CheckSummar
     let nodes = contexts.nodes.as_deref().unwrap_or(&[]);
     for node in nodes {
         match node {
-            PullRequestCheckContextRaw::CheckRun { conclusion, status } => {
-                add_check_run_to_summary(&mut summary, conclusion.as_deref(), status.as_deref())
-            }
+            PullRequestCheckContextRaw::CheckRun {
+                conclusion, status, ..
+            } => add_check_run_to_summary(&mut summary, conclusion.as_deref(), status.as_deref()),
             PullRequestCheckContextRaw::StatusContext { state } => {
                 add_status_context_to_summary(&mut summary, state.as_deref())
             }
@@ -1625,6 +1722,135 @@ fn add_status_context_to_summary(summary: &mut CheckSummary, state: Option<&str>
         Some("FAILURE" | "ERROR") => summary.failed += 1,
         Some("PENDING" | "EXPECTED") | None => summary.pending += 1,
         Some(_) => summary.pending += 1,
+    }
+}
+
+fn failed_check_runs_from_rollup(
+    rollup: Option<&PullRequestStatusRollupRaw>,
+) -> Vec<FailedCheckRunSummary> {
+    let mut runs = Vec::new();
+    let Some(contexts) = rollup.and_then(|rollup| rollup.contexts.as_ref()) else {
+        return runs;
+    };
+
+    for node in contexts.nodes.as_deref().unwrap_or(&[]) {
+        let PullRequestCheckContextRaw::CheckRun {
+            conclusion,
+            details_url,
+            name,
+            status,
+        } = node
+        else {
+            continue;
+        };
+        if !check_run_failed(conclusion.as_deref(), status.as_deref()) {
+            continue;
+        }
+        let Some(run_id) = details_url.as_deref().and_then(actions_run_id_from_url) else {
+            continue;
+        };
+        add_failed_check_run(
+            &mut runs,
+            run_id,
+            None,
+            name.clone().unwrap_or_else(|| "unknown check".to_string()),
+        );
+    }
+
+    runs
+}
+
+fn failed_check_runs_from_pr_checks_json(output: &str) -> Result<FailedCheckRunDiscovery> {
+    let checks = serde_json::from_str::<Vec<PullRequestCheckStatusRaw>>(output)?;
+    let mut discovery = FailedCheckRunDiscovery::default();
+
+    for check in checks {
+        if !pr_check_failed(&check) {
+            continue;
+        }
+        let name = check.name.unwrap_or_else(|| "unknown check".to_string());
+        let Some(run_id) = check.link.as_deref().and_then(actions_run_id_from_url) else {
+            push_unique_string(&mut discovery.unmapped_failed_checks, name);
+            continue;
+        };
+        add_failed_check_run(&mut discovery.runs, run_id, check.workflow, name);
+    }
+
+    Ok(discovery)
+}
+
+fn pr_check_failed(check: &PullRequestCheckStatusRaw) -> bool {
+    matches_normalized(check.bucket.as_deref(), &["fail", "cancel"])
+        || matches_normalized(
+            check.state.as_deref(),
+            &[
+                "fail",
+                "failure",
+                "error",
+                "cancel",
+                "cancelled",
+                "canceled",
+                "timed_out",
+                "action_required",
+                "startup_failure",
+            ],
+        )
+}
+
+fn check_run_failed(conclusion: Option<&str>, _status: Option<&str>) -> bool {
+    matches_normalized(
+        conclusion,
+        &[
+            "failure",
+            "error",
+            "cancelled",
+            "canceled",
+            "timed_out",
+            "action_required",
+            "startup_failure",
+        ],
+    )
+}
+
+fn matches_normalized(value: Option<&str>, expected: &[&str]) -> bool {
+    let Some(value) = value else {
+        return false;
+    };
+    expected
+        .iter()
+        .any(|expected| value.eq_ignore_ascii_case(expected))
+}
+
+fn actions_run_id_from_url(url: &str) -> Option<u64> {
+    let rest = url.split_once("/actions/runs/")?.1;
+    let digits: String = rest.chars().take_while(|ch| ch.is_ascii_digit()).collect();
+    digits.parse().ok()
+}
+
+fn add_failed_check_run(
+    runs: &mut Vec<FailedCheckRunSummary>,
+    run_id: u64,
+    workflow: Option<String>,
+    check: String,
+) {
+    if let Some(existing) = runs.iter_mut().find(|existing| existing.run_id == run_id) {
+        if existing.workflow.is_none() {
+            existing.workflow = workflow;
+        }
+        push_unique_string(&mut existing.checks, check);
+        return;
+    }
+
+    runs.push(FailedCheckRunSummary {
+        run_id,
+        workflow,
+        checks: vec![check],
+    });
+}
+
+fn push_unique_string(values: &mut Vec<String>, value: String) {
+    if !values.iter().any(|existing| existing == &value) {
+        values.push(value);
     }
 }
 
@@ -2290,10 +2516,14 @@ mod tests {
                     nodes: Some(vec![
                         PullRequestCheckContextRaw::CheckRun {
                             conclusion: Some("SUCCESS".to_string()),
+                            details_url: None,
+                            name: None,
                             status: Some("COMPLETED".to_string()),
                         },
                         PullRequestCheckContextRaw::CheckRun {
                             conclusion: Some("FAILURE".to_string()),
+                            details_url: None,
+                            name: None,
                             status: Some("COMPLETED".to_string()),
                         },
                         PullRequestCheckContextRaw::StatusContext {
@@ -2340,6 +2570,8 @@ mod tests {
                     total_count: 1,
                     nodes: Some(vec![PullRequestCheckContextRaw::CheckRun {
                         conclusion: Some("SUCCESS".to_string()),
+                        details_url: None,
+                        name: None,
                         status: Some("COMPLETED".to_string()),
                     }]),
                 }),
@@ -2367,6 +2599,125 @@ mod tests {
             })
         );
         assert!(hints.note.is_none());
+    }
+
+    #[test]
+    fn action_hints_collect_failed_actions_run_ids_from_rollup() {
+        let hints = pull_request_action_hints(&PullRequestActionRaw {
+            is_draft: Some(false),
+            merge_state_status: Some("BLOCKED".to_string()),
+            review_decision: None,
+            state: Some("OPEN".to_string()),
+            status_check_rollup: Some(PullRequestStatusRollupRaw {
+                state: Some("FAILURE".to_string()),
+                contexts: Some(PullRequestCheckConnectionRaw {
+                    total_count: 2,
+                    nodes: Some(vec![
+                        PullRequestCheckContextRaw::CheckRun {
+                            conclusion: Some("FAILURE".to_string()),
+                            details_url: Some(
+                                "https://github.com/owner/repo/actions/runs/987/job/654"
+                                    .to_string(),
+                            ),
+                            name: Some("test".to_string()),
+                            status: Some("COMPLETED".to_string()),
+                        },
+                        PullRequestCheckContextRaw::CheckRun {
+                            conclusion: Some("SUCCESS".to_string()),
+                            details_url: Some(
+                                "https://github.com/owner/repo/actions/runs/111/job/222"
+                                    .to_string(),
+                            ),
+                            name: Some("lint".to_string()),
+                            status: Some("COMPLETED".to_string()),
+                        },
+                    ]),
+                }),
+            }),
+            viewer_can_enable_auto_merge: Some(false),
+            viewer_can_merge_as_admin: Some(false),
+            viewer_can_update: Some(true),
+            viewer_can_update_branch: Some(false),
+            viewer_did_author: Some(false),
+            viewer_latest_review: None,
+        });
+
+        assert_eq!(
+            hints.failed_check_runs,
+            vec![FailedCheckRunSummary {
+                run_id: 987,
+                workflow: None,
+                checks: vec!["test".to_string()],
+            }]
+        );
+    }
+
+    #[test]
+    fn pr_checks_json_groups_failed_checks_by_actions_run() {
+        let output = r#"
+[
+  {
+    "bucket": "fail",
+    "link": "https://github.com/owner/repo/actions/runs/1001/job/1?pr=2",
+    "name": "test",
+    "state": "FAILURE",
+    "workflow": "CI"
+  },
+  {
+    "bucket": "fail",
+    "link": "https://github.com/owner/repo/actions/runs/1001/job/2?pr=2",
+    "name": "lint",
+    "state": "FAILURE",
+    "workflow": "CI"
+  },
+  {
+    "bucket": "pass",
+    "link": "https://github.com/owner/repo/actions/runs/1002/job/3?pr=2",
+    "name": "fmt",
+    "state": "SUCCESS",
+    "workflow": "CI"
+  },
+  {
+    "bucket": "fail",
+    "link": "https://example.com/checks/9",
+    "name": "external",
+    "state": "ERROR",
+    "workflow": null
+  }
+]
+"#;
+
+        let discovery = failed_check_runs_from_pr_checks_json(output).expect("valid checks");
+
+        assert_eq!(
+            discovery.runs,
+            vec![FailedCheckRunSummary {
+                run_id: 1001,
+                workflow: Some("CI".to_string()),
+                checks: vec!["test".to_string(), "lint".to_string()],
+            }]
+        );
+        assert_eq!(discovery.unmapped_failed_checks, vec!["external"]);
+    }
+
+    #[test]
+    fn rerun_failed_checks_commands_are_constructed_for_pr_and_run() {
+        assert_eq!(
+            pr_checks_args("owner/repo", 42),
+            vec![
+                "pr",
+                "checks",
+                "42",
+                "--repo",
+                "owner/repo",
+                "--json",
+                "name,state,bucket,workflow,link",
+            ]
+        );
+        assert_eq!(
+            rerun_failed_check_run_args("owner/repo", 1001),
+            vec!["run", "rerun", "1001", "--failed", "--repo", "owner/repo"]
+        );
     }
 
     #[test]

--- a/src/model.rs
+++ b/src/model.rs
@@ -86,7 +86,15 @@ pub struct ReviewCommentPreview {
 pub struct ActionHints {
     pub labels: Vec<String>,
     pub checks: Option<CheckSummary>,
+    pub failed_check_runs: Vec<FailedCheckRunSummary>,
     pub note: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FailedCheckRunSummary {
+    pub run_id: u64,
+    pub workflow: Option<String>,
+    pub checks: Vec<String>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]


### PR DESCRIPTION
## Summary
- add a confirmed `F` action for pull requests to rerun failed checks
- resolve latest failed PR checks to GitHub Actions run ids and call `gh run rerun --failed`
- refresh action hints/details after success and document the new shortcut

## Validation
- `rtk cargo fmt`
- `rtk cargo test`