### PR TITLE
Support resolving review threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 - Details pane with rendered Markdown, clickable links and image attachments, fenced code blocks with lightweight Rust and plain/log highlighting, descriptions, comments, review comments, PR commit activity, labels, milestones, action hints, and check summaries.
 - Inbox notifications lazily load linked PR or issue details when opened, so descriptions and recent PR commit activity appear without making the initial inbox fetch heavier.
 - PR diff mode with a changed-file list, per-file diff rendering, inline review comments, and review ranges.
-- Comment, reply, edit, milestone, merge, close/reopen, update-branch, rerun-failed-checks, local PR checkout, draft / ready-for-review, and full PR review submit flows from inside the TUI.
+- Comment, reply, edit, resolve review threads, milestone, merge, close/reopen, update-branch, rerun-failed-checks, local PR checkout, draft / ready-for-review, and full PR review submit flows from inside the TUI.
 - Inbox read/done/mute handling with explicit commands, local cache updates, GitHub sync, and dimmed read items.
 - Mouse support for tabs, lists, links, descriptions, comments, editor cursor placement, details drag-copy, scrolling, text selection mode, and split resizing.
 - Built-in `auto` plus named light and dark color themes configured through `defaults.theme` / `defaults.theme_name`; `auto` follows the macOS appearance when available.
@@ -125,6 +125,7 @@ Press `?` in the TUI for the live shortcut reference. The top-right status shows
 | `c` in Details | Add a normal comment in conversation mode, or an inline review comment in diff mode |
 | `R` | Reply to the focused comment |
 | `e` | Edit the focused comment in Details, edit the selected issue or PR when no comment is focused, or end a review range in diff mode |
+| `z` | Resolve or unresolve the focused inline review thread |
 | `T` | Edit the selected issue or PR title, assignees, labels, and body |
 | `m` | Toggle terminal text selection mode; in diff details, begin a review range |
 | `M` | Open a merge confirmation for the selected PR, defaulting to merge commits |

