### PR TITLE
[codex] Support image attachments in details

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 - Paged PR and issue lists with configurable page size.
 - Persistent ignored PRs and issues, stored in UI state and hidden from all lists.
 - Fuzzy filtering in every loaded list with `/`, quick PR/issue section filters with `f`, plus repo-scoped GitHub search with `S`.
-- Details pane with rendered Markdown, clickable links, fenced code blocks with lightweight Rust and plain/log highlighting, descriptions, comments, review comments, PR commit activity, labels, milestones, action hints, and check summaries.
+- Details pane with rendered Markdown, clickable links and image attachments, fenced code blocks with lightweight Rust and plain/log highlighting, descriptions, comments, review comments, PR commit activity, labels, milestones, action hints, and check summaries.
 - Inbox notifications lazily load linked PR or issue details when opened, so descriptions and recent PR commit activity appear without making the initial inbox fetch heavier.
 - PR diff mode with a changed-file list, per-file diff rendering, inline review comments, and review ranges.
 - Comment, reply, edit, milestone, merge, close/reopen, update-branch, rerun-failed-checks, local PR checkout, draft / ready-for-review, and full PR review submit flows from inside the TUI.

--- a/docs/index.html
+++ b/docs/index.html
@@ -89,8 +89,8 @@
           <h2>PRs, issues, notifications</h2>
           <p>
             Configurable sections, repo tabs, filters, result paging, ignored
-            items, read/done/mute notification commands, and lazy linked
-            PR/issue details with recent PR commit activity keep the list
+            items, read/done/mute notification commands, lazy linked PR/issue
+            details, and clickable Markdown image attachments keep the list
             signal clean.
           </p>
         </article>

--- a/src/app.rs
+++ b/src/app.rs
@@ -24859,6 +24859,101 @@ diff --git a/src/main.rs b/src/main.rs
     }
 
     #[test]
