### PR TITLE
feat: toggle diff inline comments

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -3691,12 +3691,12 @@ fn handle_left_click(
         app.open_url(&url);
         return;
     }
-    if app.details_mode == DetailsMode::Diff {
-        if let Some(comment_indices) = document.inline_comment_marker_at(line_index) {
-            debug!(comment_indices = ?comment_indices, "inline comment marker clicked");
-            app.reveal_diff_inline_comments(comment_indices.to_vec());
-            return;
-        }
+    if app.details_mode == DetailsMode::Diff
+        && let Some(comment_indices) = document.inline_comment_marker_at(line_index)
+    {
+        debug!(comment_indices = ?comment_indices, "inline comment marker clicked");
+        app.reveal_diff_inline_comments(comment_indices.to_vec());
+        return;
     }
     if app.details_mode == DetailsMode::Diff
         && let Some(diff_line) = document.diff_line_at(line_index)

--- a/src/app.rs
+++ b/src/app.rs
@@ -1151,6 +1151,8 @@ struct AppState {
     diff_mark: HashMap<String, DiffMarkState>,
     last_diff_click: Option<DiffClickState>,
     diff_mode_state: HashMap<String, DiffModeState>,
+    diff_inline_comments_visible: bool,
+    revealed_diff_inline_comments: HashMap<String, HashSet<usize>>,
     conversation_details_state: HashMap<String, ConversationDetailsState>,
     viewed_details_snapshot: HashMap<String, String>,
     viewed_comments_snapshot: HashMap<String, String>,
@@ -3000,6 +3002,10 @@ fn handle_key_in_area_mut(
             app.leave_diff();
             return false;
         }
+        KeyCode::Char('i') if app.details_mode == DetailsMode::Diff => {
+            app.toggle_diff_inline_comments();
+            return false;
+        }
         KeyCode::Char('q') => return true,
         KeyCode::Char('?') => app.show_help_dialog(),
         KeyCode::Char('r') => trigger_refresh(app, config, store, tx),
@@ -3684,6 +3690,13 @@ fn handle_left_click(
         }
         app.open_url(&url);
         return;
+    }
+    if app.details_mode == DetailsMode::Diff {
+        if let Some(comment_indices) = document.inline_comment_marker_at(line_index) {
+            debug!(comment_indices = ?comment_indices, "inline comment marker clicked");
+            app.reveal_diff_inline_comments(comment_indices.to_vec());
+            return;
+        }
     }
     if app.details_mode == DetailsMode::Diff
         && let Some(diff_line) = document.diff_line_at(line_index)
@@ -5128,6 +5141,7 @@ fn footer_focus_primary_shortcuts(app: &AppState) -> Vec<Span<'static>> {
                 push_footer_pair(&mut spans, "enter", "diff", Color::Cyan);
                 push_footer_pair(&mut spans, "esc", "back", Color::Cyan);
                 push_footer_pair(&mut spans, "[ ]", "file", Color::Cyan);
+                push_footer_pair(&mut spans, "i", "comments", Color::Yellow);
                 push_footer_pair(&mut spans, "c", "inline", Color::LightBlue);
                 push_footer_pair(&mut spans, "a", "comment", Color::LightBlue);
             } else {
@@ -5150,6 +5164,7 @@ fn footer_focus_primary_shortcuts(app: &AppState) -> Vec<Span<'static>> {
                 push_footer_pair(&mut spans, "tab", "files", Color::Cyan);
                 push_footer_pair(&mut spans, "n/p", "comment", Color::LightBlue);
                 push_footer_pair(&mut spans, "h/l", "page", Color::Cyan);
+                push_footer_pair(&mut spans, "i", "comments", Color::Yellow);
                 push_footer_pair(&mut spans, "c", "inline", Color::LightBlue);
                 push_footer_pair(&mut spans, "a", "comment", Color::LightBlue);
             } else {
@@ -8619,6 +8634,7 @@ fn help_dialog_content(command_palette_key: &str) -> Vec<Line<'static>> {
         help_key_line("[ / ]", "previous / next changed file"),
         help_key_line("Enter or 4", "focus the file diff"),
         help_key_line("c", "add review comment on selected diff line"),
+        help_key_line("i", "toggle inline review comments in diff"),
         help_key_line("a", "add a normal PR comment"),
         help_key_line("s", "submit a PR review summary"),
         help_key_line("A", "approve via the PR review summary"),
@@ -9160,6 +9176,8 @@ impl AppState {
             diff_mark: HashMap::new(),
             last_diff_click: None,
             diff_mode_state: HashMap::new(),
+            diff_inline_comments_visible: true,
+            revealed_diff_inline_comments: HashMap::new(),
             conversation_details_state,
             viewed_details_snapshot: ui_state.viewed_details_snapshot.clone(),
             viewed_comments_snapshot: ui_state.viewed_comments_snapshot.clone(),
@@ -13289,6 +13307,30 @@ impl AppState {
         });
     }
 