--- a/src/app.rs
+++ b/src/app.rs
@@ -58,10 +58,10 @@ use crate::github::{
     refresh_dashboard, refresh_dashboard_with_progress, refresh_idle_search_sections,
     refresh_section_page, remove_issue_label, remove_pull_request_reviewers, reopen_issue,
     reopen_pull_request, request_pull_request_reviewers, rerun_failed_pull_request_checks,
-    search_github_users, search_global, submit_pending_pull_request_review,
-    submit_pull_request_review, subscribe_notification_thread, unsubscribe_notification_thread,
-    update_issue_assignees, update_item_subscription, update_pull_request_branch,
-    with_background_github_priority,
+    search_github_users, search_global, set_pull_request_review_thread_resolved,
+    submit_pending_pull_request_review, submit_pull_request_review, subscribe_notification_thread,
+    unsubscribe_notification_thread, update_issue_assignees, update_item_subscription,
+    update_pull_request_branch, with_background_github_priority,
 };
 use crate::log::{fail_gh_request_to_start, finish_gh_request, start_gh_request};
 use crate::model::{
@@ -191,6 +191,12 @@ enum AppMsg {
     },
     ReactionPosted {
         item_id: String,
+        result: std::result::Result<CommentFetchResult, String>,
+    },
+    ReviewThreadResolutionUpdated {
+        item_id: String,
+        comment_index: usize,
+        resolved: bool,
         result: std::result::Result<CommentFetchResult, String>,
     },
     LabelUpdated {
@@ -1290,6 +1296,22 @@ fn item_subscription_action_success_status(
     }
 }
 
+fn review_thread_resolution_running_status(resolved: bool) -> &'static str {
+    if resolved {
+        "resolving review thread"
+    } else {
+        "marking review thread unresolved"
+    }
+}
+
+fn review_thread_resolution_success_status(resolved: bool) -> &'static str {
+    if resolved {
+        "review thread resolved"
+    } else {
+        "review thread marked unresolved"
+    }
+}
+
 fn item_kind_label(kind: ItemKind) -> &'static str {
     match kind {
         ItemKind::Issue => "issue",
@@ -1574,6 +1596,7 @@ struct AppState {
     posting_comment: bool,
     reaction_dialog: Option<ReactionDialog>,
     posting_reaction: bool,
+    resolving_review_thread: bool,
     pending_comment_submit: Option<PendingCommentSubmit>,
     label_dialog: Option<LabelDialog>,
     label_updating: bool,
@@ -2932,6 +2955,7 @@ impl AppState {
             posting_comment: false,
             reaction_dialog: None,
             posting_reaction: false,
+            resolving_review_thread: false,
             pending_comment_submit: None,
             label_dialog: None,
             label_updating: false,
@@ -3903,6 +3927,48 @@ impl AppState {
                     self.posting_reaction = false;
                     self.reaction_dialog = None;
                     self.status = "reaction failed".to_string();
+                }
+            },
+            AppMsg::ReviewThreadResolutionUpdated {
+                item_id,
+                comment_index,
+                resolved,
+                result,
+            } => match result {
+                Ok(mut result) => {
+                    self.selected_comment_index =
+                        comment_index.min(result.comments.len().saturating_sub(1));
+                    self.details_stale.remove(&item_id);
+                    self.details_refreshing.remove(&item_id);
+                    self.remember_details_synced_at(&item_id, &result);
+                    self.apply_comment_fetch_result_metadata(&item_id, &result);
+                    self.merge_optimistic_comments(&item_id, &mut result.comments);
+                    self.details
+                        .insert(item_id.clone(), DetailState::Loaded(result.comments));
+                    self.clamp_selected_comment();
+                    self.mark_current_details_viewed_if_current(&item_id);
+                    self.resolving_review_thread = false;
+                    self.status = review_thread_resolution_success_status(resolved).to_string();
+                    self.message_dialog = Some(success_message_dialog(
+                        "Review Thread Updated",
+                        "GitHub accepted the review thread update and comments were refreshed.",
+                    ));
+                }
+                Err(error) => {
+                    let setup_dialog = setup_dialog_from_error(&error);
+                    if self.setup_dialog.is_none() {
+                        self.setup_dialog = setup_dialog;
+                    }
+                    if setup_dialog.is_none() {
+                        self.message_dialog = Some(message_dialog(
+                            "Review Thread Update Failed",
+                            operation_error_body(&error),
+                        ));
+                    } else {
+                        self.message_dialog = None;
+                    }
+                    self.resolving_review_thread = false;
+                    self.status = "review thread update failed".to_string();
                 }
             },
             AppMsg::LabelUpdated {
@@ -5303,6 +5369,10 @@ impl AppState {
             }
             PaletteAction::ItemSubscriptionAction(action) => {
                 self.start_item_subscription_action(action, tx);
+                false
+            }
+            PaletteAction::ToggleReviewThreadResolution => {
+                self.toggle_selected_review_thread_resolution(tx);
                 false
             }
         }
@@ -8190,6 +8260,58 @@ impl AppState {
         self.posting_reaction = true;
         self.status = format!("adding reaction {} {}", reaction.emoji(), reaction.label());
         start_reaction_submit(item, target, reaction, tx.clone());
+    }
+
+    fn toggle_selected_review_thread_resolution(&mut self, tx: &UnboundedSender<AppMsg>) {
+        if self.resolving_review_thread {
+            self.status = "review thread update already running".to_string();
+            return;
+        }
+        let Some(item) = self.current_item().cloned() else {
+            self.status = "nothing selected".to_string();
+            return;
+        };
+        if item.kind != ItemKind::PullRequest || item.number.is_none() {
+            self.status = "review threads are available for pull requests".to_string();
+            return;
+        }
+        let Some(comment) = self.current_selected_comment().cloned() else {
+            self.status = "no comment selected".to_string();
+            return;
+        };
+        let Some(review) = comment.review.as_ref() else {
+            self.status = "selected comment is not an inline review thread".to_string();
+            return;
+        };
+        let Some(thread_id) = review.thread_id.clone() else {
+            self.status = "review thread id unavailable; refresh comments".to_string();
+            return;
+        };
+
+        let resolved = !review.is_resolved;
+        self.finish_details_visit(Instant::now());
+        self.comment_dialog = None;
+        self.label_dialog = None;
+        self.issue_dialog = None;
+        self.reaction_dialog = None;
+        self.review_submit_dialog = None;
+        self.item_edit_dialog = None;
+        self.milestone_dialog = None;
+        self.pr_action_dialog = None;
+        self.assignee_dialog = None;
+        self.search_active = false;
+        self.comment_search_active = false;
+        self.global_search_active = false;
+        self.focus = FocusTarget::Details;
+        self.resolving_review_thread = true;
+        self.status = review_thread_resolution_running_status(resolved).to_string();
+        start_review_thread_resolution_update(
+            item,
+            self.selected_comment_index,
+            thread_id,
+            resolved,
+            tx.clone(),
+        );
     }
 
     fn toggle_selected_comment_expanded(&mut self) {

--- a/src/app/command_palette.rs
+++ b/src/app/command_palette.rs
@@ -50,6 +50,7 @@ pub(super) enum PaletteAction {
     InboxMarkAllRead,
     InboxThreadAction(InboxThreadAction),
     ItemSubscriptionAction(ItemSubscriptionAction),
+    ToggleReviewThreadResolution,
 }
 
 pub(super) fn command_palette_area(area: Rect) -> Rect {
@@ -609,6 +610,13 @@ pub(super) fn command_palette_commands(command_palette_key: &str) -> Vec<Palette
             "Details",
             "Edit the focused comment, or the selected issue/PR when no comment is focused",
             palette_key(KeyCode::Char('e')),
+        ),
+        palette_command(
+            "Toggle Review Thread Resolution",
+            "z",
+            "Details",
+            "Resolve or unresolve the focused inline review thread",
+            PaletteAction::ToggleReviewThreadResolution,
         ),
         palette_command(
             "Previous Diff File",

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -651,6 +651,9 @@ pub(super) fn handle_key_in_area_mut(
             KeyCode::Char('R') if app.details_mode == DetailsMode::Conversation => {
                 app.start_reply_to_selected_comment()
             }
+            KeyCode::Char('z') if key.modifiers.is_empty() => {
+                app.toggle_selected_review_thread_resolution(tx)
+            }
             _ if app.details_mode == DetailsMode::Conversation && is_reaction_key(key) => {
                 app.start_keyboard_reaction_dialog(area)
             }

--- a/src/app/tasks.rs
+++ b/src/app/tasks.rs
@@ -750,6 +750,36 @@ pub(super) fn start_reaction_submit(
     });
 }
 
+pub(super) fn start_review_thread_resolution_update(
+    item: WorkItem,
+    comment_index: usize,
+    thread_id: String,
+    resolved: bool,
+    tx: UnboundedSender<AppMsg>,
+) {
+    tokio::spawn(async move {
+        let item_id = item.id.clone();
+        let result = match item.number {
+            Some(number) if item.kind == ItemKind::PullRequest => {
+                match set_pull_request_review_thread_resolved(&thread_id, resolved).await {
+                    Ok(()) => fetch_comments(&item.repo, number, item.kind)
+                        .await
+                        .map_err(|error| error.to_string()),
+                    Err(error) => Err(error.to_string()),
+                }
+            }
+            Some(_) => Err("review threads are available for pull requests".to_string()),
+            None => Err("selected item has no pull request number".to_string()),
+        };
+        let _ = tx.send(AppMsg::ReviewThreadResolutionUpdated {
+            item_id,
+            comment_index,
+            resolved,
+            result,
+        });
+    });
+}
+
 pub(super) fn start_label_update(item: WorkItem, action: LabelAction, tx: UnboundedSender<AppMsg>) {
     tokio::spawn(async move {
         let item_id = item.id.clone();

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -350,6 +350,7 @@ fn diff_details_render_inline_review_comments_below_target_line() {
     );
 
     let review = crate::model::ReviewCommentPreview {
+        thread_id: None,
         path: "src/lib.rs".to_string(),
         line: Some(1),
         original_line: None,
@@ -482,6 +483,7 @@ fn text_selection_mode_omits_inline_thread_markers() {
     );
 
     let review = crate::model::ReviewCommentPreview {
+        thread_id: None,
         path: "src/lib.rs".to_string(),
         line: Some(1),
         original_line: None,
@@ -542,6 +544,7 @@ fn diff_mode_can_hide_inline_review_comment_bodies_but_keeps_markers() {
     let mut inline = comment("alice", "Hidden until marker is opened.", None);
     inline.id = Some(1);
     inline.review = Some(crate::model::ReviewCommentPreview {
+        thread_id: None,
         path: "src/lib.rs".to_string(),
         line: Some(1),
         original_line: None,
@@ -610,6 +613,7 @@ fn clicking_hidden_diff_inline_comment_marker_reveals_that_thread() {
     let mut inline = comment("alice", "Revealed by marker click.", None);
     inline.id = Some(1);
     inline.review = Some(crate::model::ReviewCommentPreview {
+        thread_id: None,
         path: "src/lib.rs".to_string(),
         line: Some(1),
         original_line: None,
@@ -677,6 +681,7 @@ fn mouse_clicking_hidden_diff_inline_comment_marker_toggles_that_thread() {
     let mut inline = comment("alice", "Toggle me from the marker.", None);
     inline.id = Some(1);
     inline.review = Some(crate::model::ReviewCommentPreview {
+        thread_id: None,
         path: "src/lib.rs".to_string(),
         line: Some(1),
         original_line: None,
@@ -776,6 +781,7 @@ fn mouse_clicking_inline_comment_author_opens_profile() {
     );
     comment.id = Some(1);
     comment.review = Some(crate::model::ReviewCommentPreview {
+        thread_id: None,
         path: "src/lib.rs".to_string(),
         line: Some(1),
         original_line: None,
@@ -846,6 +852,7 @@ fn diff_details_render_resolved_and_outdated_review_comment_states() {
     let mut resolved = comment("alice", "Fixed now.", None);
     resolved.id = Some(1);
     resolved.review = Some(crate::model::ReviewCommentPreview {
+        thread_id: None,
         path: "src/lib.rs".to_string(),
         line: Some(1),
         original_line: None,
@@ -860,6 +867,7 @@ fn diff_details_render_resolved_and_outdated_review_comment_states() {
     let mut outdated = comment("bob", "This pointed at an old line.", None);
     outdated.id = Some(2);
     outdated.review = Some(crate::model::ReviewCommentPreview {
+        thread_id: None,
         path: "src/lib.rs".to_string(),
         line: Some(99),
         original_line: Some(99),
@@ -1220,6 +1228,7 @@ fn n_and_p_focus_comments_in_diff_details() {
     let store = SnapshotStore::new(std::path::PathBuf::from("/tmp/ghr-test-unused.db"));
     let mut first = comment("alice", "first inline", None);
     first.review = Some(crate::model::ReviewCommentPreview {
+        thread_id: None,
         path: "src/lib.rs".to_string(),
         line: Some(1),
         original_line: None,
@@ -1233,6 +1242,7 @@ fn n_and_p_focus_comments_in_diff_details() {
     });
     let mut second = comment("bob", "second inline", None);
     second.review = Some(crate::model::ReviewCommentPreview {
+        thread_id: None,
         path: "src/lib.rs".to_string(),
         line: Some(2),
         original_line: None,
@@ -1298,6 +1308,7 @@ fn n_and_p_reveal_hidden_diff_inline_comment_threads_one_at_a_time() {
     let store = SnapshotStore::new(std::path::PathBuf::from("/tmp/ghr-test-unused.db"));
     let mut first = comment("alice", "first hidden inline", None);
     first.review = Some(crate::model::ReviewCommentPreview {
+        thread_id: None,
         path: "src/lib.rs".to_string(),
         line: Some(1),
         original_line: None,
@@ -1311,6 +1322,7 @@ fn n_and_p_reveal_hidden_diff_inline_comment_threads_one_at_a_time() {
     });
     let mut second = comment("bob", "second hidden inline", None);
     second.review = Some(crate::model::ReviewCommentPreview {
+        thread_id: None,
         path: "src/lib.rs".to_string(),
         line: Some(2),
         original_line: None,
@@ -2120,6 +2132,7 @@ diff --git a/src/github.rs b/src/github.rs
     let mut app_comment = comment("alice", "inline", None);
     app_comment.id = Some(1);
     app_comment.review = Some(crate::model::ReviewCommentPreview {
+        thread_id: None,
         path: "src/app.rs".to_string(),
         line: Some(1),
         original_line: None,
@@ -2137,6 +2150,7 @@ diff --git a/src/github.rs b/src/github.rs
     let mut github_comment = comment("carol", "inline", None);
     github_comment.id = Some(3);
     github_comment.review = Some(crate::model::ReviewCommentPreview {
+        thread_id: None,
         path: "src/github.rs".to_string(),
         line: Some(1),
         original_line: None,
@@ -10210,6 +10224,7 @@ fn selected_details_text_uses_segment_copy_metadata() {
     child.id = Some(2);
     child.parent_id = Some(1);
     let review = crate::model::ReviewCommentPreview {
+        thread_id: None,
         path: "src/lib.rs".to_string(),
         line: Some(1),
         original_line: None,
@@ -11116,6 +11131,7 @@ fn github_mentions_in_comments_are_clickable() {
 fn review_replies_render_under_parent_comment() {
     let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
     let review = crate::model::ReviewCommentPreview {
+        thread_id: None,
         path: "src/lib.rs".to_string(),
         line: Some(10),
         original_line: None,
@@ -11254,6 +11270,7 @@ fn details_comments_show_inline_review_location() {
         Some("https://github.com/chenyukang/ghr/pull/8#discussion_r88"),
     );
     inline.review = Some(crate::model::ReviewCommentPreview {
+            thread_id: None,
             path: "src/github.rs".to_string(),
             line: Some(876),
             original_line: None,
@@ -11312,6 +11329,7 @@ fn details_comments_keep_long_inline_review_metadata_on_own_line() {
         Some("https://github.com/rust-lang/rust/pull/156000#discussion_r99"),
     );
     inline.review = Some(crate::model::ReviewCommentPreview {
+        thread_id: None,
         path: "tests/ui/drop/explicit-drop-call-error.stderr".to_string(),
         line: Some(10),
         original_line: None,
@@ -11377,6 +11395,7 @@ fn inline_review_context_can_fall_back_to_original_line() {
     }
     diff_hunk.push_str("+outputsData: [ccc.bytesFrom(scriptBinary)],");
     inline.review = Some(crate::model::ReviewCommentPreview {
+        thread_id: None,
         path: "skill/deployment.md".to_string(),
         line: Some(56),
         original_line: Some(50),
@@ -16884,6 +16903,7 @@ fn inline_review_comment_edit_uses_review_edit_mode() {
     let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
     let mut inline = own_comment(88, "chenyukang", "old inline", None);
     inline.review = Some(crate::model::ReviewCommentPreview {
+        thread_id: None,
         path: "src/github.rs".to_string(),
         line: Some(876),
         original_line: None,
@@ -16920,6 +16940,7 @@ fn ctrl_enter_in_inline_review_reply_submits_review_reply() {
     );
     inline.id = Some(88);
     inline.review = Some(crate::model::ReviewCommentPreview {
+        thread_id: None,
         path: "src/github.rs".to_string(),
         line: Some(876),
         original_line: None,
@@ -17383,6 +17404,73 @@ fn review_comment_result_dialog_reports_success_and_failure() {
 }
 
 #[test]
+fn z_on_inline_review_comment_without_thread_id_reports_refresh_needed() {
+    let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
+    app.focus = FocusTarget::Details;
+    app.details.insert(
+        "1".to_string(),
+        DetailState::Loaded(vec![test_review_comment(88, "src/github.rs")]),
+    );
+    let store = SnapshotStore::new(std::path::PathBuf::from("/tmp/ghr-test-unused.db"));
+    let (tx, _rx) = mpsc::unbounded_channel();
+
+    assert!(!handle_key(
+        &mut app,
+        key(KeyCode::Char('z')),
+        &Config::default(),
+        &store,
+        &tx
+    ));
+
+    assert!(!app.resolving_review_thread);
+    assert_eq!(app.status, "review thread id unavailable; refresh comments");
+}
+
+#[test]
+fn review_thread_resolution_success_refreshes_comments_and_selection() {
+    let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
+    let mut inline = test_review_comment(88, "src/github.rs");
+    inline.review.as_mut().unwrap().thread_id = Some("PRRT_1".to_string());
+    app.details
+        .insert("1".to_string(), DetailState::Loaded(vec![inline]));
+    app.resolving_review_thread = true;
+
+    let mut refreshed = test_review_comment(88, "src/github.rs");
+    let review = refreshed.review.as_mut().unwrap();
+    review.thread_id = Some("PRRT_1".to_string());
+    review.is_resolved = true;
+
+    app.handle_msg(AppMsg::ReviewThreadResolutionUpdated {
+        item_id: "1".to_string(),
+        comment_index: 0,
+        resolved: true,
+        result: Ok(CommentFetchResult {
+            item_metadata: None,
+            item_reactions: None,
+            item_milestone: None,
+            comments: vec![refreshed],
+        }),
+    });
+
+    assert!(!app.resolving_review_thread);
+    assert_eq!(app.status, "review thread resolved");
+    assert_eq!(app.selected_comment_index, 0);
+    let comments = match app.details.get("1") {
+        Some(DetailState::Loaded(comments)) => comments,
+        other => panic!("expected loaded comments, got {other:?}"),
+    };
+    let review = comments[0].review.as_ref().expect("review metadata");
+    assert_eq!(review.thread_id.as_deref(), Some("PRRT_1"));
+    assert!(review.is_resolved);
+    assert_eq!(
+        app.message_dialog
+            .as_ref()
+            .map(|dialog| dialog.title.as_str()),
+        Some("Review Thread Updated")
+    );
+}
+
+#[test]
 fn posted_review_comment_is_rendered_locally_in_diff_mode() {
     let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
     app.details_mode = DetailsMode::Diff;
@@ -17402,6 +17490,7 @@ fn posted_review_comment_is_rendered_locally_in_diff_mode() {
     posted.id = Some(99);
     posted.is_mine = true;
     posted.review = Some(crate::model::ReviewCommentPreview {
+        thread_id: None,
         path: "src/lib.rs".to_string(),
         line: Some(2),
         original_line: Some(2),
@@ -20039,6 +20128,7 @@ fn test_review_comment(id: u64, path: &str) -> CommentPreview {
     let mut comment = comment("alice", "inline", None);
     comment.id = Some(id);
     comment.review = Some(crate::model::ReviewCommentPreview {
+        thread_id: None,
         path: path.to_string(),
         line: Some(1),
         original_line: None,

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -4477,10 +4477,7 @@ fn command_palette_log_opens_recent_gh_request_dialog() {
     let request = start_gh_request("gh api", "gh api /rate_limit", None);
     fail_gh_request_to_start(
         request,
-        &std::io::Error::new(
-            std::io::ErrorKind::Other,
-            "HTTP 403: API rate limit exceeded",
-        ),
+        &std::io::Error::other("HTTP 403: API rate limit exceeded"),
     );
     let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
     let (tx, _rx) = mpsc::unbounded_channel();
@@ -4552,17 +4549,11 @@ fn diagnostics_dialog_keys_move_and_close() {
 fn gh_log_dialog_enter_opens_selected_entry_detail() {
     clear_gh_log_entries();
     let older = start_gh_request("gh", "gh pr view 55", None);
-    fail_gh_request_to_start(
-        older,
-        &std::io::Error::new(std::io::ErrorKind::Other, "HTTP 500: old failure"),
-    );
+    fail_gh_request_to_start(older, &std::io::Error::other("HTTP 500: old failure"));
     let newer = start_gh_request("gh api", "gh api /rate_limit", None);
     fail_gh_request_to_start(
         newer,
-        &std::io::Error::new(
-            std::io::ErrorKind::Other,
-            "HTTP 403: API rate limit exceeded",
-        ),
+        &std::io::Error::other("HTTP 403: API rate limit exceeded"),
     );
     let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
     app.show_gh_log_dialog();

--- a/src/github.rs
+++ b/src/github.rs
@@ -561,8 +561,9 @@ struct PullRequestTimelineCommit {
     committed_at: Option<DateTime<Utc>>,
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 struct ReviewThreadState {
+    thread_id: Option<String>,
     is_resolved: bool,
     is_outdated: bool,
     viewer_can_update: Option<bool>,
@@ -608,6 +609,7 @@ struct PullRequestReviewThreadConnectionRaw {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct PullRequestReviewThreadRaw {
+    id: Option<String>,
     is_resolved: bool,
     is_outdated: bool,
     comments: PullRequestReviewThreadCommentConnectionRaw,
@@ -2310,6 +2312,7 @@ query($owner: String!, $name: String!, $number: Int!, $cursor: String) {
           endCursor
         }
         nodes {
+          id
           isResolved
           isOutdated
           comments(first: 100) {
@@ -3218,6 +3221,56 @@ pub async fn edit_pull_request_review_comment(
     Ok(())
 }
 
+pub async fn set_pull_request_review_thread_resolved(
+    thread_id: &str,
+    resolved: bool,
+) -> Result<()> {
+    if thread_id.trim().is_empty() {
+        bail!("review thread id is required");
+    }
+    let (mutation, action) = if resolved {
+        (
+            r#"
+mutation($threadId: ID!) {
+  resolveReviewThread(input: {threadId: $threadId}) {
+    thread {
+      id
+      isResolved
+    }
+  }
+}
+"#,
+            "resolve",
+        )
+    } else {
+        (
+            r#"
+mutation($threadId: ID!) {
+  unresolveReviewThread(input: {threadId: $threadId}) {
+    thread {
+      id
+      isResolved
+    }
+  }
+}
+"#,
+            "unresolve",
+        )
+    };
+
+    run_gh_json(&[
+        "api".to_string(),
+        "graphql".to_string(),
+        "-f".to_string(),
+        format!("query={mutation}"),
+        "-F".to_string(),
+        format!("threadId={thread_id}"),
+    ])
+    .await
+    .with_context(|| format!("failed to {action} review thread {thread_id}"))?;
+    Ok(())
+}
+
 pub async fn edit_item_metadata(
     repository: &str,
     number: u64,
@@ -3989,7 +4042,7 @@ fn parse_pull_request_review_comments_output(
         .map(|comment| {
             let thread_state = comment
                 .id
-                .and_then(|id| thread_states.get(&id).copied())
+                .and_then(|id| thread_states.get(&id).cloned())
                 .unwrap_or_default();
             pull_request_review_comment_preview(comment, viewer_login, thread_state, false)
         })
@@ -4031,6 +4084,7 @@ fn pull_request_review_comment_preview(
             .map(ReactionSummary::from)
             .unwrap_or_default(),
         review: Some(ReviewCommentPreview {
+            thread_id: thread_state.thread_id,
             path: comment.path.unwrap_or_else(|| "-".to_string()),
             line: comment.line,
             original_line: comment.original_line,
@@ -4299,13 +4353,19 @@ fn parse_pull_request_review_thread_states_page(
     let mut states = HashMap::new();
     for thread in threads.nodes.unwrap_or_default() {
         let state = ReviewThreadState {
+            thread_id: thread.id,
             is_resolved: thread.is_resolved,
             is_outdated: thread.is_outdated,
             viewer_can_update: None,
         };
         for comment in thread.comments.nodes.unwrap_or_default() {
             if let Some(id) = comment.database_id {
-                states.insert(id, state.with_viewer_can_update(comment.viewer_can_update));
+                states.insert(
+                    id,
+                    state
+                        .clone()
+                        .with_viewer_can_update(comment.viewer_can_update),
+                );
             }
         }
     }
@@ -7103,6 +7163,7 @@ mod tests {
             &HashMap::from([(
                 10,
                 ReviewThreadState {
+                    thread_id: Some("PRRT_kwDOA1".to_string()),
                     is_resolved: true,
                     is_outdated: false,
                     viewer_can_update: Some(true),
@@ -7130,6 +7191,7 @@ mod tests {
             review.diff_hunk.as_deref(),
             Some("@@ -55,6 +55,7 @@ fn main() {\n line 55\n+line 57\n line 58")
         );
+        assert_eq!(review.thread_id.as_deref(), Some("PRRT_kwDOA1"));
         assert!(review.is_resolved);
         assert!(!review.is_outdated);
     }
@@ -7315,6 +7377,7 @@ mod tests {
                   },
                   "nodes": [
                     {
+                      "id": "PRRT_resolved",
                       "isResolved": true,
                       "isOutdated": false,
                       "comments": {
@@ -7325,6 +7388,7 @@ mod tests {
                       }
                     },
                     {
+                      "id": "PRRT_outdated",
                       "isResolved": false,
                       "isOutdated": true,
                       "comments": {
@@ -7349,6 +7413,7 @@ mod tests {
         assert_eq!(
             states.get(&10),
             Some(&ReviewThreadState {
+                thread_id: Some("PRRT_resolved".to_string()),
                 is_resolved: true,
                 is_outdated: false,
                 viewer_can_update: Some(true),
@@ -7357,6 +7422,7 @@ mod tests {
         assert_eq!(
             states.get(&20),
             Some(&ReviewThreadState {
+                thread_id: Some("PRRT_outdated".to_string()),
                 is_resolved: false,
                 is_outdated: true,
                 viewer_can_update: None,

--- a/src/log.rs
+++ b/src/log.rs
@@ -158,16 +158,13 @@ fn looks_like_github_rate_limit(message: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::{Error, ErrorKind};
+    use std::io::Error;
 
     #[test]
     fn recent_entries_are_newest_first_and_flag_rate_limits() {
         clear_gh_log_entries();
         let request = start_gh_request("gh api", "gh api /rate_limit", None);
-        fail_gh_request_to_start(
-            request,
-            &Error::new(ErrorKind::Other, "HTTP 403: API rate limit exceeded"),
-        );
+        fail_gh_request_to_start(request, &Error::other("HTTP 403: API rate limit exceeded"));
 
         let entries = recent_gh_log_entries();
         assert_eq!(entries.len(), 1);

--- a/src/model.rs
+++ b/src/model.rs
@@ -185,6 +185,8 @@ impl CommentPreviewKind {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReviewCommentPreview {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thread_id: Option<String>,
     pub path: String,
     #[serde(default)]
     pub line: Option<u64>,


### PR DESCRIPTION
Closes #62.

## Summary
- carry GitHub review thread node ids into inline review comment metadata
- add resolve/unresolve review thread GraphQL mutations
- wire the Details `z` shortcut and command palette action to toggle the selected inline review thread

## Tests
- cargo fmt --check
- cargo test