+    fn markdown_images_render_as_clickable_image_links() {
+        let url = "https://example.com/architecture.png";
+        let mut builder = DetailsBuilder::new(80);
+        builder.push_markdown_block_indented(
+            &format!("Screenshot:\n\n![Architecture *diagram*]({url})"),
+            "empty",
+            usize::MAX,
+            usize::MAX,
+            COMMENT_LEFT_PADDING,
+            COMMENT_RIGHT_PADDING,
+        );
+        let document = builder.finish();
+        let rendered = document
+            .lines
+            .iter()
+            .map(|line| line.to_string())
+            .collect::<Vec<_>>();
+
+        let line_index = rendered
+            .iter()
+            .position(|line| line.contains("[image: Architecture diagram]"))
+            .expect("rendered image label");
+        let column = rendered[line_index]
+            .find("[image: Architecture diagram]")
+            .expect("image label column") as u16;
+        assert_eq!(document.link_at(line_index, column), Some(url.to_string()));
+        assert!(
+            !rendered.iter().any(|line| line.contains("![")),
+            "raw markdown image syntax should not leak: {rendered:?}"
+        );
+    }
+
+    #[test]
+    fn github_html_image_tags_render_as_clickable_image_links() {
+        let url = "https://github.com/user-attachments/assets/c84fe1a4-44bc-4b62-bc58-ca0aa3c437fd";
+        let mut builder = DetailsBuilder::new(100);
+        builder.push_markdown_block_indented(
+            &format!(r#"<img width="1403" height="988" alt="Image" src="{url}" />"#),
+            "empty",
+            usize::MAX,
+            usize::MAX,
+            COMMENT_LEFT_PADDING,
+            COMMENT_RIGHT_PADDING,
+        );
+        let document = builder.finish();
+        let rendered = document
+            .lines
+            .iter()
+            .map(|line| line.to_string())
+            .collect::<Vec<_>>();
+
+        let line_index = rendered
+            .iter()
+            .position(|line| line.contains("[image 1403x988]"))
+            .expect("rendered GitHub attachment label");
+        let column = rendered[line_index]
+            .find("[image 1403x988]")
+            .expect("image label column") as u16;
+        assert_eq!(document.link_at(line_index, column), Some(url.to_string()));
+        assert!(
+            !rendered.iter().any(|line| line.contains("<img")),
+            "raw html image tag should not leak: {rendered:?}"
+        );
+    }
+
+    #[test]
+    fn html_image_attrs_decode_entities_for_label_and_url() {
+        let url = "https://example.com/shot.png?one=1&two=2";
+        let mut builder = DetailsBuilder::new(100);
+        builder.push_markdown_block_indented(
+            r#"<img alt="Packet &amp; claim" src="https://example.com/shot.png?one=1&amp;two=2">"#,
+            "empty",
+            usize::MAX,
+            usize::MAX,
+            0,
+            0,
+        );
+        let document = builder.finish();
+        let rendered = document
+            .lines
+            .iter()
+            .map(|line| line.to_string())
+            .collect::<Vec<_>>();
+
+        let line_index = rendered
+            .iter()
+            .position(|line| line.contains("[image: Packet & claim]"))
+            .expect("rendered decoded image label");
+        let column = rendered[line_index]
+            .find("[image: Packet & claim]")
+            .expect("image label column") as u16;
+        assert_eq!(document.link_at(line_index, column), Some(url.to_string()));
+    }
+
+    #[test]
     fn pr_and_issue_detail_comment_authors_are_clickable() {
         let mut pr_app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
         pr_app.details.insert(

--- a/src/app/details.rs
+++ b/src/app/details.rs
@@ -361,6 +361,15 @@ pub(super) struct MarkdownTableRow {
     pub(super) header: bool,
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(super) struct MarkdownImage {
+    pub(super) url: String,
+    pub(super) alt: Option<String>,
+    pub(super) title: Option<String>,
+    pub(super) width: Option<String>,
+    pub(super) height: Option<String>,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum CodeLanguage {
     Rust,
@@ -3405,6 +3414,7 @@ pub(super) fn markdown_blocks(text: &str) -> Vec<MarkdownBlock> {
     let mut blocks = Vec::new();
     let mut current = Vec::new();
     let mut link: Option<String> = None;
+    let mut image: Option<MarkdownImage> = None;
     let mut code_block = String::new();
     let mut in_code_block = false;
     let mut code_language = CodeLanguage::Other;
@@ -3520,6 +3530,22 @@ pub(super) fn markdown_blocks(text: &str) -> Vec<MarkdownBlock> {
             MarkdownEvent::End(TagEnd::Link) => {
                 link = None;
             }
+            MarkdownEvent::Start(Tag::Image {
+                dest_url, title, ..
+            }) => {
+                image = Some(MarkdownImage {
+                    url: dest_url.to_string(),
+                    alt: None,
+                    title: non_empty_inline_text(&title),
+                    width: None,
+                    height: None,
+                });
+            }
+            MarkdownEvent::End(TagEnd::Image) => {
+                if let Some(image) = image.take() {
+                    current.push(image_segment(&image));
+                }
+            }
             MarkdownEvent::Start(Tag::Strong) => {
                 strong_depth = strong_depth.saturating_add(1);
             }
@@ -3568,6 +3594,8 @@ pub(super) fn markdown_blocks(text: &str) -> Vec<MarkdownBlock> {
             MarkdownEvent::Text(text) => {
                 if in_code_block {
                     code_block.push_str(&text);
+                } else if let Some(image) = image.as_mut() {
+                    push_image_alt(image, &text);
                 } else {
                     append_text_segments(
                         &mut current,
@@ -3577,15 +3605,52 @@ pub(super) fn markdown_blocks(text: &str) -> Vec<MarkdownBlock> {
                     );
                 }
             }
-            MarkdownEvent::Code(text) => current.push(DetailSegment::styled(
-                text.to_string(),
-                Style::default().fg(Color::LightGreen),
-            )),
+            MarkdownEvent::Code(text) => {
+                if let Some(image) = image.as_mut() {
+                    push_image_alt(image, &text);
+                } else {
+                    current.push(DetailSegment::styled(
+                        text.to_string(),
+                        Style::default().fg(Color::LightGreen),
+                    ));
+                }
+            }
             MarkdownEvent::SoftBreak | MarkdownEvent::HardBreak => {
                 if in_code_block {
                     code_block.push('\n');
+                } else if let Some(image) = image.as_mut() {
+                    push_image_alt(image, " ");
                 } else {
                     current.push(DetailSegment::raw("\n"));
+                }
+            }
+            MarkdownEvent::InlineHtml(html) => {
+                if let Some(image) = image.as_mut() {
+                    push_image_alt(image, &html);
+                    continue;
+                }
+                current.extend(html_image_segments(&html));
+            }
+            MarkdownEvent::Html(html) => {
+                if in_code_block {
+                    code_block.push_str(&html);
+                    continue;
+                }
+
+                let segments = html_image_segments(&html);
+                if !segments.is_empty() {
+                    flush_markdown_block(
+                        &mut blocks,
+                        &mut current,
+                        quote_depth,
+                        MarkdownBlockKind::Text,
+                    );
+                    push_markdown_block(
+                        &mut blocks,
+                        quote_depth,
+                        MarkdownBlockKind::Text,
+                        segments,
+                    );
                 }
             }
             MarkdownEvent::Rule => push_markdown_block(
@@ -3610,6 +3675,208 @@ pub(super) fn markdown_blocks(text: &str) -> Vec<MarkdownBlock> {
         MarkdownBlockKind::Text,
     );
     blocks
+}
+
+pub(super) fn push_image_alt(image: &mut MarkdownImage, text: &str) {
+    if let Some(alt) = image.alt.as_mut() {
+        alt.push_str(text);
+    } else {
+        image.alt = Some(text.to_string());
+    }
+}
+
+pub(super) fn html_image_segments(html: &str) -> Vec<DetailSegment> {
+    let mut segments = Vec::new();
+    for image in html_images(html) {
+        if !segments.is_empty() {
+            segments.push(DetailSegment::raw(" "));
+        }
+        segments.push(image_segment(&image));
+    }
+    segments
+}
+
+pub(super) fn html_images(html: &str) -> Vec<MarkdownImage> {
+    let mut images = Vec::new();
+    let lower = html.to_ascii_lowercase();
+    let mut search_start = 0;
+    while let Some(relative_start) = lower[search_start..].find("<img") {
+        let tag_start = search_start + relative_start;
+        let after_name = tag_start + "<img".len();
+        if !html_tag_name_boundary(html, after_name) {
+            search_start = after_name;
+            continue;
+        }
+
+        let Some(tag_end) = html_tag_end(html, after_name) else {
+            break;
+        };
+        let tag = &html[tag_start..=tag_end];
+        if let Some(url) = html_attr_value(tag, "src") {
+            images.push(MarkdownImage {
+                url,
+                alt: html_attr_value(tag, "alt").and_then(|alt| non_empty_inline_text(&alt)),
+                title: html_attr_value(tag, "title")
+                    .and_then(|title| non_empty_inline_text(&title)),
+                width: html_attr_value(tag, "width")
+                    .and_then(|width| non_empty_inline_text(&width)),
+                height: html_attr_value(tag, "height")
+                    .and_then(|height| non_empty_inline_text(&height)),
+            });
+        }
+        search_start = tag_end + 1;
+    }
+    images
+}
+
+pub(super) fn html_tag_name_boundary(html: &str, index: usize) -> bool {
+    html[index..]
+        .chars()
+        .next()
+        .is_none_or(|ch| ch.is_ascii_whitespace() || matches!(ch, '/' | '>'))
+}
+
+pub(super) fn html_tag_end(html: &str, start: usize) -> Option<usize> {
+    let mut quote = None;
+    for (offset, ch) in html[start..].char_indices() {
+        match (quote, ch) {
+            (Some(active), current) if current == active => quote = None,
+            (None, '"' | '\'') => quote = Some(ch),
+            (None, '>') => return Some(start + offset),
+            _ => {}
+        }
+    }
+    None
+}
+
+pub(super) fn html_attr_value(tag: &str, name: &str) -> Option<String> {
+    let bytes = tag.as_bytes();
+    let mut index = 0;
+    while index < bytes.len() {
+        while bytes
+            .get(index)
+            .is_some_and(|byte| byte.is_ascii_whitespace() || matches!(byte, b'<' | b'/' | b'>'))
+        {
+            index += 1;
+        }
+
+        let name_start = index;
+        while bytes
+            .get(index)
+            .is_some_and(|byte| is_html_attr_name_byte(*byte))
+        {
+            index += 1;
+        }
+        if name_start == index {
+            index += 1;
+            continue;
+        }
+        let attr_name = &tag[name_start..index];
+        while bytes
+            .get(index)
+            .is_some_and(|byte| byte.is_ascii_whitespace())
+        {
+            index += 1;
+        }
+        if bytes.get(index) != Some(&b'=') {
+            continue;
+        }
+        index += 1;
+        while bytes
+            .get(index)
+            .is_some_and(|byte| byte.is_ascii_whitespace())
+        {
+            index += 1;
+        }
+
+        let Some(first) = bytes.get(index).copied() else {
+            break;
+        };
+        let value_start;
+        let value_end;
+        if matches!(first, b'"' | b'\'') {
+            let quote = first;
+            index += 1;
+            value_start = index;
+            while bytes.get(index).is_some_and(|byte| *byte != quote) {
+                index += 1;
+            }
+            value_end = index;
+            if bytes.get(index) == Some(&quote) {
+                index += 1;
+            }
+        } else {
+            value_start = index;
+            while bytes
+                .get(index)
+                .is_some_and(|byte| !byte.is_ascii_whitespace() && *byte != b'>')
+            {
+                index += 1;
+            }
+            value_end = index;
+        }
+
+        if attr_name.eq_ignore_ascii_case(name) {
+            return non_empty_inline_text(&decode_basic_html_entities(
+                &tag[value_start..value_end],
+            ));
+        }
+    }
+    None
+}
+
+pub(super) fn is_html_attr_name_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b':')
+}
+
+pub(super) fn image_segment(image: &MarkdownImage) -> DetailSegment {
+    DetailSegment::link(image_label(image), image.url.clone())
+}
+
+pub(super) fn image_label(image: &MarkdownImage) -> String {
+    if let Some(alt) = useful_image_label(image.alt.as_deref().or(image.title.as_deref())) {
+        return format!("[image: {}]", truncate_inline(&alt, 72));
+    }
+    match (
+        image.width.as_deref().and_then(non_empty_dimension),
+        image.height.as_deref().and_then(non_empty_dimension),
+    ) {
+        (Some(width), Some(height)) => format!("[image {width}x{height}]"),
+        (Some(width), None) => format!("[image width {width}]"),
+        (None, Some(height)) => format!("[image height {height}]"),
+        (None, None) => "[image]".to_string(),
+    }
+}
+
+pub(super) fn useful_image_label(value: Option<&str>) -> Option<String> {
+    let value = non_empty_inline_text(value?)?;
+    if value.is_empty() || value.eq_ignore_ascii_case("image") {
+        None
+    } else {
+        Some(value)
+    }
+}
+
+pub(super) fn non_empty_dimension(value: &str) -> Option<&str> {
+    let value = value.trim();
+    (!value.is_empty()).then_some(value)
+}
+
+pub(super) fn non_empty_inline_text(value: &str) -> Option<String> {
+    let text = value.split_whitespace().collect::<Vec<_>>().join(" ");
+    (!text.is_empty()).then_some(text)
+}
+
+pub(super) fn decode_basic_html_entities(value: &str) -> String {
+    value
+        .replace("&quot;", "\"")
+        .replace("&#34;", "\"")
+        .replace("&#x22;", "\"")
+        .replace("&#39;", "'")
+        .replace("&apos;", "'")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&amp;", "&")
 }
 
 pub(super) fn is_rust_code_info(info: &str) -> bool {


### PR DESCRIPTION
## Summary
- Render Markdown image syntax as clickable image attachment links in the details Markdown renderer.
- Render GitHub HTML `<img>` attachments, including `github.com/user-attachments/assets/...`, as clickable `[image]` labels with useful alt text or dimensions.
- Update README/docs and add regression coverage for Markdown images, GitHub HTML image tags, and HTML entity decoding.

## Root Cause
Issue descriptions from GitHub can contain uploaded screenshots as raw HTML `<img>` tags. The existing Markdown renderer preserved regular links and raw URLs, but ignored image tags and HTML image events, so attachment URLs never became clickable detail segments.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo test` (514 passed)
- `cargo clippy --all-targets -- -D warnings`