+    fn toggle_diff_inline_comments(&mut self) {
+        self.diff_inline_comments_visible = !self.diff_inline_comments_visible;
+        if self.diff_inline_comments_visible {
+            self.revealed_diff_inline_comments.clear();
+            self.status = "diff comments shown".to_string();
+        } else {
+            self.status = "diff comments hidden; click markers to reveal threads".to_string();
+        }
+    }
+
+    fn reveal_diff_inline_comments(&mut self, comment_indices: Vec<usize>) {
+        let Some(item_id) = self.current_item().map(|item| item.id.clone()) else {
+            return;
+        };
+        if comment_indices.is_empty() {
+            return;
+        }
+        self.revealed_diff_inline_comments
+            .entry(item_id)
+            .or_default()
+            .extend(comment_indices);
+        self.status = "diff comment thread shown".to_string();
+    }
+
     fn show_diff(&mut self) {
         let Some(item) = self.current_item() else {
             self.status = "nothing to diff".to_string();
@@ -17300,6 +17342,142 @@ deleted file mode 100644
         assert_eq!(
             document.action_at(header_line, reply_column),
             Some(DetailAction::ReplyComment(0))
+        );
+    }
+
+    #[test]
+    fn diff_mode_can_hide_inline_review_comment_bodies_but_keeps_markers() {
+        let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
+        app.show_diff();
+        app.focus_details();
+        app.diffs.insert(
+            "1".to_string(),
+            DiffState::Loaded(
+                parse_pull_request_diff(
+                    r#"diff --git a/src/lib.rs b/src/lib.rs
+--- a/src/lib.rs
++++ b/src/lib.rs
+@@ -1 +1 @@
+-old
++new
+"#,
+                )
+                .expect("parse diff"),
+            ),
+        );
+        let mut inline = comment("alice", "Hidden until marker is opened.", None);
+        inline.id = Some(1);
+        inline.review = Some(crate::model::ReviewCommentPreview {
+            path: "src/lib.rs".to_string(),
+            line: Some(1),
+            original_line: None,
+            start_line: None,
+            original_start_line: None,
+            side: Some("RIGHT".to_string()),
+            start_side: None,
+            diff_hunk: None,
+            is_resolved: false,
+            is_outdated: false,
+        });
+        app.details
+            .insert("1".to_string(), DetailState::Loaded(vec![inline]));
+
+        app.toggle_diff_inline_comments();
+        let document = build_details_document(&app, 120);
+        let rendered = document
+            .lines
+            .iter()
+            .map(|line| line.to_string())
+            .collect::<Vec<_>>();
+
+        assert!(
+            rendered.iter().any(|line| line.contains("│ ● + new")),
+            "diff line should keep a clickable inline-comment marker when comments are hidden: {rendered:?}"
+        );
+        assert!(
+            document
+                .inline_comment_marker_at(
+                    rendered
+                        .iter()
+                        .position(|line| line.contains("│ ● + new"))
+                        .expect("marker line")
+                )
+                .is_some(),
+            "marker line should be discoverable for mouse clicks"
+        );
+        assert!(
+            !rendered
+                .iter()
+                .any(|line| line.contains("alice")
+                    || line.contains("Hidden until marker is opened.")),
+            "inline comment body/header should be hidden until marker click: {rendered:?}"
+        );
+    }
+
+    #[test]
+    fn clicking_hidden_diff_inline_comment_marker_reveals_that_thread() {
+        let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
+        app.show_diff();
+        app.focus_details();
+        app.diffs.insert(
+            "1".to_string(),
+            DiffState::Loaded(
+                parse_pull_request_diff(
+                    r#"diff --git a/src/lib.rs b/src/lib.rs
+--- a/src/lib.rs
++++ b/src/lib.rs
+@@ -1 +1 @@
+-old
++new
+"#,
+                )
+                .expect("parse diff"),
+            ),
+        );
+        let mut inline = comment("alice", "Revealed by marker click.", None);
+        inline.id = Some(1);
+        inline.review = Some(crate::model::ReviewCommentPreview {
+            path: "src/lib.rs".to_string(),
+            line: Some(1),
+            original_line: None,
+            start_line: None,
+            original_start_line: None,
+            side: Some("RIGHT".to_string()),
+            start_side: None,
+            diff_hunk: None,
+            is_resolved: false,
+            is_outdated: false,
+        });
+        app.details
+            .insert("1".to_string(), DetailState::Loaded(vec![inline]));
+
+        app.toggle_diff_inline_comments();
+        let marker_indices = build_details_document(&app, 120)
+            .inline_comment_marker_at(
+                build_details_document(&app, 120)
+                    .lines
+                    .iter()
+                    .position(|line| line.to_string().contains("│ ● + new"))
+                    .expect("marker line"),
+            )
+            .expect("marker indices")
+            .to_vec();
+        app.reveal_diff_inline_comments(marker_indices);
+        let rendered = build_details_document(&app, 120)
+            .lines
+            .iter()
+            .map(|line| line.to_string())
+            .collect::<Vec<_>>();
+
+        assert!(
+            rendered.iter().any(|line| line.contains("alice")),
+            "marker click should reveal the inline comment header: {rendered:?}"
+        );
+        assert!(
+            rendered
+                .iter()
+                .any(|line| line.contains("Revealed by marker click.")),
+            "marker click should reveal the inline comment body: {rendered:?}"
         );
     }
 

--- a/src/app/details.rs
+++ b/src/app/details.rs
@@ -15,6 +15,7 @@ pub(super) struct DetailsDocument {
     pub(super) comments: Vec<CommentRegion>,
     pub(super) diff_files: Vec<usize>,
     pub(super) diff_lines: Vec<DiffLineRegion>,
+    pub(super) inline_comment_markers: Vec<DiffInlineCommentMarkerRegion>,
     pub(super) selected_diff_line: Option<usize>,
 }
 
@@ -55,6 +56,13 @@ impl DetailsDocument {
             .iter()
             .find(|diff_line| diff_line.line == line)
             .map(|diff_line| diff_line.review_index)
+    }
+
+    pub(super) fn inline_comment_marker_at(&self, line: usize) -> Option<&[usize]> {
+        self.inline_comment_markers
+            .iter()
+            .find(|marker| marker.line == line)
+            .map(|marker| marker.comment_indices.as_slice())
     }
 }
 
