### PR TITLE
Fix quote replies and activity timeline rendering

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -64,12 +64,12 @@ use crate::github::{
     with_background_github_priority,
 };
 use crate::model::{
-    ActionHints, CheckSummary, CommentPreview, EditorDraft, FailedCheckRunSummary, ItemKind,
-    Milestone, PullRequestBranch, PullRequestReviewActor, ReactionSummary, SectionKind,
-    SectionSnapshot, WorkItem, builtin_view_key, configured_sections, global_search_view_key,
-    mark_all_notifications_read_in_section, mark_notification_done_in_section,
-    mark_notification_read_in_section, merge_cached_sections, merge_refreshed_sections,
-    repo_view_key, section_view_key,
+    ActionHints, CheckSummary, CommentPreview, CommentPreviewKind, EditorDraft,
+    FailedCheckRunSummary, ItemKind, Milestone, PullRequestBranch, PullRequestReviewActor,
+    ReactionSummary, SectionKind, SectionSnapshot, WorkItem, builtin_view_key, configured_sections,
+    global_search_view_key, mark_all_notifications_read_in_section,
+    mark_notification_done_in_section, mark_notification_read_in_section, merge_cached_sections,
+    merge_refreshed_sections, repo_view_key, section_view_key,
 };
 use crate::snapshot::{RepoCandidateCache, SnapshotStore};
 use crate::state::{
@@ -11585,7 +11585,8 @@ impl AppState {
         if self.comment_selection_cleared() {
             return None;
         }
-        self.current_comments()?.get(self.selected_comment_index)
+        let comment = self.current_comments()?.get(self.selected_comment_index)?;
+        (comment.kind != CommentPreviewKind::Activity).then_some(comment)
     }
 
     fn comment_collapse_state(
@@ -11775,11 +11776,18 @@ impl AppState {
         if self.comment_selection_cleared() {
             return;
         }
-        let len = self.current_comments().map(Vec::len).unwrap_or(0);
-        if len == 0 {
-            self.selected_comment_index = 0;
-        } else {
-            self.selected_comment_index = self.selected_comment_index.min(len - 1);
+        let Some(comments) = self.current_comments() else {
+            self.clear_selected_comment();
+            return;
+        };
+        let order = comment_display_entries(comments)
+            .into_iter()
+            .map(|entry| entry.index)
+            .collect::<Vec<_>>();
+        if order.is_empty() {
+            self.clear_selected_comment();
+        } else if !order.contains(&self.selected_comment_index) {
+            self.selected_comment_index = order[0];
         }
     }
 
@@ -11946,6 +11954,13 @@ fn comment_search_matches(comments: &[CommentPreview], query: &str) -> Vec<usize
 }
 
 fn comment_display_entries(comments: &[CommentPreview]) -> Vec<CommentDisplayEntry> {
+    conversation_display_entries(comments)
+        .into_iter()
+        .filter(|entry| comments[entry.index].kind != CommentPreviewKind::Activity)
+        .collect()
+}
+
+fn conversation_display_entries(comments: &[CommentPreview]) -> Vec<CommentDisplayEntry> {
     let mut id_to_index = HashMap::new();
     for (index, comment) in comments.iter().enumerate() {
         if let Some(id) = comment.id {
@@ -11981,6 +11996,16 @@ fn comment_display_entries(comments: &[CommentPreview]) -> Vec<CommentDisplayEnt
         }
     }
     entries
+}
+
+fn activity_display_indices(comments: &[CommentPreview]) -> Vec<usize> {
+    comments
+        .iter()
+        .enumerate()
+        .filter_map(|(index, comment)| {
+            (comment.kind == CommentPreviewKind::Activity).then_some(index)
+        })
+        .collect()
 }
 
 fn push_comment_display_entry(

--- a/src/app.rs
+++ b/src/app.rs
@@ -7676,6 +7676,10 @@ impl AppState {
         tx: Option<&UnboundedSender<AppMsg>>,
     ) {
         match action {
+            DetailAction::ReplyItemDescription => {
+                self.select_details_body_without_scroll();
+                self.start_reply_to_item_description();
+            }
             DetailAction::ReplyComment(index) => {
                 self.select_comment(index);
                 self.start_reply_to_selected_comment();
@@ -9339,6 +9343,10 @@ impl AppState {
             return;
         };
         let Some(comment) = self.current_selected_comment().cloned() else {
+            if self.comment_selection_cleared() {
+                self.start_reply_to_item_description_with_item(item);
+                return;
+            }
             self.status = "no comment selected".to_string();
             return;
         };
@@ -9376,6 +9384,56 @@ impl AppState {
             format!("loaded reply draft for @{author}")
         } else {
             format!("replying to @{author}")
+        };
+    }
+
+    fn start_reply_to_item_description(&mut self) {
+        if !self.current_item_supports_comments() {
+            self.status = "selected item cannot be commented on".to_string();
+            return;
+        }
+        let Some(item) = self.current_item().cloned() else {
+            self.status = "nothing selected".to_string();
+            return;
+        };
+        self.start_reply_to_item_description_with_item(item);
+    }
+
+    fn start_reply_to_item_description_with_item(&mut self, item: WorkItem) {
+        if !item_description_can_reply(&item) {
+            self.status = "description cannot be replied to".to_string();
+            return;
+        }
+        self.finish_details_visit(Instant::now());
+        self.focus = FocusTarget::Details;
+        self.clear_selected_comment();
+        self.search_active = false;
+        self.comment_search_active = false;
+        self.global_search_active = false;
+        self.filter_input_active = false;
+        self.pr_action_dialog = None;
+        self.label_dialog = None;
+        self.issue_dialog = None;
+        self.reaction_dialog = None;
+        self.review_submit_dialog = None;
+        self.item_edit_dialog = None;
+        self.assignee_dialog = None;
+        let body = quote_item_description_for_reply(&item);
+        let loaded = self.open_comment_dialog_with_draft(
+            CommentDialogMode::New,
+            body,
+            reply_item_description_draft_key(&item),
+        );
+        self.scroll_comment_dialog_to_cursor();
+        let label = match item.kind {
+            ItemKind::PullRequest => "pull request description",
+            ItemKind::Issue => "issue description",
+            ItemKind::Notification => "description",
+        };
+        self.status = if loaded {
+            format!("loaded reply draft for {label}")
+        } else {
+            format!("replying to {label}")
         };
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -7763,7 +7763,7 @@ impl AppState {
             self.status = "no comment selected".to_string();
             return;
         };
-        if comment.kind.is_activity() {
+        if !comment.can_react() {
             self.status = "activity cannot be reacted to".to_string();
             return;
         }
@@ -9342,7 +9342,7 @@ impl AppState {
             self.status = "no comment selected".to_string();
             return;
         };
-        if comment.kind.is_activity() {
+        if !comment.can_reply() {
             self.status = "activity cannot be replied to".to_string();
             return;
         }

--- a/src/app/command_palette.rs
+++ b/src/app/command_palette.rs
@@ -589,10 +589,10 @@ pub(super) fn command_palette_commands(command_palette_key: &str) -> Vec<Palette
             palette_key(KeyCode::Char('p')),
         ),
         palette_command(
-            "Reply to Focused Comment",
+            "Reply to Focused Description or Comment",
             "R",
             "Details",
-            "Quote reply to the focused comment",
+            "Quote reply to the focused description or comment",
             palette_key(KeyCode::Char('R')),
         ),
         palette_command(

--- a/src/app/details.rs
+++ b/src/app/details.rs
@@ -2078,18 +2078,20 @@ pub(super) fn push_diff_inline_comment(
         append_review_state_segments(&mut header, review);
     }
     append_reaction_segments(&mut header, &comment.reactions);
-    if !comment.kind.is_activity() {
+    if comment.can_react() {
         header.push(DetailSegment::raw("  "));
         header.push(DetailSegment::action(
             "+ react",
             DetailAction::ReactComment(index),
         ));
     }
-    header.push(DetailSegment::raw("  "));
-    header.push(DetailSegment::action(
-        "reply",
-        DetailAction::ReplyComment(index),
-    ));
+    if comment.can_reply() {
+        header.push(DetailSegment::raw("  "));
+        header.push(DetailSegment::action(
+            "reply",
+            DetailAction::ReplyComment(index),
+        ));
+    }
     if comment.can_edit() {
         header.push(DetailSegment::raw("  "));
         header.push(DetailSegment::action(
@@ -2845,7 +2847,7 @@ pub(super) fn push_comment(
         header.push(DetailSegment::link("open", url.clone()));
     }
     append_reaction_segments(&mut header, &comment.reactions);
-    if !comment.kind.is_activity() {
+    if comment.can_react() {
         header.push(DetailSegment::raw("  "));
         header.push(DetailSegment::action(
             "+ react",
@@ -2875,7 +2877,7 @@ pub(super) fn push_comment(
             DetailAction::ToggleCommentExpanded(index),
         ));
     }
-    if !comment.kind.is_activity() {
+    if comment.can_reply() {
         header.push(DetailSegment::raw("  "));
         header.push(DetailSegment::action(
             "reply",

--- a/src/app/details.rs
+++ b/src/app/details.rs
@@ -1411,16 +1411,29 @@ pub(super) fn build_conversation_document(app: &AppState, width: u16) -> Details
 
     if matches!(item.kind, ItemKind::Issue | ItemKind::PullRequest) {
         builder.push_blank();
-        builder.push_heading("Comments");
-        builder.push_blank();
         match app.details.get(&item.id) {
             Some(DetailState::Loading) => {
+                builder.push_heading("Comments");
+                builder.push_blank();
                 builder.push_plain("loading comments...");
             }
-            Some(DetailState::Loaded(comments)) if comments.is_empty() => {
-                builder.push_plain("No comments.");
-            }
             Some(DetailState::Loaded(comments)) => {
+                let comment_entries = comment_display_entries(comments);
+                let activity_indices = activity_display_indices(comments);
+                if !activity_indices.is_empty() {
+                    builder.push_heading("Activity");
+                    builder.push_blank();
+                    for (position, index) in activity_indices.iter().enumerate() {
+                        if position > 0 {
+                            builder.push_blank();
+                        }
+                        push_timeline_activity(&mut builder, &comments[*index]);
+                    }
+                    builder.push_blank();
+                }
+
+                builder.push_heading("Comments");
+                builder.push_blank();
                 let comment_search_query = app.comment_search_query.trim();
                 let search_matches = (!comment_search_query.is_empty())
                     .then(|| comment_search_matches(comments, comment_search_query));
@@ -1428,12 +1441,15 @@ pub(super) fn build_conversation_document(app: &AppState, width: u16) -> Details
                     builder.push_plain(format!(
                         "Comment search: {}/{} matches for /{}",
                         matches.len(),
-                        comments.len(),
+                        comment_entries.len(),
                         comment_search_query
                     ));
                     builder.push_blank();
                 }
-                for (position, entry) in comment_display_entries(comments).iter().enumerate() {
+                if comment_entries.is_empty() {
+                    builder.push_plain("No comments.");
+                }
+                for (position, entry) in comment_entries.iter().enumerate() {
                     if position > 0 {
                         builder.push_blank();
                     }
@@ -1467,9 +1483,13 @@ pub(super) fn build_conversation_document(app: &AppState, width: u16) -> Details
                 }
             }
             Some(DetailState::Error(error)) => {
+                builder.push_heading("Comments");
+                builder.push_blank();
                 builder.push_plain(format!("Failed to load comments: {error}"));
             }
             None => {
+                builder.push_heading("Comments");
+                builder.push_blank();
                 builder.push_plain("loading comments...");
             }
         }
@@ -2966,6 +2986,35 @@ pub(super) fn push_comment(
         start_line,
         end_line: builder.document.lines.len(),
     });
+}
+
+pub(super) fn push_timeline_activity(builder: &mut DetailsBuilder, activity: &CommentPreview) {
+    let timestamp = activity
+        .updated_at
+        .as_ref()
+        .or(activity.created_at.as_ref())
+        .cloned();
+    let prefix = padding_prefix(DESCRIPTION_BODY_PADDING);
+    let mut header = vec![
+        DetailSegment::styled("activity: ", active_theme().muted()),
+        comment_author_link_segment(&activity.author, false),
+        DetailSegment::raw(format!(" - {}", relative_time(timestamp))),
+    ];
+    if let Some(url) = &activity.url {
+        header.push(DetailSegment::raw("  "));
+        header.push(DetailSegment::link("open", url.clone()));
+    }
+    builder.push_prefixed_wrapped_limited(header, prefix.clone(), DESCRIPTION_BODY_PADDING, 2);
+    builder.push_markdown_block_prefixed(
+        &activity.body,
+        "No activity body.",
+        usize::MAX,
+        usize::MAX,
+        MarkdownRenderOptions {
+            prefix,
+            right_padding: DESCRIPTION_BODY_PADDING,
+        },
+    );
 }
 
 pub(super) fn push_comment_body_gap(

--- a/src/app/details.rs
+++ b/src/app/details.rs
@@ -287,6 +287,7 @@ impl DiffReviewTarget {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) enum DetailAction {
+    ReplyItemDescription,
     ReplyComment(usize),
     EditComment(usize),
     ToggleCommentExpanded(usize),
@@ -1401,7 +1402,12 @@ pub(super) fn build_conversation_document(app: &AppState, width: u16) -> Details
 
     builder.push_blank();
     push_description_block(&mut builder, app, item);
-    push_reactions_line(&mut builder, &item.reactions, item.supports_reactions());
+    push_reactions_line(
+        &mut builder,
+        &item.reactions,
+        item.supports_reactions(),
+        item_description_can_reply(item),
+    );
 
     if matches!(item.kind, ItemKind::Issue | ItemKind::PullRequest) {
         builder.push_blank();
@@ -2708,8 +2714,9 @@ pub(super) fn push_reactions_line(
     builder: &mut DetailsBuilder,
     reactions: &ReactionSummary,
     can_react: bool,
+    can_reply: bool,
 ) {
-    if reactions.is_empty() && !can_react {
+    if reactions.is_empty() && !can_react && !can_reply {
         return;
     }
     builder.push_blank();
@@ -2729,6 +2736,17 @@ pub(super) fn push_reactions_line(
             "  "
         }));
         segments.push(DetailSegment::action("+ react", DetailAction::ReactItem));
+    }
+    if can_reply {
+        segments.push(DetailSegment::raw(if reactions.is_empty() && !can_react {
+            " "
+        } else {
+            "  "
+        }));
+        segments.push(DetailSegment::action(
+            "reply",
+            DetailAction::ReplyItemDescription,
+        ));
     }
     builder.push_prefixed_wrapped_limited(
         segments,
@@ -3991,6 +4009,40 @@ pub(super) fn push_check_part(segments: &mut Vec<DetailSegment>, text: String, s
 pub(super) fn quote_comment_for_reply(comment: &CommentPreview) -> String {
     let quote = truncate_text(&normalize_text(&comment.body), 1_200);
     let mut body = format!("> @{} wrote:\n", comment.author);
+    push_quote_excerpt(&mut body, &quote);
+    body
+}
+
+pub(super) fn quote_item_description_for_reply(item: &WorkItem) -> String {
+    let quote = truncate_text(
+        &normalize_text(item.body.as_deref().unwrap_or_default()),
+        1_200,
+    );
+    let target = match item.kind {
+        ItemKind::PullRequest => "pull request description",
+        ItemKind::Issue => "issue description",
+        ItemKind::Notification => "description",
+    };
+    let mut body = item
+        .author
+        .as_deref()
+        .filter(|author| !author.trim().is_empty())
+        .map(|author| format!("> @{author} wrote in the {target}:\n"))
+        .unwrap_or_else(|| format!("> {target}:\n"));
+    push_quote_excerpt(&mut body, &quote);
+    body
+}
+
+pub(super) fn item_description_can_reply(item: &WorkItem) -> bool {
+    matches!(item.kind, ItemKind::Issue | ItemKind::PullRequest)
+        && item.number.is_some()
+        && item
+            .body
+            .as_deref()
+            .is_some_and(|body| !body.trim().is_empty())
+}
+
+fn push_quote_excerpt(body: &mut String, quote: &str) {
     if quote.trim().is_empty() {
         body.push_str(">\n");
     } else {
@@ -4008,7 +4060,6 @@ pub(super) fn quote_comment_for_reply(comment: &CommentPreview) -> String {
         }
     }
     body.push('\n');
-    body
 }
 
 pub(super) fn markdown_blocks(text: &str) -> Vec<MarkdownBlock> {

--- a/src/app/drafts.rs
+++ b/src/app/drafts.rs
@@ -28,6 +28,10 @@ pub(super) fn reply_comment_draft_key(
     format!("comment:{}:reply:{target}", editor_draft_item_key(item))
 }
 
+pub(super) fn reply_item_description_draft_key(item: &WorkItem) -> String {
+    format!("comment:{}:reply:description", editor_draft_item_key(item))
+}
+
 pub(super) fn edit_comment_draft_key(item: &WorkItem, comment_id: u64, is_review: bool) -> String {
     let kind = if is_review { "review" } else { "issue" };
     format!(

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -1331,10 +1331,18 @@ pub(super) fn footer_mouse_shortcut(
 }
 
 pub(super) fn footer_has_selected_comment(app: &AppState) -> bool {
-    app.details_mode == DetailsMode::Conversation
-        && app
-            .current_selected_comment()
-            .is_some_and(|comment| comment.can_reply())
+    if app.details_mode != DetailsMode::Conversation {
+        return false;
+    }
+    if app
+        .current_selected_comment()
+        .is_some_and(|comment| comment.can_reply())
+    {
+        return true;
+    }
+    app.focus == FocusTarget::Details
+        && app.comment_selection_cleared()
+        && app.current_item().is_some_and(item_description_can_reply)
 }
 
 pub(super) fn footer_focus_primary_shortcuts(app: &AppState) -> Vec<Span<'static>> {

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -1334,7 +1334,7 @@ pub(super) fn footer_has_selected_comment(app: &AppState) -> bool {
     app.details_mode == DetailsMode::Conversation
         && app
             .current_selected_comment()
-            .is_some_and(|comment| !comment.kind.is_activity())
+            .is_some_and(|comment| comment.can_reply())
 }
 
 pub(super) fn footer_focus_primary_shortcuts(app: &AppState) -> Vec<Span<'static>> {

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -11316,6 +11316,100 @@ fn reply_action_opens_dialog_prefilled_with_quote() {
 }
 
 #[test]
+fn description_reply_action_opens_prefilled_conversation_comment() {
+    let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
+    app.sections[0].items[0].author = Some("chenyukang".to_string());
+    app.focus_details();
+    app.selected_comment_index = NO_SELECTED_COMMENT_INDEX;
+
+    app.start_reply_to_selected_comment();
+
+    let dialog = app.comment_dialog.as_mut().expect("reply dialog");
+    assert_eq!(dialog.mode, CommentDialogMode::New);
+    assert!(
+        dialog
+            .body
+            .text()
+            .contains("> @chenyukang wrote in the pull request description:")
+    );
+    assert!(dialog.body.text().contains("> A body with useful context"));
+    dialog.body.set_text("reply to description");
+
+    let mut submitted = None;
+    app.handle_comment_dialog_key_with_submit(
+        KeyEvent::new(KeyCode::Enter, crossterm::event::KeyModifiers::CONTROL),
+        None,
+        |pending| submitted = Some((pending.item.id, pending.body, pending.mode)),
+    );
+
+    assert!(app.comment_dialog.is_none());
+    assert!(app.posting_comment);
+    assert_eq!(app.status, "posting comment");
+    assert_eq!(
+        submitted,
+        Some((
+            "1".to_string(),
+            "reply to description".to_string(),
+            PendingCommentMode::Post
+        ))
+    );
+}
+
+#[test]
+fn issue_description_reply_uses_issue_description_quote() {
+    let mut section = test_section();
+    section.kind = SectionKind::Issues;
+    section.key = "issues:test".to_string();
+    section.items[0].kind = ItemKind::Issue;
+    section.items[0].id = "issue-1".to_string();
+    section.items[0].url = "https://github.com/owner/repo/issues/1".to_string();
+    section.items[0].author = Some("chenyukang".to_string());
+    let mut app = AppState::new(SectionKind::Issues, vec![section]);
+    app.focus_details();
+    app.selected_comment_index = NO_SELECTED_COMMENT_INDEX;
+
+    app.start_reply_to_selected_comment();
+
+    let dialog = app.comment_dialog.expect("reply dialog");
+    assert_eq!(dialog.mode, CommentDialogMode::New);
+    assert!(
+        dialog
+            .body
+            .text()
+            .contains("> @chenyukang wrote in the issue description:")
+    );
+    assert!(dialog.body.text().contains("> A body with useful context"));
+    assert_eq!(app.status, "replying to issue description");
+}
+
+#[test]
+fn description_reactions_line_exposes_reply_action() {
+    let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
+    app.focus_details();
+    app.selected_comment_index = NO_SELECTED_COMMENT_INDEX;
+
+    let document = build_details_document(&app, 120);
+    let rendered = document
+        .lines
+        .iter()
+        .map(|line| line.to_string())
+        .collect::<Vec<_>>();
+    let reactions_line = rendered
+        .iter()
+        .position(|line| line.contains("reactions:"))
+        .expect("description reactions line");
+
+    assert!(rendered[reactions_line].contains("reply"));
+    let reply_column = rendered[reactions_line]
+        .find("reply")
+        .expect("reply action") as u16;
+    assert_eq!(
+        document.action_at(reactions_line, reply_column),
+        Some(DetailAction::ReplyItemDescription)
+    );
+}
+
+#[test]
 fn review_summary_reply_submits_as_conversation_comment() {
     let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
     app.details.insert(

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -7013,6 +7013,36 @@ fn comment_search_n_and_p_cycle_matching_comments() {
 }
 
 #[test]
+fn comment_navigation_skips_activity_timeline_entries() {
+    let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
+    let item_id = app.current_item().expect("item").id.clone();
+    let mut activity = comment("bot", "pushed 1 commit", None);
+    activity.kind = CommentPreviewKind::Activity;
+    app.details.insert(
+        item_id,
+        DetailState::Loaded(vec![
+            comment("alice", "first comment", None),
+            activity,
+            comment("bob", "second comment", None),
+        ]),
+    );
+    app.focus_details();
+    app.selected_comment_index = 0;
+
+    app.move_comment(1);
+    assert_eq!(app.selected_comment_index, 2);
+    assert_eq!(app.status, "comment 2/2 focused");
+
+    app.move_comment(1);
+    assert_eq!(app.selected_comment_index, 2);
+    assert_eq!(app.status, "comment 2/2 focused");
+
+    app.selected_comment_index = 1;
+    app.clamp_selected_comment();
+    assert_eq!(app.selected_comment_index, 0);
+}
+
+#[test]
 fn details_title_shows_comment_search_input_prompt() {
     let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
     let item_id = app.current_item().expect("item").id.clone();
@@ -10387,14 +10417,21 @@ fn details_activity_hides_comment_actions() {
     app.details
         .insert("1".to_string(), DetailState::Loaded(vec![activity]));
 
-    let rendered = build_details_document(&app, 120)
+    let document = build_details_document(&app, 120);
+    let rendered = document
         .lines
         .iter()
         .map(|line| line.to_string())
         .collect::<Vec<_>>()
         .join("\n");
 
+    assert!(rendered.contains("No comments."));
+    assert!(rendered.contains("Activity"));
     assert!(rendered.contains("pushed 3 commits"));
+    assert!(
+        rendered.find("Activity").unwrap() < rendered.find("Comments").unwrap(),
+        "activity timeline should render before comments: {rendered:?}"
+    );
     assert!(
         rendered.lines().any(|line| line.contains("- ee8130a fix")),
         "first commit should render as its own list line: {rendered:?}"
@@ -10413,8 +10450,10 @@ fn details_activity_hides_comment_actions() {
         .lines()
         .find(|line| line.contains("doitian"))
         .expect("activity header");
+    assert!(activity_header.contains("activity:"));
     assert!(!activity_header.contains("+ react"));
     assert!(!activity_header.contains("reply"));
+    assert!(document.comments.is_empty());
 }
 
 #[test]

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -11316,6 +11316,96 @@ fn reply_action_opens_dialog_prefilled_with_quote() {
 }
 
 #[test]
+fn review_summary_reply_submits_as_conversation_comment() {
+    let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
+    app.details.insert(
+        "1".to_string(),
+        DetailState::Loaded(vec![review_summary_comment(
+            4229433610,
+            "alice",
+            "Review summary body",
+            Some("https://github.com/owner/repo/pull/1#pullrequestreview-4229433610"),
+        )]),
+    );
+
+    app.handle_detail_action(DetailAction::ReplyComment(0), None, None);
+
+    let dialog = app.comment_dialog.as_mut().expect("reply dialog");
+    assert_eq!(
+        dialog.mode,
+        CommentDialogMode::Reply {
+            comment_index: 0,
+            author: "alice".to_string(),
+            review_comment_id: None,
+        }
+    );
+    assert!(dialog.body.text().contains("> @alice wrote:"));
+    assert!(dialog.body.text().contains("> Review summary body"));
+    dialog.body.set_text("reply to summary");
+
+    let mut submitted = None;
+    app.handle_comment_dialog_key_with_submit(
+        KeyEvent::new(KeyCode::Enter, crossterm::event::KeyModifiers::CONTROL),
+        None,
+        |pending| submitted = Some((pending.item.id, pending.body, pending.mode)),
+    );
+
+    assert!(app.comment_dialog.is_none());
+    assert!(app.posting_comment);
+    assert_eq!(app.status, "posting comment");
+    assert_eq!(
+        app.message_dialog
+            .as_ref()
+            .map(|dialog| (dialog.title.as_str(), dialog.body.as_str())),
+        Some((
+            "Posting Comment",
+            "Waiting for GitHub to accept the comment..."
+        ))
+    );
+    assert_eq!(
+        submitted,
+        Some((
+            "1".to_string(),
+            "reply to summary".to_string(),
+            PendingCommentMode::Post
+        ))
+    );
+}
+
+#[test]
+fn review_summary_details_show_reply_without_reaction_action() {
+    let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
+    app.details.insert(
+        "1".to_string(),
+        DetailState::Loaded(vec![review_summary_comment(
+            4229433610,
+            "alice",
+            "Review summary body",
+            Some("https://github.com/owner/repo/pull/1#pullrequestreview-4229433610"),
+        )]),
+    );
+
+    let document = build_details_document(&app, 120);
+    let rendered = document
+        .lines
+        .iter()
+        .map(|line| line.to_string())
+        .collect::<Vec<_>>();
+    let header_line = rendered
+        .iter()
+        .position(|line| line.contains("alice"))
+        .expect("review summary header");
+
+    assert!(rendered[header_line].contains("reply"));
+    assert!(!rendered[header_line].contains("+ react"));
+    let reply_column = rendered[header_line].find("reply").expect("reply action") as u16;
+    assert_eq!(
+        document.action_at(header_line, reply_column),
+        Some(DetailAction::ReplyComment(0))
+    );
+}
+
+#[test]
 fn assignee_actions_are_rendered_in_details() {
     let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
 
@@ -19800,6 +19890,13 @@ fn comment(author: &str, body: &str, url: Option<&str>) -> CommentPreview {
         reactions: ReactionSummary::default(),
         review: None,
     }
+}
+
+fn review_summary_comment(id: u64, author: &str, body: &str, url: Option<&str>) -> CommentPreview {
+    let mut comment = comment(author, body, url);
+    comment.id = Some(id);
+    comment.kind = CommentPreviewKind::ReviewSummary;
+    comment
 }
 
 fn own_comment(id: u64, author: &str, body: &str, url: Option<&str>) -> CommentPreview {

--- a/src/github.rs
+++ b/src/github.rs
@@ -4112,7 +4112,7 @@ fn pull_request_timeline_review_summary_comment(
     let timestamp = event.submitted_at.or(event.created_at);
     Some(CommentPreview {
         id: event.id,
-        kind: CommentPreviewKind::Activity,
+        kind: CommentPreviewKind::ReviewSummary,
         author,
         body,
         created_at: timestamp,
@@ -7145,7 +7145,9 @@ mod tests {
         assert_eq!(comments.len(), 1);
         let comment = &comments[0];
         assert_eq!(comment.id, Some(4229433610));
-        assert_eq!(comment.kind, CommentPreviewKind::Activity);
+        assert_eq!(comment.kind, CommentPreviewKind::ReviewSummary);
+        assert!(comment.can_reply());
+        assert!(!comment.can_react());
         assert_eq!(comment.author, "chenyukang");
         assert!(comment.body.contains("according to the blame history"));
         assert_eq!(

--- a/src/model.rs
+++ b/src/model.rs
@@ -144,7 +144,15 @@ pub struct CommentPreview {
 
 impl CommentPreview {
     pub fn can_edit(&self) -> bool {
-        self.id.is_some() && self.viewer_can_update.unwrap_or(self.is_mine)
+        self.kind.can_edit() && self.id.is_some() && self.viewer_can_update.unwrap_or(self.is_mine)
+    }
+
+    pub fn can_react(&self) -> bool {
+        self.kind.can_react()
+    }
+
+    pub fn can_reply(&self) -> bool {
+        self.kind.can_reply()
     }
 }
 
@@ -153,6 +161,7 @@ impl CommentPreview {
 pub enum CommentPreviewKind {
     #[default]
     Comment,
+    ReviewSummary,
     Activity,
 }
 
@@ -161,8 +170,16 @@ impl CommentPreviewKind {
         matches!(kind, Self::Comment)
     }
 
-    pub fn is_activity(self) -> bool {
-        matches!(self, Self::Activity)
+    pub fn can_edit(self) -> bool {
+        matches!(self, Self::Comment)
+    }
+
+    pub fn can_react(self) -> bool {
+        matches!(self, Self::Comment)
+    }
+
+    pub fn can_reply(self) -> bool {
+        matches!(self, Self::Comment | Self::ReviewSummary)
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/chenyukang/ghr/issues/55

## Summary
- allow quote replies for PR review summary comments
- allow quote replies from PR and issue descriptions as regular conversation comments
- render push activity in a separate Activity timeline before Comments, without making it selectable as a comment

## Validation
- cargo fmt --check
- cargo test --locked
- cargo clippy --locked -- -D warnings