### PR TITLE
feat: add 13 popular terminal color themes

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2774,7 +2774,7 @@ pub async fn run(mut config: Config, paths: Paths, store: SnapshotStore) -> Resu
             RefreshScope::View(app.active_view.clone()),
         );
     }
-    app.apply_theme_preference(config.defaults.theme);
+    app.apply_theme_preference(&config);
 
     enable_raw_mode()?;
     let mut stdout = io::stdout();
@@ -12663,18 +12663,25 @@ impl AppState {
         self.global_search_saved_by_repo = saved_search_map_from_config(config);
     }
 
+    fn effective_theme(config: &Config) -> ThemeName {
+        config
+            .defaults
+            .theme_name
+            .unwrap_or_else(|| config.defaults.theme.effective())
+    }
+
     fn set_theme(&mut self, theme_name: ThemeName) {
         self.theme_name = theme_name;
         set_active_theme(theme_name);
     }
 
-    fn apply_theme_preference(&mut self, preference: ThemePreference) {
-        self.set_theme(preference.effective());
+    fn apply_theme_preference(&mut self, config: &Config) {
+        self.set_theme(Self::effective_theme(config));
         self.last_auto_theme_check = Instant::now();
     }
 
     fn refresh_auto_theme(&mut self, config: &Config, now: Instant) -> bool {
-        if !config.defaults.theme.is_auto() {
+        if !config.defaults.theme.is_auto() || config.defaults.theme_name.is_some() {
             return false;
         }
         if now.duration_since(self.last_auto_theme_check) < AUTO_THEME_CHECK_INTERVAL {
@@ -12692,31 +12699,54 @@ impl AppState {
 
     fn toggle_theme(&mut self, config: &mut Config, paths: &Paths) {
         let previous_app_theme = self.theme_name;
+        let previous_theme_name = config.defaults.theme_name;
         let previous_config_theme = config.defaults.theme;
-        let next_theme = self.theme_name.toggled();
-        let next_preference = match config.defaults.theme {
-            ThemePreference::Auto => ThemePreference::from_theme_name(next_theme),
-            ThemePreference::Dark => ThemePreference::Light,
-            ThemePreference::Light => ThemePreference::Auto,
-        };
-        let next_effective = next_preference.effective();
 
-        self.set_theme(next_effective);
-        self.last_auto_theme_check = Instant::now();
-        config.defaults.theme = next_preference;
+        if let Some(current_name) = config.defaults.theme_name {
+            let pos = ThemeName::ALL
+                .iter()
+                .position(|t| *t == current_name)
+                .unwrap_or(0);
+            let next_name = ThemeName::ALL[(pos + 1) % ThemeName::ALL.len()];
 
-        if let Err(error) = config.save(&paths.config_path) {
-            self.set_theme(previous_app_theme);
-            config.defaults.theme = previous_config_theme;
-            self.status = format!("theme toggle failed: {error}");
-            return;
-        }
+            self.set_theme(next_name);
+            self.last_auto_theme_check = Instant::now();
+            config.defaults.theme_name = Some(next_name);
 
-        self.status = if next_preference.is_auto() {
-            format!("theme: auto ({})", next_effective.as_str())
+            if let Err(error) = config.save(&paths.config_path) {
+                self.set_theme(previous_app_theme);
+                config.defaults.theme_name = previous_theme_name;
+                self.status = format!("theme toggle failed: {error}");
+                return;
+            }
+
+            self.status = format!("theme: {}", next_name.as_str());
         } else {
-            format!("theme: {}", next_preference.as_str())
-        };
+            let next_theme = self.theme_name.toggled();
+            let next_preference = match config.defaults.theme {
+                ThemePreference::Auto => ThemePreference::from_theme_name(next_theme),
+                ThemePreference::Dark => ThemePreference::Light,
+                ThemePreference::Light => ThemePreference::Auto,
+            };
+            let next_effective = next_preference.effective();
+
+            self.set_theme(next_effective);
+            self.last_auto_theme_check = Instant::now();
+            config.defaults.theme = next_preference;
+
+            if let Err(error) = config.save(&paths.config_path) {
+                self.set_theme(previous_app_theme);
+                config.defaults.theme = previous_config_theme;
+                self.status = format!("theme toggle failed: {error}");
+                return;
+            }
+
+            self.status = if next_preference.is_auto() {
+                format!("theme: auto ({})", next_effective.as_str())
+            } else {
+                format!("theme: {}", next_preference.as_str())
+            };
+        }
     }
 
     fn load_repo_candidate_cache(&mut self, cache: RepoCandidateCache) {
@@ -26569,6 +26599,25 @@ diff --git a/src/main.rs b/src/main.rs
 
         let saved = Config::load_or_create(&paths.config_path).expect("load saved config");
         assert_eq!(saved.defaults.theme, ThemePreference::Auto);
+    }
+
+    #[test]
+    fn theme_toggle_with_theme_name_cycles_through_all_themes() {
+        let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
+        app.set_theme(ThemeName::CatppuccinMocha);
+        let mut config = Config::default();
+        config.defaults.theme_name = Some(ThemeName::CatppuccinMocha);
+        let paths = unique_test_paths("toggle-theme-cycle");
+        config.save(&paths.config_path).expect("save config");
+
+        app.toggle_theme(&mut config, &paths);
+
+        assert_eq!(config.defaults.theme_name, Some(ThemeName::CatppuccinLatte));
+        assert_eq!(app.theme_name, ThemeName::CatppuccinLatte);
+        assert!(app.status.contains("catppuccin_latte"));
+
+        let saved = Config::load_or_create(&paths.config_path).expect("load saved config");
+        assert_eq!(saved.defaults.theme_name, Some(ThemeName::CatppuccinLatte));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::model::SectionKind;
 use crate::state::{GlobalSearchSavedState, GlobalSearchState};
-use crate::theme::ThemePreference;
+use crate::theme::{ThemeName, ThemePreference};
 
 pub const DEFAULT_COMMAND_PALETTE_KEY: &str = ":";
 pub const DEFAULT_LOG_LEVEL: &str = "info";
@@ -31,6 +31,8 @@ pub struct Defaults {
     pub view: SectionKind,
     pub command_palette_key: String,
     pub theme: ThemePreference,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub theme_name: Option<ThemeName>,
     pub log_level: String,
     pub pr_per_page: usize,
     pub issue_per_page: usize,
@@ -465,6 +467,7 @@ impl Default for Defaults {
             view: SectionKind::PullRequests,
             command_palette_key: DEFAULT_COMMAND_PALETTE_KEY.to_string(),
             theme: ThemePreference::Auto,
+            theme_name: None,
             log_level: DEFAULT_LOG_LEVEL.to_string(),
             pr_per_page: 50,
             issue_per_page: 50,
@@ -955,6 +958,25 @@ mod tests {
         .expect("auto theme should parse");
 
         assert_eq!(config.defaults.theme, ThemePreference::Auto);
+    }
+
+    #[test]
+    fn parses_theme_name() {
+        let config = toml::from_str::<Config>(
+            r#"
+            [defaults]
+            theme_name = "catppuccin_mocha"
+            "#,
+        )
+        .expect("theme_name should parse");
+
+        assert_eq!(config.defaults.theme_name, Some(ThemeName::CatppuccinMocha));
+    }
+
+    #[test]
+    fn theme_name_is_none_by_default() {
+        let config = Config::default();
+        assert_eq!(config.defaults.theme_name, None);
     }
 
     #[test]

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -15,6 +15,19 @@ pub enum ThemeName {
     #[default]
     Dark = 0,
     Light = 1,
+    CatppuccinMocha = 2,
+    CatppuccinLatte = 3,
+    Nord = 4,
+    GruvboxDark = 5,
+    GruvboxLight = 6,
+    TokyoNight = 7,
+    Dracula = 8,
+    SolarizedDark = 9,
+    SolarizedLight = 10,
+    OneDark = 11,
+    Monokai = 12,
+    GitHubDark = 13,
+    GitHubLight = 14,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -26,11 +39,69 @@ pub enum ThemePreference {
     Light,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ThemeFamily {
+    Dark,
+    Light,
+}
+
 impl ThemeName {
+    pub const ALL: &[ThemeName] = &[
+        ThemeName::Dark,
+        ThemeName::Light,
+        ThemeName::CatppuccinMocha,
+        ThemeName::CatppuccinLatte,
+        ThemeName::Nord,
+        ThemeName::GruvboxDark,
+        ThemeName::GruvboxLight,
+        ThemeName::TokyoNight,
+        ThemeName::Dracula,
+        ThemeName::SolarizedDark,
+        ThemeName::SolarizedLight,
+        ThemeName::OneDark,
+        ThemeName::Monokai,
+        ThemeName::GitHubDark,
+        ThemeName::GitHubLight,
+    ];
+
     fn from_u8(value: u8) -> Self {
         match value {
+            0 => Self::Dark,
             1 => Self::Light,
+            2 => Self::CatppuccinMocha,
+            3 => Self::CatppuccinLatte,
+            4 => Self::Nord,
+            5 => Self::GruvboxDark,
+            6 => Self::GruvboxLight,
+            7 => Self::TokyoNight,
+            8 => Self::Dracula,
+            9 => Self::SolarizedDark,
+            10 => Self::SolarizedLight,
+            11 => Self::OneDark,
+            12 => Self::Monokai,
+            13 => Self::GitHubDark,
+            14 => Self::GitHubLight,
             _ => Self::Dark,
+        }
+    }
+
+    pub fn family(self) -> ThemeFamily {
+        match self {
+            Self::Dark => ThemeFamily::Dark,
+            Self::Light => ThemeFamily::Light,
+            Self::CatppuccinMocha => ThemeFamily::Dark,
+            Self::CatppuccinLatte => ThemeFamily::Light,
+            Self::Nord => ThemeFamily::Dark,
+            Self::GruvboxDark => ThemeFamily::Dark,
+            Self::GruvboxLight => ThemeFamily::Light,
+            Self::TokyoNight => ThemeFamily::Dark,
+            Self::Dracula => ThemeFamily::Dark,
+            Self::SolarizedDark => ThemeFamily::Dark,
+            Self::SolarizedLight => ThemeFamily::Light,
+            Self::OneDark => ThemeFamily::Dark,
+            Self::Monokai => ThemeFamily::Dark,
+            Self::GitHubDark => ThemeFamily::Dark,
+            Self::GitHubLight => ThemeFamily::Light,
         }
     }
 
@@ -38,6 +109,19 @@ impl ThemeName {
         match self {
             Self::Dark => Self::Light,
             Self::Light => Self::Dark,
+            Self::CatppuccinMocha => Self::CatppuccinLatte,
+            Self::CatppuccinLatte => Self::CatppuccinMocha,
+            Self::Nord => Self::Light,
+            Self::GruvboxDark => Self::GruvboxLight,
+            Self::GruvboxLight => Self::GruvboxDark,
+            Self::TokyoNight => Self::Light,
+            Self::Dracula => Self::Light,
+            Self::SolarizedDark => Self::SolarizedLight,
+            Self::SolarizedLight => Self::SolarizedDark,
+            Self::OneDark => Self::Light,
+            Self::Monokai => Self::Light,
+            Self::GitHubDark => Self::GitHubLight,
+            Self::GitHubLight => Self::GitHubDark,
         }
     }
 
@@ -45,6 +129,19 @@ impl ThemeName {
         match self {
             Self::Dark => "dark",
             Self::Light => "light",
+            Self::CatppuccinMocha => "catppuccin_mocha",
+            Self::CatppuccinLatte => "catppuccin_latte",
+            Self::Nord => "nord",
+            Self::GruvboxDark => "gruvbox_dark",
+            Self::GruvboxLight => "gruvbox_light",
+            Self::TokyoNight => "tokyo_night",
+            Self::Dracula => "dracula",
+            Self::SolarizedDark => "solarized_dark",
+            Self::SolarizedLight => "solarized_light",
+            Self::OneDark => "one_dark",
+            Self::Monokai => "monokai",
+            Self::GitHubDark => "github_dark",
+            Self::GitHubLight => "github_light",
         }
     }
 }
@@ -63,9 +160,9 @@ impl ThemePreference {
     }
 
     pub fn from_theme_name(theme: ThemeName) -> Self {
-        match theme {
-            ThemeName::Dark => Self::Dark,
-            ThemeName::Light => Self::Light,
+        match theme.family() {
+            ThemeFamily::Dark => Self::Dark,
+            ThemeFamily::Light => Self::Light,
         }
     }
 
@@ -212,6 +309,393 @@ impl Theme {
                 reaction: Color::Rgb(161, 98, 7),
                 label: Color::Rgb(79, 70, 229),
                 search: Color::Rgb(194, 65, 12),
+            },
+            // https://catppuccin.com/palette — Mocha
+            ThemeName::CatppuccinMocha => Self {
+                background: Color::Rgb(30, 30, 46),
+                surface: Color::Rgb(24, 24, 37),
+                text: Color::Rgb(205, 214, 244),
+                muted: Color::Rgb(108, 112, 134),
+                subtle: Color::Rgb(166, 173, 200),
+                border: Color::Rgb(69, 71, 90),
+                focus: Color::Rgb(137, 180, 250),
+                focus_alt: Color::Rgb(250, 179, 135),
+                highlight_fg: Color::Rgb(30, 30, 46),
+                highlight_bg: Color::Rgb(137, 180, 250),
+                selected_fg: Color::Rgb(205, 214, 244),
+                selected_bg: Color::Rgb(69, 71, 90),
+                code_bg: Color::Rgb(17, 17, 27),
+                quote_bg: Color::Rgb(49, 50, 68),
+                link: Color::Rgb(137, 180, 250),
+                action: Color::Rgb(245, 194, 231),
+                success: Color::Rgb(166, 227, 161),
+                warning: Color::Rgb(249, 226, 175),
+                error: Color::Rgb(243, 139, 168),
+                info: Color::Rgb(137, 220, 235),
+                added: Color::Rgb(166, 227, 161),
+                removed: Color::Rgb(243, 139, 168),
+                code: Color::Rgb(166, 173, 200),
+                quote: Color::Rgb(186, 194, 222),
+                reaction: Color::Rgb(249, 226, 175),
+                label: Color::Rgb(137, 180, 250),
+                search: Color::Rgb(249, 226, 175),
+            },
+            // https://catppuccin.com/palette — Latte
+            ThemeName::CatppuccinLatte => Self {
+                background: Color::Rgb(239, 241, 245),
+                surface: Color::Rgb(230, 233, 239),
+                text: Color::Rgb(76, 79, 105),
+                muted: Color::Rgb(140, 143, 161),
+                subtle: Color::Rgb(156, 160, 176),
+                border: Color::Rgb(204, 208, 218),
+                focus: Color::Rgb(30, 102, 245),
+                focus_alt: Color::Rgb(254, 100, 11),
+                highlight_fg: Color::Rgb(239, 241, 245),
+                highlight_bg: Color::Rgb(30, 102, 245),
+                selected_fg: Color::Rgb(76, 79, 105),
+                selected_bg: Color::Rgb(204, 208, 218),
+                code_bg: Color::Rgb(230, 233, 239),
+                quote_bg: Color::Rgb(204, 208, 218),
+                link: Color::Rgb(30, 102, 245),
+                action: Color::Rgb(234, 118, 203),
+                success: Color::Rgb(64, 160, 43),
+                warning: Color::Rgb(223, 142, 29),
+                error: Color::Rgb(210, 15, 57),
+                info: Color::Rgb(4, 165, 229),
+                added: Color::Rgb(64, 160, 43),
+                removed: Color::Rgb(210, 15, 57),
+                code: Color::Rgb(124, 127, 147),
+                quote: Color::Rgb(92, 95, 119),
+                reaction: Color::Rgb(223, 142, 29),
+                label: Color::Rgb(30, 102, 245),
+                search: Color::Rgb(223, 142, 29),
+            },
+            // https://www.nordtheme.com/docs/colors-and-fonts
+            ThemeName::Nord => Self {
+                background: Color::Rgb(46, 52, 64),
+                surface: Color::Rgb(59, 66, 82),
+                text: Color::Rgb(216, 222, 233),
+                muted: Color::Rgb(97, 110, 136),
+                subtle: Color::Rgb(129, 161, 193),
+                border: Color::Rgb(76, 86, 106),
+                focus: Color::Rgb(136, 192, 208),
+                focus_alt: Color::Rgb(208, 135, 112),
+                highlight_fg: Color::Rgb(46, 52, 64),
+                highlight_bg: Color::Rgb(136, 192, 208),
+                selected_fg: Color::Rgb(216, 222, 233),
+                selected_bg: Color::Rgb(76, 86, 106),
+                code_bg: Color::Rgb(46, 52, 64),
+                quote_bg: Color::Rgb(59, 66, 82),
+                link: Color::Rgb(136, 192, 208),
+                action: Color::Rgb(180, 142, 173),
+                success: Color::Rgb(163, 190, 140),
+                warning: Color::Rgb(235, 203, 139),
+                error: Color::Rgb(191, 97, 106),
+                info: Color::Rgb(129, 161, 193),
+                added: Color::Rgb(163, 190, 140),
+                removed: Color::Rgb(191, 97, 106),
+                code: Color::Rgb(129, 161, 193),
+                quote: Color::Rgb(216, 222, 233),
+                reaction: Color::Rgb(235, 203, 139),
+                label: Color::Rgb(136, 192, 208),
+                search: Color::Rgb(235, 203, 139),
+            },
+            // https://github.com/morhetz/gruvbox
+            ThemeName::GruvboxDark => Self {
+                background: Color::Rgb(40, 40, 40),
+                surface: Color::Rgb(29, 32, 33),
+                text: Color::Rgb(235, 219, 178),
+                muted: Color::Rgb(146, 131, 116),
+                subtle: Color::Rgb(168, 153, 132),
+                border: Color::Rgb(80, 73, 69),
+                focus: Color::Rgb(131, 165, 152),
+                focus_alt: Color::Rgb(254, 128, 25),
+                highlight_fg: Color::Rgb(40, 40, 40),
+                highlight_bg: Color::Rgb(131, 165, 152),
+                selected_fg: Color::Rgb(235, 219, 178),
+                selected_bg: Color::Rgb(80, 73, 69),
+                code_bg: Color::Rgb(29, 32, 33),
+                quote_bg: Color::Rgb(60, 56, 54),
+                link: Color::Rgb(131, 165, 152),
+                action: Color::Rgb(211, 134, 155),
+                success: Color::Rgb(184, 187, 38),
+                warning: Color::Rgb(250, 189, 47),
+                error: Color::Rgb(251, 73, 52),
+                info: Color::Rgb(131, 165, 152),
+                added: Color::Rgb(184, 187, 38),
+                removed: Color::Rgb(251, 73, 52),
+                code: Color::Rgb(168, 153, 132),
+                quote: Color::Rgb(189, 174, 147),
+                reaction: Color::Rgb(250, 189, 47),
+                label: Color::Rgb(131, 165, 152),
+                search: Color::Rgb(250, 189, 47),
+            },
+            ThemeName::GruvboxLight => Self {
+                background: Color::Rgb(251, 241, 199),
+                surface: Color::Rgb(242, 229, 188),
+                text: Color::Rgb(60, 56, 54),
+                muted: Color::Rgb(146, 131, 116),
+                subtle: Color::Rgb(124, 111, 100),
+                border: Color::Rgb(213, 196, 161),
+                focus: Color::Rgb(7, 102, 120),
+                focus_alt: Color::Rgb(175, 58, 3),
+                highlight_fg: Color::Rgb(251, 241, 199),
+                highlight_bg: Color::Rgb(7, 102, 120),
+                selected_fg: Color::Rgb(60, 56, 54),
+                selected_bg: Color::Rgb(213, 196, 161),
+                code_bg: Color::Rgb(242, 229, 188),
+                quote_bg: Color::Rgb(235, 219, 178),
+                link: Color::Rgb(7, 102, 120),
+                action: Color::Rgb(143, 63, 113),
+                success: Color::Rgb(121, 116, 14),
+                warning: Color::Rgb(181, 118, 20),
+                error: Color::Rgb(157, 0, 6),
+                info: Color::Rgb(7, 102, 120),
+                added: Color::Rgb(121, 116, 14),
+                removed: Color::Rgb(157, 0, 6),
+                code: Color::Rgb(124, 111, 100),
+                quote: Color::Rgb(80, 73, 69),
+                reaction: Color::Rgb(181, 118, 20),
+                label: Color::Rgb(7, 102, 120),
+                search: Color::Rgb(181, 118, 20),
+            },
+            // https://github.com/folke/tokyonight.nvim
+            ThemeName::TokyoNight => Self {
+                background: Color::Rgb(26, 27, 38),
+                surface: Color::Rgb(22, 22, 30),
+                text: Color::Rgb(192, 202, 245),
+                muted: Color::Rgb(86, 95, 137),
+                subtle: Color::Rgb(154, 165, 206),
+                border: Color::Rgb(59, 66, 97),
+                focus: Color::Rgb(122, 162, 247),
+                focus_alt: Color::Rgb(255, 158, 100),
+                highlight_fg: Color::Rgb(26, 27, 38),
+                highlight_bg: Color::Rgb(122, 162, 247),
+                selected_fg: Color::Rgb(192, 202, 245),
+                selected_bg: Color::Rgb(59, 66, 97),
+                code_bg: Color::Rgb(22, 22, 30),
+                quote_bg: Color::Rgb(41, 46, 66),
+                link: Color::Rgb(122, 162, 247),
+                action: Color::Rgb(187, 154, 247),
+                success: Color::Rgb(158, 206, 106),
+                warning: Color::Rgb(224, 175, 104),
+                error: Color::Rgb(247, 118, 142),
+                info: Color::Rgb(125, 207, 255),
+                added: Color::Rgb(158, 206, 106),
+                removed: Color::Rgb(247, 118, 142),
+                code: Color::Rgb(154, 165, 206),
+                quote: Color::Rgb(172, 176, 208),
+                reaction: Color::Rgb(224, 175, 104),
+                label: Color::Rgb(122, 162, 247),
+                search: Color::Rgb(224, 175, 104),
+            },
+            // https://draculatheme.com
+            ThemeName::Dracula => Self {
+                background: Color::Rgb(40, 42, 54),
+                surface: Color::Rgb(33, 34, 44),
+                text: Color::Rgb(248, 248, 242),
+                muted: Color::Rgb(98, 114, 164),
+                subtle: Color::Rgb(189, 147, 249),
+                border: Color::Rgb(68, 71, 90),
+                focus: Color::Rgb(189, 147, 249),
+                focus_alt: Color::Rgb(255, 184, 108),
+                highlight_fg: Color::Rgb(40, 42, 54),
+                highlight_bg: Color::Rgb(189, 147, 249),
+                selected_fg: Color::Rgb(248, 248, 242),
+                selected_bg: Color::Rgb(68, 71, 90),
+                code_bg: Color::Rgb(33, 34, 44),
+                quote_bg: Color::Rgb(68, 71, 90),
+                link: Color::Rgb(139, 233, 253),
+                action: Color::Rgb(255, 121, 198),
+                success: Color::Rgb(80, 250, 123),
+                warning: Color::Rgb(241, 250, 140),
+                error: Color::Rgb(255, 85, 85),
+                info: Color::Rgb(139, 233, 253),
+                added: Color::Rgb(80, 250, 123),
+                removed: Color::Rgb(255, 85, 85),
+                code: Color::Rgb(139, 233, 253),
+                quote: Color::Rgb(241, 250, 140),
+                reaction: Color::Rgb(241, 250, 140),
+                label: Color::Rgb(139, 233, 253),
+                search: Color::Rgb(241, 250, 140),
+            },
+            // https://ethanschoonover.com/solarized
+            ThemeName::SolarizedDark => Self {
+                background: Color::Rgb(0, 43, 54),
+                surface: Color::Rgb(7, 54, 66),
+                text: Color::Rgb(147, 161, 161),
+                muted: Color::Rgb(88, 110, 117),
+                subtle: Color::Rgb(101, 123, 131),
+                border: Color::Rgb(88, 110, 117),
+                focus: Color::Rgb(38, 139, 210),
+                focus_alt: Color::Rgb(203, 75, 22),
+                highlight_fg: Color::Rgb(0, 43, 54),
+                highlight_bg: Color::Rgb(38, 139, 210),
+                selected_fg: Color::Rgb(147, 161, 161),
+                selected_bg: Color::Rgb(88, 110, 117),
+                code_bg: Color::Rgb(7, 54, 66),
+                quote_bg: Color::Rgb(0, 43, 54),
+                link: Color::Rgb(38, 139, 210),
+                action: Color::Rgb(211, 54, 130),
+                success: Color::Rgb(133, 153, 0),
+                warning: Color::Rgb(181, 137, 0),
+                error: Color::Rgb(220, 50, 47),
+                info: Color::Rgb(42, 161, 152),
+                added: Color::Rgb(133, 153, 0),
+                removed: Color::Rgb(220, 50, 47),
+                code: Color::Rgb(131, 148, 150),
+                quote: Color::Rgb(147, 161, 161),
+                reaction: Color::Rgb(181, 137, 0),
+                label: Color::Rgb(38, 139, 210),
+                search: Color::Rgb(181, 137, 0),
+            },
+            ThemeName::SolarizedLight => Self {
+                background: Color::Rgb(253, 246, 227),
+                surface: Color::Rgb(238, 232, 213),
+                text: Color::Rgb(88, 110, 117),
+                muted: Color::Rgb(147, 161, 161),
+                subtle: Color::Rgb(131, 148, 150),
+                border: Color::Rgb(147, 161, 161),
+                focus: Color::Rgb(38, 139, 210),
+                focus_alt: Color::Rgb(203, 75, 22),
+                highlight_fg: Color::Rgb(253, 246, 227),
+                highlight_bg: Color::Rgb(38, 139, 210),
+                selected_fg: Color::Rgb(88, 110, 117),
+                selected_bg: Color::Rgb(147, 161, 161),
+                code_bg: Color::Rgb(238, 232, 213),
+                quote_bg: Color::Rgb(253, 246, 227),
+                link: Color::Rgb(38, 139, 210),
+                action: Color::Rgb(211, 54, 130),
+                success: Color::Rgb(133, 153, 0),
+                warning: Color::Rgb(181, 137, 0),
+                error: Color::Rgb(220, 50, 47),
+                info: Color::Rgb(42, 161, 152),
+                added: Color::Rgb(133, 153, 0),
+                removed: Color::Rgb(220, 50, 47),
+                code: Color::Rgb(131, 148, 150),
+                quote: Color::Rgb(101, 123, 131),
+                reaction: Color::Rgb(181, 137, 0),
+                label: Color::Rgb(38, 139, 210),
+                search: Color::Rgb(181, 137, 0),
+            },
+            // https://github.com/atom/atom/tree/master/packages/one-dark-ui
+            ThemeName::OneDark => Self {
+                background: Color::Rgb(40, 44, 52),
+                surface: Color::Rgb(33, 37, 43),
+                text: Color::Rgb(171, 178, 191),
+                muted: Color::Rgb(92, 99, 112),
+                subtle: Color::Rgb(130, 137, 151),
+                border: Color::Rgb(62, 68, 81),
+                focus: Color::Rgb(97, 175, 239),
+                focus_alt: Color::Rgb(209, 154, 102),
+                highlight_fg: Color::Rgb(40, 44, 52),
+                highlight_bg: Color::Rgb(97, 175, 239),
+                selected_fg: Color::Rgb(171, 178, 191),
+                selected_bg: Color::Rgb(62, 68, 81),
+                code_bg: Color::Rgb(33, 37, 43),
+                quote_bg: Color::Rgb(44, 49, 60),
+                link: Color::Rgb(97, 175, 239),
+                action: Color::Rgb(198, 120, 221),
+                success: Color::Rgb(152, 195, 121),
+                warning: Color::Rgb(229, 192, 123),
+                error: Color::Rgb(224, 108, 117),
+                info: Color::Rgb(86, 182, 194),
+                added: Color::Rgb(152, 195, 121),
+                removed: Color::Rgb(224, 108, 117),
+                code: Color::Rgb(130, 137, 151),
+                quote: Color::Rgb(171, 178, 191),
+                reaction: Color::Rgb(229, 192, 123),
+                label: Color::Rgb(97, 175, 239),
+                search: Color::Rgb(229, 192, 123),
+            },
+            // https://monokai.pro
+            ThemeName::Monokai => Self {
+                background: Color::Rgb(39, 40, 34),
+                surface: Color::Rgb(30, 31, 28),
+                text: Color::Rgb(248, 248, 242),
+                muted: Color::Rgb(117, 113, 94),
+                subtle: Color::Rgb(166, 166, 166),
+                border: Color::Rgb(73, 72, 62),
+                focus: Color::Rgb(166, 226, 46),
+                focus_alt: Color::Rgb(253, 151, 31),
+                highlight_fg: Color::Rgb(39, 40, 34),
+                highlight_bg: Color::Rgb(166, 226, 46),
+                selected_fg: Color::Rgb(248, 248, 242),
+                selected_bg: Color::Rgb(73, 72, 62),
+                code_bg: Color::Rgb(30, 31, 28),
+                quote_bg: Color::Rgb(62, 61, 50),
+                link: Color::Rgb(102, 217, 239),
+                action: Color::Rgb(249, 38, 114),
+                success: Color::Rgb(166, 226, 46),
+                warning: Color::Rgb(230, 219, 116),
+                error: Color::Rgb(249, 38, 114),
+                info: Color::Rgb(102, 217, 239),
+                added: Color::Rgb(166, 226, 46),
+                removed: Color::Rgb(249, 38, 114),
+                code: Color::Rgb(166, 166, 166),
+                quote: Color::Rgb(230, 219, 116),
+                reaction: Color::Rgb(230, 219, 116),
+                label: Color::Rgb(102, 217, 239),
+                search: Color::Rgb(230, 219, 116),
+            },
+            // https://primer.style — GitHub dark
+            ThemeName::GitHubDark => Self {
+                background: Color::Rgb(13, 17, 23),
+                surface: Color::Rgb(22, 27, 34),
+                text: Color::Rgb(201, 209, 217),
+                muted: Color::Rgb(139, 148, 158),
+                subtle: Color::Rgb(110, 118, 129),
+                border: Color::Rgb(48, 54, 61),
+                focus: Color::Rgb(88, 166, 255),
+                focus_alt: Color::Rgb(240, 136, 62),
+                highlight_fg: Color::Rgb(13, 17, 23),
+                highlight_bg: Color::Rgb(88, 166, 255),
+                selected_fg: Color::Rgb(201, 209, 217),
+                selected_bg: Color::Rgb(48, 54, 61),
+                code_bg: Color::Rgb(22, 27, 34),
+                quote_bg: Color::Rgb(33, 38, 45),
+                link: Color::Rgb(88, 166, 255),
+                action: Color::Rgb(247, 120, 186),
+                success: Color::Rgb(63, 185, 80),
+                warning: Color::Rgb(210, 153, 34),
+                error: Color::Rgb(248, 81, 73),
+                info: Color::Rgb(88, 166, 255),
+                added: Color::Rgb(63, 185, 80),
+                removed: Color::Rgb(248, 81, 73),
+                code: Color::Rgb(139, 148, 158),
+                quote: Color::Rgb(201, 209, 217),
+                reaction: Color::Rgb(210, 153, 34),
+                label: Color::Rgb(88, 166, 255),
+                search: Color::Rgb(210, 153, 34),
+            },
+            ThemeName::GitHubLight => Self {
+                background: Color::Rgb(255, 255, 255),
+                surface: Color::Rgb(246, 248, 250),
+                text: Color::Rgb(36, 41, 47),
+                muted: Color::Rgb(101, 109, 118),
+                subtle: Color::Rgb(87, 96, 106),
+                border: Color::Rgb(208, 215, 222),
+                focus: Color::Rgb(9, 105, 218),
+                focus_alt: Color::Rgb(207, 34, 46),
+                highlight_fg: Color::Rgb(255, 255, 255),
+                highlight_bg: Color::Rgb(9, 105, 218),
+                selected_fg: Color::Rgb(36, 41, 47),
+                selected_bg: Color::Rgb(208, 215, 222),
+                code_bg: Color::Rgb(246, 248, 250),
+                quote_bg: Color::Rgb(246, 248, 250),
+                link: Color::Rgb(9, 105, 218),
+                action: Color::Rgb(207, 34, 46),
+                success: Color::Rgb(26, 127, 55),
+                warning: Color::Rgb(154, 103, 0),
+                error: Color::Rgb(207, 34, 46),
+                info: Color::Rgb(9, 105, 218),
+                added: Color::Rgb(26, 127, 55),
+                removed: Color::Rgb(207, 34, 46),
+                code: Color::Rgb(101, 109, 118),
+                quote: Color::Rgb(87, 96, 106),
+                reaction: Color::Rgb(154, 103, 0),
+                label: Color::Rgb(9, 105, 218),
+                search: Color::Rgb(154, 103, 0),
             },
         }
     }
@@ -361,5 +845,78 @@ mod tests {
         assert_ne!(theme.subtle, theme.background);
         assert_ne!(theme.code_bg, theme.background);
         assert_ne!(theme.quote_bg, theme.background);
+    }
+
+    #[test]
+    fn all_themes_use_explicit_colors() {
+        for &name in ThemeName::ALL {
+            let theme = Theme::from_name(name);
+            assert_ne!(
+                theme.background,
+                Color::Reset,
+                "{name:?} should define background"
+            );
+            assert_ne!(theme.surface, Color::Reset, "{name:?} should define surface");
+            assert_ne!(theme.text, Color::Reset, "{name:?} should define text");
+            assert_ne!(theme.border, theme.background, "{name:?} border must differ from background");
+        }
+    }
+
+    #[test]
+    fn theme_family_is_consistent() {
+        for &name in ThemeName::ALL {
+            let theme = Theme::from_name(name);
+            assert!(
+                !name.as_str().is_empty(),
+                "{name:?} should have a non-empty as_str"
+            );
+            // Dark themes should have darker backgrounds than text
+            if name.family() == ThemeFamily::Dark {
+                let bg = match theme.background {
+                    Color::Rgb(r, g, b) => (r as u32 + g as u32 + b as u32) / 3,
+                    _ => 0,
+                };
+                let fg = match theme.text {
+                    Color::Rgb(r, g, b) => (r as u32 + g as u32 + b as u32) / 3,
+                    _ => 255,
+                };
+                assert!(
+                    bg < fg,
+                    "{name:?} dark theme: background brightness ({bg}) should be less than text brightness ({fg})"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn all_theme_names_have_unique_discriminants() {
+        let mut seen = std::collections::HashSet::new();
+        for &name in ThemeName::ALL {
+            assert!(
+                seen.insert(name as u8),
+                "duplicate discriminant: {name:?} = {}",
+                name as u8
+            );
+        }
+    }
+
+    #[test]
+    fn from_u8_round_trips_all_variants() {
+        for &name in ThemeName::ALL {
+            assert_eq!(ThemeName::from_u8(name as u8), name);
+        }
+    }
+
+    #[test]
+    fn toggle_flips_family() {
+        for &name in ThemeName::ALL {
+            let toggled = name.toggled();
+            assert_ne!(name, toggled, "{name:?} toggle must change theme");
+            assert_ne!(
+                name.family(),
+                toggled.family(),
+                "{name:?} toggle must flip family"
+            );
+        }
     }
 }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -26,7 +26,9 @@ pub enum ThemeName {
     SolarizedLight = 10,
     OneDark = 11,
     Monokai = 12,
+    #[serde(rename = "github_dark", alias = "git_hub_dark")]
     GitHubDark = 13,
+    #[serde(rename = "github_light", alias = "git_hub_light")]
     GitHubLight = 14,
 }
 
@@ -778,6 +780,7 @@ pub fn active_theme() -> Theme {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use toml;
 
     #[test]
     fn auto_theme_uses_detected_system_theme() {
@@ -904,6 +907,28 @@ mod tests {
     fn from_u8_round_trips_all_variants() {
         for &name in ThemeName::ALL {
             assert_eq!(ThemeName::from_u8(name as u8), name);
+        }
+    }
+
+    #[test]
+    fn github_theme_variants_serialize_as_github_not_git_hub() {
+        #[derive(serde::Serialize, serde::Deserialize)]
+        struct Wrapper {
+            theme: ThemeName,
+        }
+        for (name, expected) in [
+            (ThemeName::GitHubDark, "github_dark"),
+            (ThemeName::GitHubLight, "github_light"),
+        ] {
+            let wrapper = Wrapper { theme: name };
+            let encoded = toml::to_string_pretty(&wrapper).unwrap();
+            assert!(
+                encoded.contains(&format!("theme = \"{expected}\"")),
+                "expected theme = \"{expected}\" in:\n{encoded}"
+            );
+            let decoded: Wrapper =
+                toml::from_str(&format!("theme = \"{expected}\"")).unwrap();
+            assert_eq!(decoded.theme, name);
         }
     }
 


### PR DESCRIPTION
## Summary
- Expands theme system from 2 themes (Dark/Light) to 15 themes
- Adds 13 popular terminal color schemes: Catppuccin Mocha/Latte, Nord, Gruvbox Dark/Light, Tokyo Night, Dracula, Solarized Dark/Light, One Dark, Monokai, GitHub Dark/Light
- Adds optional `theme_name` config key for selecting a specific theme
- When `theme_name` is set, the command palette toggle cycles through all 15 themes
- When `theme_name` is unset, the existing Auto/Dark/Light preference cycle is preserved (full backward compatibility)

## Test plan
- [x] 619/619 tests pass
- [x] Zero clippy warnings
- [x] Config parsing tests for `theme_name` field
- [x] Theme cycling test with `theme_name` set
- [x] Existing toggle behavior preserved when `theme_name` is None
- [x] All 15 themes have explicit color definitions
- [x] Dark/light family consistency validated