@@ -128,6 +136,12 @@ pub(super) struct CommentRenderOptions {
 pub(super) struct DiffLineRegion {
     pub(super) line: usize,
     pub(super) review_index: usize,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct DiffInlineCommentMarkerRegion {
+    pub(super) line: usize,
+    pub(super) comment_indices: Vec<usize>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -217,6 +231,8 @@ pub(super) struct DiffRenderContext<'a> {
     item_id: &'a str,
     comments: Option<&'a [CommentPreview]>,
     expanded_comments: &'a HashSet<String>,
+    diff_inline_comments_visible: bool,
+    revealed_diff_inline_comments: Option<&'a HashSet<usize>>,
     details_focused: bool,
     selected_comment_index: usize,
     selected_file: usize,
@@ -396,6 +412,7 @@ impl DetailsBuilder {
                 comments: Vec::new(),
                 diff_files: Vec::new(),
                 diff_lines: Vec::new(),
+                inline_comment_markers: Vec::new(),
                 selected_diff_line: None,
             },
             width: usize::from(width.max(1)),
@@ -422,6 +439,19 @@ impl DetailsBuilder {
         if selected {
             self.document.selected_diff_line = Some(line);
         }
+    }
+
+    fn mark_inline_comment_marker(&mut self, comment_indices: Vec<usize>) {
+        if comment_indices.is_empty() {
+            return;
+        }
+        let line = self.document.lines.len();
+        self.document
+            .inline_comment_markers
+            .push(DiffInlineCommentMarkerRegion {
+                line,
+                comment_indices,
+            });
     }
 
     fn push_line(&mut self, segments: Vec<DetailSegment>) {
@@ -1350,6 +1380,8 @@ pub(super) fn build_diff_document(app: &AppState, width: u16) -> DetailsDocument
                     item_id: &item.id,
                     comments: inline_comments,
                     expanded_comments: &app.expanded_comments,
+                    diff_inline_comments_visible: app.diff_inline_comments_visible,
+                    revealed_diff_inline_comments: app.revealed_diff_inline_comments.get(&item.id),
                     details_focused: app.focus == FocusTarget::Details,
                     selected_comment_index: app.selected_comment_index,
                     selected_file,
@@ -1483,6 +1515,11 @@ pub(super) fn push_diff(
                 index
             });
             let inline_summary = diff_inline_comment_summary(context.comments, inline_entries);
+            if inline_summary.count > 0 {
+                builder.mark_inline_comment_marker(
+                    inline_entries.iter().map(|entry| entry.index).collect(),
+                );
+            }
             push_diff_line(
                 builder,
                 line,
@@ -1493,36 +1530,58 @@ pub(super) fn push_diff(
                 inline_summary,
             );
             if let Some(comments) = context.comments {
+                if context.diff_inline_comments_visible {
+                    push_diff_inline_comments(
+                        builder,
+                        context.item_id,
+                        comments,
+                        inline_entries,
+                        context.expanded_comments,
+                        context.details_focused,
+                        context.selected_comment_index,
+                    );
+                } else if let Some(revealed) = context.revealed_diff_inline_comments {
+                    let revealed_entries = inline_entries
+                        .iter()
+                        .filter(|entry| revealed.contains(&entry.index))
+                        .cloned()
+                        .collect::<Vec<_>>();
+                    push_diff_inline_comments(
+                        builder,
+                        context.item_id,
+                        comments,
+                        &revealed_entries,
+                        context.expanded_comments,
+                        context.details_focused,
+                        context.selected_comment_index,
+                    );
+                }
+            }
+        }
+    }
+    if context.diff_inline_comments_visible {
+        if let Some(comments) = context.comments {
+            let unplaced_entries = diff_unplaced_review_comment_entries(
+                comments,
+                file,
+                &rendered_inline_comment_indices,
+            );
+            if !unplaced_entries.is_empty() {
+                builder.push_blank();
+                builder.push_line(vec![DetailSegment::styled(
+                    "Resolved/outdated comments not attached to a current diff line",
+                    diff_metadata_style(),
+                )]);
                 push_diff_inline_comments(
                     builder,
                     context.item_id,
                     comments,
-                    inline_entries,
+                    &unplaced_entries,
                     context.expanded_comments,
                     context.details_focused,
                     context.selected_comment_index,
                 );
             }
-        }
-    }
-    if let Some(comments) = context.comments {
-        let unplaced_entries =
-            diff_unplaced_review_comment_entries(comments, file, &rendered_inline_comment_indices);
-        if !unplaced_entries.is_empty() {
-            builder.push_blank();
-            builder.push_line(vec![DetailSegment::styled(
-                "Resolved/outdated comments not attached to a current diff line",
-                diff_metadata_style(),
-            )]);
-            push_diff_inline_comments(
-                builder,
-                context.item_id,
-                comments,
-                &unplaced_entries,
-                context.expanded_comments,
-                context.details_focused,
-                context.selected_comment_index,
-            );
         }
     }
 }

--- a/src/app/details.rs
+++ b/src/app/details.rs
@@ -1559,29 +1559,26 @@ pub(super) fn push_diff(
             }
         }
     }
