### PR TITLE
[codex] Use created date as default sort

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,14 +149,14 @@ include_read_notifications = true
 
 [[pr_sections]]
 title = "My Pull Requests"
-filters = "is:open author:@me archived:false sort:updated-desc"
+filters = "is:open author:@me archived:false sort:created-desc"
 
 [[pr_sections]]
 title = "All Requests"
 queries = [
-  "author:@me archived:false sort:updated-desc",
-  "involves:@me -author:@me archived:false sort:updated-desc",
-  "reviewed-by:@me -author:@me archived:false sort:updated-desc",
+  "author:@me archived:false sort:created-desc",
+  "involves:@me -author:@me archived:false sort:created-desc",
+  "reviewed-by:@me -author:@me archived:false sort:created-desc",
 ]
 
 exclude_repos = ["some-org/archive-*"]

--- a/src/app.rs
+++ b/src/app.rs
@@ -14693,7 +14693,7 @@ diff --git a/src/github.rs b/src/github.rs
         section.page = 1;
         section.page_size = 100;
         section.filters =
-            "repo:rust-lang/rust is:open archived:false sort:updated-desc".to_string();
+            "repo:rust-lang/rust is:open archived:false sort:created-desc".to_string();
         let app = AppState::new(SectionKind::PullRequests, vec![section]);
         let request = app
             .section_page_request(1, &Config::default())
@@ -14704,7 +14704,7 @@ diff --git a/src/github.rs b/src/github.rs
         assert_eq!(request.total_pages, 3);
         assert_eq!(
             request.filters,
-            "repo:rust-lang/rust is:open archived:false sort:updated-desc"
+            "repo:rust-lang/rust is:open archived:false sort:created-desc"
         );
     }
 
@@ -14792,7 +14792,7 @@ diff --git a/src/github.rs b/src/github.rs
             key: "repo:Fiber:pull_requests:Pull Requests".to_string(),
             kind: SectionKind::PullRequests,
             title: "Pull Requests".to_string(),
-            filters: "repo:nervosnetwork/fiber is:open archived:false sort:updated-desc"
+            filters: "repo:nervosnetwork/fiber is:open archived:false sort:created-desc"
                 .to_string(),
             items: Vec::new(),
             total_count: None,
@@ -17397,13 +17397,13 @@ diff --git a/src/github.rs b/src/github.rs
                 "repo:fiber",
                 SectionKind::PullRequests,
                 "Pull Requests",
-                "repo:nervosnetwork/fiber is:open archived:false sort:updated-desc",
+                "repo:nervosnetwork/fiber is:open archived:false sort:created-desc",
             ),
             SectionSnapshot::empty_for_view(
                 "repo:fiber",
                 SectionKind::Issues,
                 "Issues",
-                "repo:nervosnetwork/fiber is:open archived:false sort:updated-desc",
+                "repo:nervosnetwork/fiber is:open archived:false sort:created-desc",
             ),
         ];
         let mut app = AppState::new(SectionKind::PullRequests, sections);

