### PR TITLE
[codex] Show PR commit count and created dates

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -4,7 +4,7 @@ use std::process::Command;
 use std::time::{Duration, Instant};
 
 use anyhow::Result;
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, Local, Utc};
 use crossterm::event::{
     self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEvent, KeyEventKind,
     KeyModifiers, KeyboardEnhancementFlags, MouseButton, MouseEvent, MouseEventKind,
@@ -2719,6 +2719,15 @@ fn pull_request_changes_url(item: &WorkItem) -> String {
     }
 }
 
+fn pull_request_commits_url(item: &WorkItem) -> String {
+    match item.number {
+        Some(number) if !item.repo.trim().is_empty() => {
+            format!("https://github.com/{}/pull/{number}/commits", item.repo)
+        }
+        _ => format!("{}/commits", item.url.trim_end_matches('/')),
+    }
+}
+
 fn same_view_key(left: &str, right: &str) -> bool {
     left == right
         || (left.starts_with("repo:")
@@ -5172,7 +5181,7 @@ fn build_conversation_document(app: &AppState, width: u16) -> DetailsDocument {
         3,
     );
 
-    builder.push_meta_line(vec![
+    let mut primary_meta = vec![
         ("repo", vec![DetailSegment::raw(item.repo.clone())]),
         (
             "number",
@@ -5188,11 +5197,18 @@ fn build_conversation_document(app: &AppState, width: u16) -> DetailsDocument {
                 item.state.clone().unwrap_or_else(|| "-".to_string()),
             )],
         ),
-        (
-            "updated",
-            vec![DetailSegment::raw(relative_time(item.updated_at))],
-        ),
-    ]);
+    ];
+    if matches!(item.kind, ItemKind::Issue | ItemKind::PullRequest) {
+        primary_meta.push((
+            "created",
+            vec![DetailSegment::raw(local_datetime(item.created_at))],
+        ));
+    }
+    primary_meta.push((
+        "updated",
+        vec![DetailSegment::raw(relative_time(item.updated_at))],
+    ));
+    builder.push_meta_line(primary_meta);
 
     let mut secondary_meta = Vec::new();
     let mut action_note = None;
@@ -5207,6 +5223,12 @@ fn build_conversation_document(app: &AppState, width: u16) -> DetailsDocument {
     }
     if let Some(comments) = details_comment_count(app, item) {
         secondary_meta.push(("comments", vec![DetailSegment::raw(comments.to_string())]));
+    }
+    if matches!(item.kind, ItemKind::PullRequest) {
+        secondary_meta.push((
+            "commits",
+            commit_count_segments(app.action_hints.get(&item.id), item),
+        ));
     }
     if let Some(reason) = useful_meta_value(item.reason.as_deref()) {
         secondary_meta.push(("reason", vec![DetailSegment::raw(reason.to_string())]));
@@ -6653,6 +6675,22 @@ fn check_hint_segments(state: Option<&ActionHintState>) -> Vec<DetailSegment> {
             .checks
             .as_ref()
             .map(check_summary_segments)
+            .unwrap_or_else(|| vec![DetailSegment::raw("-")]),
+        Some(ActionHintState::Loading) | None => vec![DetailSegment::raw("loading...")],
+        Some(ActionHintState::Error(_)) => vec![DetailSegment::raw("unavailable")],
+    }
+}
+
+fn commit_count_segments(state: Option<&ActionHintState>, item: &WorkItem) -> Vec<DetailSegment> {
+    match state {
+        Some(ActionHintState::Loaded(hints)) => hints
+            .commits
+            .map(|commits| {
+                vec![DetailSegment::link(
+                    commits.to_string(),
+                    pull_request_commits_url(item),
+                )]
+            })
             .unwrap_or_else(|| vec![DetailSegment::raw("-")]),
         Some(ActionHintState::Loading) | None => vec![DetailSegment::raw("loading...")],
         Some(ActionHintState::Error(_)) => vec![DetailSegment::raw("unavailable")],
@@ -11406,6 +11444,17 @@ fn relative_time(value: Option<DateTime<Utc>>) -> String {
     }
 }
 
+fn local_datetime(value: Option<DateTime<Utc>>) -> String {
+    value
+        .map(|value| {
+            value
+                .with_timezone(&Local)
+                .format("%Y-%m-%d %H:%M %:z")
+                .to_string()
+        })
+        .unwrap_or_else(|| "-".to_string())
+}
+
 fn item_meta(item: &WorkItem) -> String {
     let mut parts = Vec::new();
     if item.unread.unwrap_or(false) {
@@ -11457,7 +11506,7 @@ mod tests {
 
     #[test]
     fn compact_error_label_hides_long_gh_command_context() {
-        let error = "gh search prs --json number,title,body,repository,author,updatedAt,url,state,isDraft,labels,commentsCount --limit 500 -- repo:rust-lang/rust is:open failed: HTTP 403: API rate limit exceeded for user ID 230646";
+        let error = "gh search prs --json number,title,body,repository,author,createdAt,updatedAt,url,state,isDraft,labels,commentsCount --limit 500 -- repo:rust-lang/rust is:open failed: HTTP 403: API rate limit exceeded for user ID 230646";
 
         assert_eq!(compact_error_label(error), "GitHub search rate limited");
         assert!(!compact_error_label(error).contains("--json"));
@@ -14326,6 +14375,10 @@ diff --git a/src/github.rs b/src/github.rs
     #[test]
     fn details_meta_is_compact_and_links_author() {
         let mut item = work_item("1", "chenyukang/ghr", 1, "More on tui", Some("chenyukang"));
+        let created_at = DateTime::parse_from_rfc3339("2026-05-04T01:02:03Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        item.created_at = Some(created_at);
         item.reason = Some("-".to_string());
         item.comments = Some(3);
         let section = SectionSnapshot {
@@ -14352,6 +14405,7 @@ diff --git a/src/github.rs b/src/github.rs
         assert!(rendered.contains("repo: chenyukang/ghr"));
         assert!(rendered.contains("number: #1"));
         assert!(rendered.contains("state: open"));
+        assert!(rendered.contains(&format!("created: {}", local_datetime(Some(created_at)))));
         assert!(rendered.contains("author: chenyukang"));
         assert!(rendered.contains("comments: 3"));
         assert!(rendered.contains("labels: T-compiler remove  add label"));
@@ -14461,11 +14515,13 @@ diff --git a/src/github.rs b/src/github.rs
                     total: 13,
                     incomplete: false,
                 }),
+                commits: Some(4),
                 note: Some("Merge blocked: checks pending".to_string()),
             }),
         );
 
-        let rendered = build_details_document(&app, 120)
+        let document = build_details_document(&app, 120);
+        let rendered = document
             .lines
             .iter()
             .map(|line| line.to_string())
@@ -14474,6 +14530,12 @@ diff --git a/src/github.rs b/src/github.rs
 
         assert!(rendered.contains("action: Approvable, Mergeable"));
         assert!(rendered.contains("checks: 10 pass, 2 fail, 1 pending"));
+        assert!(rendered.contains("commits: 4"));
+        assert_document_link_for_text(
+            &document,
+            "4",
+            "https://github.com/chenyukang/ghr/pull/1/commits",
+        );
         assert!(rendered.contains("action note: Merge blocked: checks pending"));
     }
 
@@ -18114,6 +18176,7 @@ diff --git a/d.rs b/d.rs
             author: author.map(str::to_string),
             state: Some("open".to_string()),
             url: format!("https://github.com/{repo}/pull/{number}"),
+            created_at: None,
             updated_at: None,
             labels: vec!["T-compiler".to_string()],
             comments: Some(0),
@@ -18134,6 +18197,7 @@ diff --git a/d.rs b/d.rs
             author: None,
             state: None,
             url: "https://github.com/rust-lang/rust/pull/1".to_string(),
+            created_at: None,
             updated_at: None,
             labels: Vec::new(),
             comments: None,

--- a/src/github.rs
+++ b/src/github.rs
@@ -79,6 +79,7 @@ struct SearchItemRaw {
     author: Option<SearchAuthorRaw>,
     body: Option<String>,
     comments_count: Option<u64>,
+    created_at: Option<DateTime<Utc>>,
     is_draft: Option<bool>,
     labels: Option<Vec<SearchLabelRaw>>,
     number: u64,
@@ -120,6 +121,7 @@ struct SearchPageRaw {
 struct SearchApiIssueRaw {
     body: Option<String>,
     comments: Option<u64>,
+    created_at: Option<DateTime<Utc>>,
     draft: Option<bool>,
     html_url: String,
     labels: Option<Vec<SearchLabelRaw>>,
@@ -225,6 +227,7 @@ struct PullRequestActionRepositoryRaw {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct PullRequestActionRaw {
+    commits: Option<PullRequestCommitConnectionRaw>,
     is_draft: Option<bool>,
     merge_state_status: Option<String>,
     review_decision: Option<String>,
@@ -236,6 +239,12 @@ struct PullRequestActionRaw {
     viewer_can_update_branch: Option<bool>,
     viewer_did_author: Option<bool>,
     viewer_latest_review: Option<PullRequestViewerReviewRaw>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PullRequestCommitConnectionRaw {
+    total_count: usize,
 }
 
 #[derive(Debug, Deserialize)]
@@ -785,10 +794,10 @@ fn is_plain_search_term(token: &str) -> bool {
 fn search_fields(kind: SectionKind) -> &'static str {
     match kind {
         SectionKind::PullRequests => {
-            "number,title,body,repository,author,updatedAt,url,state,isDraft,labels,commentsCount"
+            "number,title,body,repository,author,createdAt,updatedAt,url,state,isDraft,labels,commentsCount"
         }
         SectionKind::Issues => {
-            "number,title,body,repository,author,updatedAt,url,state,labels,commentsCount"
+            "number,title,body,repository,author,createdAt,updatedAt,url,state,labels,commentsCount"
         }
         SectionKind::Notifications => unreachable!("notifications are not fetched via search"),
     }
@@ -884,6 +893,9 @@ query($owner: String!, $name: String!, $number: Int!) {
       viewerCanEnableAutoMerge
       viewerCanMergeAsAdmin
       viewerDidAuthor
+      commits {
+        totalCount
+      }
       viewerLatestReview {
         state
       }
@@ -1594,6 +1606,7 @@ fn pull_request_action_hints(pr: &PullRequestActionRaw) -> ActionHints {
     ActionHints {
         labels,
         checks,
+        commits: pr.commits.as_ref().map(|commits| commits.total_count),
         note,
     }
 }
@@ -1760,6 +1773,7 @@ fn search_item_to_work_item(kind: SectionKind, item: SearchItemRaw) -> WorkItem 
         author: item.author.map(|author| author.login),
         state: item.state,
         url: item.url,
+        created_at: item.created_at,
         updated_at: item.updated_at,
         labels,
         comments: item.comments_count,
@@ -1796,6 +1810,7 @@ fn search_api_item_to_work_item(kind: SectionKind, item: SearchApiIssueRaw) -> W
         author: item.user.map(|author| author.login),
         state: item.state,
         url: item.html_url,
+        created_at: item.created_at,
         updated_at: item.updated_at,
         labels,
         comments: item.comments,
@@ -1861,6 +1876,7 @@ fn notification_to_work_item(notification: &NotificationRaw) -> WorkItem {
         author: None,
         state: None,
         url,
+        created_at: None,
         updated_at: notification.updated_at,
         labels: Vec::new(),
         comments: None,
@@ -2117,6 +2133,9 @@ mod tests {
         let item = SearchApiIssueRaw {
             body: Some("hello".to_string()),
             comments: Some(7),
+            created_at: DateTime::parse_from_rfc3339("2026-01-01T08:30:00Z")
+                .ok()
+                .map(|value| value.with_timezone(&Utc)),
             draft: Some(false),
             html_url: "https://github.com/rust-lang/rust/issues/1".to_string(),
             labels: Some(vec![SearchLabelRaw {
@@ -2138,6 +2157,7 @@ mod tests {
         assert_eq!(mapped.repo, "rust-lang/rust");
         assert_eq!(mapped.author.as_deref(), Some("chenyukang"));
         assert_eq!(mapped.comments, Some(7));
+        assert!(mapped.created_at.is_some());
         assert_eq!(mapped.labels, vec!["T-compiler"]);
     }
 
@@ -2184,6 +2204,7 @@ mod tests {
         assert_eq!(item.kind, ItemKind::PullRequest);
         assert_eq!(item.number, Some(42));
         assert_eq!(item.url, "https://github.com/owner/repo/pull/42");
+        assert!(item.created_at.is_none());
         assert_eq!(item.unread, Some(true));
         assert_eq!(item.reason.as_deref(), Some("review-requested"));
         assert_eq!(item.extra.as_deref(), Some("PullRequest"));
@@ -2225,6 +2246,8 @@ mod tests {
     fn search_fields_include_body_for_preview() {
         assert!(search_fields(SectionKind::PullRequests).contains("body"));
         assert!(search_fields(SectionKind::Issues).contains("body"));
+        assert!(search_fields(SectionKind::PullRequests).contains("createdAt"));
+        assert!(search_fields(SectionKind::Issues).contains("createdAt"));
     }
 
     #[test]
@@ -2409,6 +2432,7 @@ mod tests {
     #[test]
     fn action_hints_show_approvable_when_review_is_needed() {
         let hints = pull_request_action_hints(&PullRequestActionRaw {
+            commits: Some(PullRequestCommitConnectionRaw { total_count: 5 }),
             is_draft: Some(false),
             merge_state_status: Some("BLOCKED".to_string()),
             review_decision: Some("REVIEW_REQUIRED".to_string()),
@@ -2441,6 +2465,7 @@ mod tests {
         });
 
         assert_eq!(hints.labels, vec!["Approvable"]);
+        assert_eq!(hints.commits, Some(5));
         assert_eq!(
             hints.checks,
             Some(CheckSummary {
@@ -2460,6 +2485,7 @@ mod tests {
     #[test]
     fn action_hints_show_mergeable_when_pr_is_ready_and_viewer_can_merge() {
         let hints = pull_request_action_hints(&PullRequestActionRaw {
+            commits: Some(PullRequestCommitConnectionRaw { total_count: 2 }),
             is_draft: Some(false),
             merge_state_status: Some("CLEAN".to_string()),
             review_decision: Some("APPROVED".to_string()),
@@ -2485,6 +2511,7 @@ mod tests {
         });
 
         assert_eq!(hints.labels, vec!["Mergeable"]);
+        assert_eq!(hints.commits, Some(2));
         assert_eq!(
             hints.checks,
             Some(CheckSummary {

--- a/src/model.rs
+++ b/src/model.rs
@@ -38,6 +38,8 @@ pub struct WorkItem {
     pub author: Option<String>,
     pub state: Option<String>,
     pub url: String,
+    #[serde(default)]
+    pub created_at: Option<DateTime<Utc>>,
     pub updated_at: Option<DateTime<Utc>>,
     pub labels: Vec<String>,
     pub comments: Option<u64>,
@@ -86,6 +88,7 @@ pub struct ReviewCommentPreview {
 pub struct ActionHints {
     pub labels: Vec<String>,
     pub checks: Option<CheckSummary>,
+    pub commits: Option<usize>,
     pub note: Option<String>,
 }
 

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -258,6 +258,7 @@ mod tests {
             author: None,
             state: None,
             url: "https://github.com/rust-lang/rust/pull/1".to_string(),
+            created_at: None,
             updated_at: None,
             labels: Vec::new(),
             comments: None,


### PR DESCRIPTION
## Summary

- Show a clickable PR commit count in the PR details metadata.
- Link the count to the GitHub commits page for the selected pull request.
- Add created timestamps to PR and issue details using the local timezone.

## Why

PR details should expose commit history directly, and PR/issue details should show when the item was created without requiring a browser hop.

## Validation

- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `git diff --check`
- Verified `gh search prs/issues --json createdAt` returns created timestamps.
- Verified REST `search/issues` returns `created_at` for the fallback path.