-    if context.diff_inline_comments_visible {
-        if let Some(comments) = context.comments {
-            let unplaced_entries = diff_unplaced_review_comment_entries(
+    if context.diff_inline_comments_visible
+        && let Some(comments) = context.comments
+    {
+        let unplaced_entries =
+            diff_unplaced_review_comment_entries(comments, file, &rendered_inline_comment_indices);
+        if !unplaced_entries.is_empty() {
+            builder.push_blank();
+            builder.push_line(vec![DetailSegment::styled(
+                "Resolved/outdated comments not attached to a current diff line",
+                diff_metadata_style(),
+            )]);
+            push_diff_inline_comments(
+                builder,
+                context.item_id,
                 comments,
-                file,
-                &rendered_inline_comment_indices,
+                &unplaced_entries,
+                context.expanded_comments,
+                context.details_focused,
+                context.selected_comment_index,
             );
-            if !unplaced_entries.is_empty() {
-                builder.push_blank();
-                builder.push_line(vec![DetailSegment::styled(
-                    "Resolved/outdated comments not attached to a current diff line",
-                    diff_metadata_style(),
-                )]);
-                push_diff_inline_comments(
-                    builder,
-                    context.item_id,
-                    comments,
-                    &unplaced_entries,
-                    context.expanded_comments,
-                    context.details_focused,
-                    context.selected_comment_index,
-                );
-            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- add an `i` shortcut in diff mode to show/hide inline review comments
- keep clickable inline comment markers visible while comment bodies are hidden
- allow clicking a marker to reveal that specific comment thread
- document the shortcut in the footer/help text

## Test Plan
- cargo test diff_mode_can_hide_inline_review_comment_bodies_but_keeps_markers -- --nocapture
- cargo test clicking_hidden_diff_inline_comment_marker_reveals_that_thread -- --nocapture
- cargo test