--- a/src/config.rs
+++ b/src/config.rs
@@ -212,13 +212,13 @@ impl Default for Config {
             pr_sections: vec![
                 SearchSection {
                     title: "My Pull Requests".to_string(),
-                    filters: "is:open author:@me archived:false sort:updated-desc".to_string(),
+                    filters: "is:open author:@me archived:false sort:created-desc".to_string(),
                     queries: Vec::new(),
                     limit: None,
                 },
                 SearchSection {
                     title: "Assigned to Me".to_string(),
-                    filters: "is:open assignee:@me archived:false sort:updated-desc".to_string(),
+                    filters: "is:open assignee:@me archived:false sort:created-desc".to_string(),
                     queries: Vec::new(),
                     limit: None,
                 },
@@ -226,9 +226,9 @@ impl Default for Config {
                     title: "All Requests".to_string(),
                     filters: String::new(),
                     queries: vec![
-                        "author:@me archived:false sort:updated-desc".to_string(),
-                        "involves:@me -author:@me archived:false sort:updated-desc".to_string(),
-                        "reviewed-by:@me -author:@me archived:false sort:updated-desc".to_string(),
+                        "author:@me archived:false sort:created-desc".to_string(),
+                        "involves:@me -author:@me archived:false sort:created-desc".to_string(),
+                        "reviewed-by:@me -author:@me archived:false sort:created-desc".to_string(),
                     ],
                     limit: None,
                 },
@@ -236,19 +236,19 @@ impl Default for Config {
             issue_sections: vec![
                 SearchSection {
                     title: "Assigned to Me".to_string(),
-                    filters: "is:open assignee:@me archived:false sort:updated-desc".to_string(),
+                    filters: "is:open assignee:@me archived:false sort:created-desc".to_string(),
                     queries: Vec::new(),
                     limit: None,
                 },
                 SearchSection {
                     title: "Mentioned".to_string(),
-                    filters: "is:open mentions:@me archived:false sort:updated-desc".to_string(),
+                    filters: "is:open mentions:@me archived:false sort:created-desc".to_string(),
                     queries: Vec::new(),
                     limit: None,
                 },
                 SearchSection {
                     title: "Involved".to_string(),
-                    filters: "is:open involves:@me archived:false sort:updated-desc".to_string(),
+                    filters: "is:open involves:@me archived:false sort:created-desc".to_string(),
                     queries: Vec::new(),
                     limit: None,
                 },
@@ -437,8 +437,8 @@ mod tests {
             title: "All Requests".to_string(),
             filters: String::new(),
             queries: vec![
-                "author:@me sort:updated-desc".to_string(),
-                "reviewed-by:@me sort:updated-desc".to_string(),
+                "author:@me sort:created-desc".to_string(),
+                "reviewed-by:@me sort:created-desc".to_string(),
             ],
             limit: None,
         };
@@ -446,13 +446,13 @@ mod tests {
         assert_eq!(
             section.search_filters(),
             vec![
-                "author:@me sort:updated-desc".to_string(),
-                "reviewed-by:@me sort:updated-desc".to_string()
+                "author:@me sort:created-desc".to_string(),
+                "reviewed-by:@me sort:created-desc".to_string()
             ]
         );
         assert_eq!(
             section.display_filters(),
-            "author:@me sort:updated-desc | reviewed-by:@me sort:updated-desc"
+            "author:@me sort:created-desc | reviewed-by:@me sort:created-desc"
         );
     }
 
@@ -478,11 +478,11 @@ mod tests {
 
             [[pr_sections]]
             title = "Assigned to Me"
-            filters = "is:open assignee:@me archived:false sort:updated-desc"
+            filters = "is:open assignee:@me archived:false sort:created-desc"
 
             [[issue_sections]]
             title = "Assigned to Me"
-            filters = "is:open assignee:@me archived:false sort:updated-desc"
+            filters = "is:open assignee:@me archived:false sort:created-desc"
 
             [[notification_sections]]
             title = "Unread"

--- a/src/github.rs
+++ b/src/github.rs
@@ -813,7 +813,7 @@ fn global_search_filters(query: &str, repo_scope: Option<&str>) -> String {
         tokens.push("archived:false".to_string());
     }
     if !tokens.iter().any(|token| token.starts_with("sort:")) {
-        tokens.push("sort:updated-desc".to_string());
+        tokens.push("sort:created-desc".to_string());
     }
     tokens.join(" ")
 }
@@ -2205,7 +2205,7 @@ mod tests {
         let args = search_args(
             "prs",
             "number,title",
-            "reviewed-by:chenyukang -author:chenyukang sort:updated-desc",
+            "reviewed-by:chenyukang -author:chenyukang sort:created-desc",
             50,
         );
 
@@ -2221,7 +2221,7 @@ mod tests {
                 "--",
                 "reviewed-by:chenyukang",
                 "-author:chenyukang",
-                "sort:updated-desc"
+                "sort:created-desc"
             ]
         );
     }
@@ -2254,7 +2254,7 @@ mod tests {
     fn search_page_args_use_rest_search_pagination_and_sort() {
         let args = search_page_args(
             SectionKind::Issues,
-            "repo:rust-lang/rust is:open archived:false sort:updated-desc",
+            "repo:rust-lang/rust is:open archived:false sort:created-desc",
             3,
             250,
         );
@@ -2273,7 +2273,7 @@ mod tests {
                 "-f",
                 "page=3",
                 "-f",
-                "sort=updated",
+                "sort=created",
                 "-f",
                 "order=desc"
             ]
@@ -2389,7 +2389,7 @@ mod tests {
     fn global_search_filters_add_default_sort_and_archive_filter() {
         assert_eq!(
             global_search_filters("fiber rpc", None),
-            "fiber rpc in:title archived:false sort:updated-desc"
+            "fiber rpc in:title archived:false sort:created-desc"
         );
         assert_eq!(
             global_search_filters("fiber archived:true sort:created-desc", None),
@@ -2397,11 +2397,11 @@ mod tests {
         );
         assert_eq!(
             global_search_filters("fiber in:body", None),
-            "fiber in:body archived:false sort:updated-desc"
+            "fiber in:body archived:false sort:created-desc"
         );
         assert_eq!(
             global_search_filters("author:chenyukang", None),
-            "author:chenyukang archived:false sort:updated-desc"
+            "author:chenyukang archived:false sort:created-desc"
         );
     }
 
@@ -2409,11 +2409,11 @@ mod tests {
     fn global_search_filters_scope_to_current_repo_when_available() {
         assert_eq!(
             global_search_filters("payment channel", Some("nervosnetwork/fiber")),
-            "payment channel in:title repo:nervosnetwork/fiber archived:false sort:updated-desc"
+            "payment channel in:title repo:nervosnetwork/fiber archived:false sort:created-desc"
         );
         assert_eq!(
             global_search_filters("rpc repo:rust-lang/rust", Some("nervosnetwork/fiber")),
-            "rpc repo:rust-lang/rust in:title archived:false sort:updated-desc"
+            "rpc repo:rust-lang/rust in:title archived:false sort:created-desc"
         );
     }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -321,7 +321,7 @@ pub fn configured_sections(config: &Config) -> Vec<SectionSnapshot> {
 }
 
 pub fn repo_section_filters(repo: &str) -> String {
-    format!("repo:{repo} is:open archived:false sort:updated-desc")
+    format!("repo:{repo} is:open archived:false sort:created-desc")
 }
 
 pub fn merge_cached_sections(
@@ -456,7 +456,7 @@ mod tests {
         assert!(repo_sections[0].key.starts_with("repo:fiber:"));
         assert_eq!(
             repo_sections[0].filters,
-            "repo:nervosnetwork/fiber is:open archived:false sort:updated-desc"
+            "repo:nervosnetwork/fiber is:open archived:false sort:created-desc"
         );
     }
 


### PR DESCRIPTION
## Summary

- Change the built-in PR and issue section defaults from `sort:updated-desc` to `sort:created-desc`.
- Update repo-tab default filters and global search fallback sorting to created date descending.
- Refresh README examples and tests to match the new default.

## Why

Newly created pull requests and issues should appear first by default instead of recently updated items bubbling to the top.

## Validation

- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `git diff --check`
- Confirmed there are no remaining `sort:updated-desc` defaults in `src` or `README.md`.