### PR TITLE
fix: support tmux-safe editor submit shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,10 +145,10 @@ Press `?` in the TUI for the live shortcut reference. The top-right status shows
 | `t` | Change or clear the selected issue/PR milestone |
 | `y` / `Enter` | Confirm the current action in the confirmation dialog |
 | `Enter` in Reviewer Action | Submit the reviewer login list |
-| `Ctrl+Enter` | Send a comment or save the active issue/PR editor dialog |
+| `Ctrl+Enter` / `Ctrl+O` | Send a comment or save the active issue/PR editor dialog |
 | `Ctrl+S` / `Cmd+S` in editor dialogs | Save the current comment, issue, or pull request draft |
 | `@` in editor dialogs | Search GitHub accounts for mention completion; `Up`/`Down` choose and `Tab`/`Enter` insert |
-| `Ctrl+Enter` in issue dialog | Create the issue |
+| `Ctrl+Enter` / `Ctrl+O` in issue dialog | Create the issue |
 | `←` / `→` / `↑` / `↓` in editor dialogs | Move the cursor by character or rendered line |
 | `Home` / `End` in editor dialogs | Jump to the start or end of the current line |
 | `Ctrl+W` / `Alt+Backspace` in editor dialogs | Delete the previous word |
@@ -188,7 +188,7 @@ Diff review ranges:
 - Press `m` on a diff line to begin a range, move the highlight, then press `e` to end it.
 - Press `c` after ending a range to post an inline review comment for the selected range.
 - With the mouse, single click selects one diff line. Double click begins a range, then single click the end line to complete it.
-- Press `s` to open the review summary editor, use `Tab` or `1` / `2` / `3` to choose comment, request changes, or approve, then press `Ctrl+Enter` to submit.
+- Press `s` to open the review summary editor, use `Tab` or `1` / `2` / `3` to choose comment, request changes, or approve, then press `Ctrl+Enter` or `Ctrl+O` to submit.
 - Press `Ctrl+P` in the review summary editor to create a pending review draft, then press `s` later to submit it or `D` to discard it.
 
 Local PR checkout:
@@ -268,6 +268,7 @@ issue_labels = ["E-easy"]
 [defaults]
 view = "pull_requests"
 command_palette_key = ":"
+editor_submit_key = "Ctrl+O"
 theme = "auto"
 log_level = "info"
 pr_per_page = 50
@@ -311,7 +312,7 @@ Use `[[saved_search_filters]]` for named PR/issue searches that should be editab
 
 When `ghr` starts inside a Git checkout with a GitHub remote, it adds that repository as a repo tab if it is not already configured and saves it back to `config.toml` with `local_dir` set to the launch directory. If the checkout has more than one GitHub remote, ghr opens a startup modal so you can choose the remote, then stores non-origin choices as `remote = "upstream"` or whichever remote you selected. If the repo already exists in the config but has no `local_dir`, `ghr` fills that field without overwriting an existing value.
 
-Set `command_palette_key` to change the command palette shortcut. Printable keys such as `":"` are treated as text while typing in search, filter, and editor dialogs; use a modified key such as `"Ctrl+L"` if you want the palette to open from those text inputs.
+Set `command_palette_key` to change the command palette shortcut. Printable keys such as `":"` are treated as text while typing in search, filter, and editor dialogs; use a modified key such as `"Ctrl+L"` if you want the palette to open from those text inputs. Set `editor_submit_key` to add a custom submit shortcut for editor dialogs; `Ctrl+Enter` and `Ctrl+O` are always accepted.
 
 Set `theme` to `"auto"`, `"dark"`, or `"light"` to switch the base TUI palette. Set `theme_name` for a fixed named theme such as `"catppuccin_mocha"`, `"gruvbox_light"`, or `"github_dark"`. `auto` follows the macOS system appearance and falls back to dark when the system theme cannot be detected; fixed themes do not auto-switch.
 

--- a/docs/script.js
+++ b/docs/script.js
@@ -41,7 +41,7 @@ const shortcuts = [
   ["Merge Dialog", "m / s / r", "Choose merge, squash, or rebase"],
   ["Merge Dialog", "Tab", "Cycle merge method"],
   ["Dialog", "y / Enter", "Confirm the current action"],
-  ["Editor", "Ctrl+Enter", "Send, update, create, or submit from editor dialogs"],
+  ["Editor", "Ctrl+Enter / Ctrl+O", "Send, update, create, or submit from editor dialogs"],
   ["Editor", "Ctrl+S / Cmd+S", "Save the current comment, issue, or pull request draft"],
   ["Editor", "@", "Search GitHub accounts for mention completion; Up/Down choose and Tab/Enter insert"],
   ["Editor", "Arrows", "Move the cursor by character or rendered line"],

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,5 +1,5 @@
 use std::collections::{HashMap, HashSet};
-#[cfg(all(not(test), unix, not(target_os = "macos")))]
+#[cfg(all(not(test), unix))]
 use std::env;
 use std::io;
 use std::io::IsTerminal;
@@ -37,8 +37,9 @@ use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use tracing::{debug, error, warn};
 
 use crate::config::{
-    Config, CurrentRepoRemotePrompt, DEFAULT_COMMAND_PALETTE_KEY, GitHubRemoteCandidate,
-    RepoConfig, SavedSearchFilterConfig, github_repo_from_remote_url, repo_remote_config_value,
+    Config, CurrentRepoRemotePrompt, DEFAULT_COMMAND_PALETTE_KEY, DEFAULT_EDITOR_SUBMIT_KEY,
+    GitHubRemoteCandidate, RepoConfig, SavedSearchFilterConfig, github_repo_from_remote_url,
+    repo_remote_config_value,
 };
 use crate::dirs::Paths;
 use crate::github::{
@@ -116,7 +117,10 @@ use drafts::*;
 use editor::*;
 use global_search::*;
 use input::*;
-use keymap::{command_palette_key_binding, normalized_command_palette_key};
+use keymap::{
+    command_palette_key_binding, editor_submit_key_binding, normalized_command_palette_key,
+    normalized_editor_submit_key,
+};
 use layout::{
     block_inner, body_areas_with_ratio, centered_rect, centered_rect_width,
     centered_rect_with_size, details_area_for, page_areas, rect_contains,
@@ -1606,6 +1610,7 @@ struct AppState {
     startup_dialog: Option<StartupDialog>,
     message_dialog: Option<MessageDialog>,
     mouse_capture_enabled: bool,
+    editor_submit_key: String,
     details_text_drag: Option<DetailsTextDrag>,
     details_text_selection: Option<DetailsTextSelection>,
     dialog_text_drag: Option<DialogTextDrag>,
@@ -1857,6 +1862,7 @@ pub async fn run(
     app.load_repo_candidate_cache(repo_candidate_cache);
     app.load_editor_drafts(editor_drafts);
     app.command_palette_key = normalized_command_palette_key(&config.defaults.command_palette_key);
+    app.editor_submit_key = normalized_editor_submit_key(&config.defaults.editor_submit_key);
     let startup_setup_dialog = startup_setup_dialog();
     if let Some(dialog) = startup_setup_dialog {
         app.show_setup_dialog(dialog);
@@ -1878,6 +1884,9 @@ pub async fn run(
         );
     }
     app.apply_theme_preference(&config);
+
+    #[cfg(all(not(test), unix))]
+    let _tmux_extended_keys_guard = prepare_tmux_extended_keys();
 
     enable_raw_mode()?;
     let mut stdout = io::stdout();
@@ -2297,9 +2306,87 @@ const UNIX_CLIPBOARD_COMMANDS: &[ClipboardCommand] = &[
     },
 ];
 
-#[cfg(all(not(test), unix, not(target_os = "macos")))]
+#[cfg(all(not(test), unix))]
 fn env_var_present(name: &str) -> bool {
     env::var_os(name).is_some_and(|value| !value.as_os_str().is_empty())
+}
+
+#[cfg(all(not(test), unix))]
+struct TmuxExtendedKeysGuard {
+    previous: String,
+}
+
+#[cfg(all(not(test), unix))]
+impl Drop for TmuxExtendedKeysGuard {
+    fn drop(&mut self) {
+        if let Err(error) = set_tmux_extended_keys(&self.previous) {
+            debug!(
+                previous = %self.previous,
+                error = %error,
+                "failed to restore tmux extended-keys option"
+            );
+        }
+    }
+}
+
+#[cfg(all(not(test), unix))]
+fn prepare_tmux_extended_keys() -> Option<TmuxExtendedKeysGuard> {
+    if !env_var_present("TMUX") {
+        return None;
+    }
+
+    let previous = match tmux_extended_keys() {
+        Ok(value) => value,
+        Err(error) => {
+            debug!(error = %error, "failed to read tmux extended-keys option");
+            return None;
+        }
+    };
+    if tmux_extended_keys_enabled(&previous) {
+        return None;
+    }
+
+    match set_tmux_extended_keys("on") {
+        Ok(()) => Some(TmuxExtendedKeysGuard { previous }),
+        Err(error) => {
+            debug!(error = %error, "failed to enable tmux extended-keys option");
+            None
+        }
+    }
+}
+
+#[cfg(all(not(test), unix))]
+fn tmux_extended_keys_enabled(value: &str) -> bool {
+    matches!(value.trim(), "on" | "always")
+}
+
+#[cfg(all(not(test), unix))]
+fn tmux_extended_keys() -> io::Result<String> {
+    tmux_output(&["show-options", "-qv", "extended-keys"])
+}
+
+#[cfg(all(not(test), unix))]
+fn set_tmux_extended_keys(value: &str) -> io::Result<()> {
+    tmux_output(&["set-option", "-q", "extended-keys", value]).map(|_| ())
+}
+
+#[cfg(all(not(test), unix))]
+fn tmux_output(args: &[&str]) -> io::Result<String> {
+    let output = Command::new("tmux")
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()?;
+
+    if !output.status.success() {
+        return Err(io::Error::other(command_failure_message(
+            "tmux",
+            &output.status.to_string(),
+            &output.stderr,
+        )));
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
 #[cfg(any(test, all(not(test), unix, not(target_os = "macos"))))]
@@ -2555,11 +2642,14 @@ fn clipboard_copy_error(errors: &[String]) -> io::Error {
 }
 
 fn is_comment_submit_key(key: KeyEvent) -> bool {
-    if !key.modifiers.contains(KeyModifiers::CONTROL) {
-        return false;
+    if key.modifiers.contains(KeyModifiers::CONTROL) {
+        return matches!(
+            key.code,
+            KeyCode::Enter | KeyCode::Char('\n' | 'm' | 'M' | 'o' | 'O')
+        );
     }
 
-    matches!(key.code, KeyCode::Enter | KeyCode::Char('\n'))
+    key.modifiers.contains(KeyModifiers::ALT) && matches!(key.code, KeyCode::Enter)
 }
 
 fn is_ctrl_c_key(key: KeyEvent) -> bool {
@@ -2965,6 +3055,7 @@ impl AppState {
             startup_dialog: None,
             message_dialog: None,
             mouse_capture_enabled: true,
+            editor_submit_key: DEFAULT_EDITOR_SUBMIT_KEY.to_string(),
             details_text_drag: None,
             details_text_selection: None,
             dialog_text_drag: None,
@@ -2996,6 +3087,11 @@ impl AppState {
 
     fn load_saved_search_filters(&mut self, config: &Config) {
         self.global_search_saved_by_repo = saved_search_map_from_config(config);
+    }
+
+    fn is_editor_submit_key(&self, key: KeyEvent) -> bool {
+        is_comment_submit_key(key)
+            || editor_submit_key_binding(&self.editor_submit_key).matches(key)
     }
 
     fn effective_theme(config: &Config) -> ThemeName {
@@ -5250,7 +5346,7 @@ impl AppState {
         else {
             return;
         };
-        let commands = command_palette_commands(&self.command_palette_key);
+        let commands = command_palette_commands(&self.command_palette_key, &self.editor_submit_key);
         let len = self.command_palette_match_indices(&commands, &query).len();
         if let Some(palette) = &mut self.command_palette {
             palette.selected = move_wrapping(palette.selected, len, delta);
@@ -5292,6 +5388,9 @@ impl AppState {
             PaletteAction::ShowCommandPalette => {
                 self.show_command_palette();
                 false
+            }
+            PaletteAction::SubmitEditor => {
+                self.submit_active_editor_from_command(config, paths, store, tx, area)
             }
             PaletteAction::Refresh => {
                 trigger_refresh(self, config, store, tx);
@@ -5376,9 +5475,41 @@ impl AppState {
         }
     }
 
+    fn submit_active_editor_from_command(
+        &mut self,
+        config: &mut Config,
+        paths: &Paths,
+        store: &SnapshotStore,
+        tx: &UnboundedSender<AppMsg>,
+        area: Option<Rect>,
+    ) -> bool {
+        if !self.editor_dialog_active() {
+            self.status = "no active editor to submit".to_string();
+            return false;
+        }
+
+        handle_key_in_area_mut(
+            self,
+            KeyEvent::new(KeyCode::Char('o'), KeyModifiers::CONTROL),
+            config,
+            paths,
+            store,
+            tx,
+            area,
+        )
+    }
+
+    fn editor_dialog_active(&self) -> bool {
+        self.comment_dialog.is_some()
+            || self.issue_dialog.is_some()
+            || self.pr_create_dialog.is_some()
+            || self.review_submit_dialog.is_some()
+            || self.item_edit_dialog.is_some()
+    }
+
     fn selected_command_palette_command(&self) -> Option<PaletteCommand> {
         let palette = self.command_palette.as_ref()?;
-        let commands = command_palette_commands(&self.command_palette_key);
+        let commands = command_palette_commands(&self.command_palette_key, &self.editor_submit_key);
         let matches = self.command_palette_match_indices(&commands, &palette.query);
         let selected = palette.selected.min(matches.len().saturating_sub(1));
         matches
@@ -8584,7 +8715,7 @@ impl AppState {
             KeyCode::BackTab => self.move_item_edit_field(-1),
             KeyCode::PageDown => self.scroll_item_edit_body(6, area),
             KeyCode::PageUp => self.scroll_item_edit_body(-6, area),
-            _ if is_comment_submit_key(key) => {
+            _ if self.is_editor_submit_key(key) => {
                 if let Some(pending) = self.prepare_item_edit_submit() {
                     submit(pending);
                 }
@@ -9120,7 +9251,7 @@ impl AppState {
             }
             KeyCode::PageDown => self.scroll_review_submit_dialog(6, area),
             KeyCode::PageUp => self.scroll_review_submit_dialog(-6, area),
-            _ if is_comment_submit_key(key) => {
+            _ if self.is_editor_submit_key(key) => {
                 if let Some(pending) = self.prepare_review_submit() {
                     submit(pending);
                 }
@@ -10342,7 +10473,7 @@ impl AppState {
             return;
         }
 
-        if is_comment_submit_key(key) {
+        if self.is_editor_submit_key(key) {
             if let Some(pending) = self.prepare_issue_create() {
                 submit(pending);
             }
@@ -10500,7 +10631,7 @@ impl AppState {
             return;
         }
 
-        if is_comment_submit_key(key) {
+        if self.is_editor_submit_key(key) {
             if let Some(pending) = self.prepare_pr_create() {
                 submit(pending);
             }
@@ -10652,7 +10783,7 @@ impl AppState {
             }
             KeyCode::PageDown => self.scroll_comment_dialog(6, area),
             KeyCode::PageUp => self.scroll_comment_dialog(-6, area),
-            _ if is_comment_submit_key(key) => {
+            _ if self.is_editor_submit_key(key) => {
                 if let Some(pending) = self.prepare_comment_submit() {
                     submit(pending);
                 }

--- a/src/app/command_palette.rs
+++ b/src/app/command_palette.rs
@@ -30,6 +30,7 @@ pub(super) enum PaletteAction {
     ShowGhLog,
     ShowHelp,
     ShowCommandPalette,
+    SubmitEditor,
     Refresh,
     RecentItems,
     SetColorTheme,
@@ -118,7 +119,10 @@ pub(super) fn command_palette_result_line(
     ])
 }
 
-pub(super) fn command_palette_commands(command_palette_key: &str) -> Vec<PaletteCommand> {
+pub(super) fn command_palette_commands(
+    command_palette_key: &str,
+    editor_submit_key: &str,
+) -> Vec<PaletteCommand> {
     let mut commands = vec![
         palette_command(
             "Show Command Palette",
@@ -667,11 +671,11 @@ pub(super) fn command_palette_commands(command_palette_key: &str) -> Vec<Palette
             palette_key(KeyCode::Char('y')),
         ),
         palette_command(
-            "Submit Comment",
-            "Ctrl+Enter",
-            "Comment Editor",
-            "Send or update the current comment",
-            palette_ctrl_key(KeyCode::Enter),
+            "Submit Editor",
+            editor_submit_key_label(editor_submit_key),
+            "Editor",
+            "Send, update, create, or submit from the active editor dialog",
+            PaletteAction::SubmitEditor,
         ),
         palette_command(
             "Insert Comment Newline",
@@ -780,10 +784,10 @@ pub(super) fn command_palette_commands(command_palette_key: &str) -> Vec<Palette
         ),
         palette_command(
             "Create Issue from Dialog",
-            "Ctrl+Enter",
+            editor_submit_key_label(editor_submit_key),
             "Issue Dialog",
             "Create the issue from the issue dialog",
-            palette_ctrl_key(KeyCode::Enter),
+            PaletteAction::SubmitEditor,
         ),
     ];
 
@@ -825,6 +829,15 @@ fn palette_command(
         detail,
         action,
     }
+}
+
+fn editor_submit_key_label(editor_submit_key: &str) -> String {
+    let mut keys = vec!["Ctrl+Enter".to_string(), "Ctrl+O".to_string()];
+    let configured = editor_submit_key.trim();
+    if !configured.is_empty() && !keys.iter().any(|key| key.eq_ignore_ascii_case(configured)) {
+        keys.push(configured.to_string());
+    }
+    keys.join(" / ")
 }
 
 fn palette_key(code: KeyCode) -> PaletteAction {
@@ -976,13 +989,18 @@ fn command_palette_search_symbol(ch: char) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::DEFAULT_COMMAND_PALETTE_KEY;
+    use crate::config::{DEFAULT_COMMAND_PALETTE_KEY, DEFAULT_EDITOR_SUBMIT_KEY};
 
     #[test]
     fn command_palette_lists_and_fuzzy_filters_shortcuts() {
-        let commands = command_palette_commands(DEFAULT_COMMAND_PALETTE_KEY);
+        let commands =
+            command_palette_commands(DEFAULT_COMMAND_PALETTE_KEY, DEFAULT_EDITOR_SUBMIT_KEY);
         assert!(commands.iter().any(|command| command.keys == ":"));
-        assert!(commands.iter().any(|command| command.keys == "Ctrl+Enter"));
+        assert!(
+            commands
+                .iter()
+                .any(|command| command.keys == "Ctrl+Enter / Ctrl+O")
+        );
         assert!(
             commands
                 .iter()
@@ -1116,5 +1134,16 @@ mod tests {
                 .iter()
                 .any(|command| command.title == "Copy Content")
         );
+    }
+
+    #[test]
+    fn command_palette_shows_custom_editor_submit_key() {
+        let commands = command_palette_commands(DEFAULT_COMMAND_PALETTE_KEY, "Ctrl+T");
+        let submit = commands
+            .iter()
+            .find(|command| command.title == "Submit Editor")
+            .expect("submit editor command");
+
+        assert_eq!(submit.keys, "Ctrl+Enter / Ctrl+O / Ctrl+T");
     }
 }

--- a/src/app/dialogs.rs
+++ b/src/app/dialogs.rs
@@ -302,7 +302,7 @@ pub(super) fn draw_command_palette(
     area: Rect,
     command_palette_key: &str,
 ) {
-    let commands = command_palette_commands(command_palette_key);
+    let commands = command_palette_commands(command_palette_key, &app.editor_submit_key);
     let matches = app.command_palette_match_indices(&commands, &palette.query);
     let dialog_area = command_palette_area(area);
     let inner = block_inner(dialog_area);
@@ -2084,7 +2084,7 @@ pub(super) fn draw_issue_dialog(
     let footer = if running {
         "working..."
     } else {
-        "Tab: field  Ctrl+Enter: create  Ctrl+S/click: save draft  arrows/Home/End edit  Ctrl+W/U/K/X word/line"
+        "Tab: field  Ctrl+Enter/Ctrl+O: create  Ctrl+S/click: save draft  arrows/Home/End edit  Ctrl+W/U/K/X word/line"
     };
 
     let block = Block::default()
@@ -2156,7 +2156,7 @@ pub(super) fn draw_pr_create_dialog(
     let footer = if running {
         "working..."
     } else {
-        "Tab: field  Ctrl+Enter: create PR  Ctrl+S/click: save draft  arrows/Home/End edit  Ctrl+W/U/K/X word/line"
+        "Tab: field  Ctrl+Enter/Ctrl+O: create PR  Ctrl+S/click: save draft  arrows/Home/End edit  Ctrl+W/U/K/X word/line"
     };
 
     let block = Block::default()
@@ -3050,7 +3050,7 @@ pub(super) fn draw_item_edit_dialog(
     let footer = if running {
         "working..."
     } else {
-        "Tab: field  Ctrl+Enter: save  Enter: add/remove candidate  Backspace: remove last when empty  Esc: cancel"
+        "Tab: field  Ctrl+Enter/Ctrl+O: save  Enter: add/remove candidate  Backspace: remove last when empty  Esc: cancel"
     };
     let block = Block::default()
         .borders(Borders::ALL)
@@ -4116,7 +4116,7 @@ pub(super) fn draw_review_submit_dialog(
         area,
         dialog_area,
         modal_footer_line(
-            "Tab/1/2/3: event    Ctrl+Enter: submit    arrows/Home/End/Ctrl+W/U/K/X edit    click cursor",
+            "Tab/1/2/3: event    Ctrl+Enter/Ctrl+O: submit    arrows/Home/End/Ctrl+W/U/K/X edit    click cursor",
         ),
     );
     if let Some(position) = review_submit_cursor_position(
@@ -4192,8 +4192,7 @@ pub(super) fn draw_comment_editor(
         lines.push(Line::from(""));
     }
     apply_dialog_text_selection(app, DialogTextTarget::Comment, scroll, 0, &mut lines);
-    let footer =
-        "Ctrl+Enter: send    Ctrl+S/click: save draft    arrows/Home/End edit    click cursor";
+    let footer = "Ctrl+Enter/Ctrl+O: send    Ctrl+S/click: save draft    arrows/Home/End edit    click cursor";
     let block = Block::default()
         .borders(Borders::ALL)
         .border_style(themed_fg_style(Color::LightMagenta))
@@ -4710,6 +4709,7 @@ pub(super) fn help_dialog_content(command_palette_key: &str) -> Vec<Line<'static
         help_key_line("Alt+D", "delete next word"),
         help_key_line("Ctrl+U / Ctrl+K", "delete to line start / end"),
         help_key_line("Ctrl+X", "delete current line"),
+        help_key_line("Ctrl+Enter / Ctrl+O", "submit the active editor"),
         help_key_line("Ctrl+S / Cmd+S", "save the active editor draft"),
         help_key_line("Ctrl+Z / Cmd+Z", "undo text edits"),
         help_key_line("Ctrl+R / Cmd+Shift+Z", "redo text edits"),

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -228,6 +228,7 @@ pub(super) fn handle_key_in_area_mut(
     area: Option<Rect>,
 ) -> bool {
     app.command_palette_key = normalized_command_palette_key(&config.defaults.command_palette_key);
+    app.editor_submit_key = normalized_editor_submit_key(&config.defaults.editor_submit_key);
 
     if is_ctrl_c_key(key) {
         return true;

--- a/src/app/keymap.rs
+++ b/src/app/keymap.rs
@@ -1,6 +1,6 @@
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
-use crate::config::DEFAULT_COMMAND_PALETTE_KEY;
+use crate::config::{DEFAULT_COMMAND_PALETTE_KEY, DEFAULT_EDITOR_SUBMIT_KEY};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct KeyBinding {
@@ -48,6 +48,16 @@ pub(super) fn normalized_command_palette_key(value: &str) -> String {
 pub(super) fn command_palette_key_binding(value: &str) -> KeyBinding {
     parse_key_binding(value).unwrap_or_else(|| {
         parse_key_binding(DEFAULT_COMMAND_PALETTE_KEY).expect("default command palette key parses")
+    })
+}
+
+pub(super) fn normalized_editor_submit_key(value: &str) -> String {
+    editor_submit_key_binding(value).label
+}
+
+pub(super) fn editor_submit_key_binding(value: &str) -> KeyBinding {
+    parse_key_binding(value).unwrap_or_else(|| {
+        parse_key_binding(DEFAULT_EDITOR_SUBMIT_KEY).expect("default editor submit key parses")
     })
 }
 

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -4247,8 +4247,8 @@ fn help_dialog_content_lists_core_shortcuts() {
     assert!(text.contains("terminal text selection"));
     assert!(text.contains("@ / -"));
     assert!(text.contains("add a reaction"));
+    assert!(text.contains("Ctrl+Enter / Ctrl+O"));
     assert!(!text.contains("Reaction Dialog"));
-    assert!(!text.contains("Ctrl+Enter"));
 }
 
 #[test]
@@ -4420,7 +4420,7 @@ fn modified_command_palette_key_can_open_over_text_input() {
 #[test]
 fn command_palette_orders_recently_selected_commands_first() {
     let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
-    let commands = command_palette_commands(DEFAULT_COMMAND_PALETTE_KEY);
+    let commands = command_palette_commands(DEFAULT_COMMAND_PALETTE_KEY, DEFAULT_EDITOR_SUBMIT_KEY);
     app.recent_commands = vec![
         RecentCommand {
             id: "Refresh".to_string(),
@@ -4441,7 +4441,7 @@ fn command_palette_orders_recently_selected_commands_first() {
 #[test]
 fn command_palette_recent_ties_fall_back_to_default_order() {
     let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
-    let commands = command_palette_commands(DEFAULT_COMMAND_PALETTE_KEY);
+    let commands = command_palette_commands(DEFAULT_COMMAND_PALETTE_KEY, DEFAULT_EDITOR_SUBMIT_KEY);
     let selected_at = DateTime::from_timestamp(1_700_000_000, 0).unwrap();
     app.recent_commands = vec![
         RecentCommand {
@@ -4547,7 +4547,7 @@ fn command_palette_info_opens_runtime_info_dialog() {
 
 #[test]
 fn command_palette_does_not_include_debug_command() {
-    let commands = command_palette_commands(DEFAULT_COMMAND_PALETTE_KEY);
+    let commands = command_palette_commands(DEFAULT_COMMAND_PALETTE_KEY, DEFAULT_EDITOR_SUBMIT_KEY);
     assert!(commands.iter().any(|command| command.title == "Info"));
     assert!(!commands.iter().any(|command| command.title == "Debug"));
 }
@@ -4591,6 +4591,37 @@ fn command_palette_log_opens_recent_gh_request_dialog() {
     );
     assert_eq!(app.status, "log");
     clear_gh_log_entries();
+}
+
+#[tokio::test]
+async fn command_palette_submit_editor_submits_comment_dialog() {
+    let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
+    app.start_new_comment_dialog();
+    app.comment_dialog.as_mut().unwrap().body.set_text("hello");
+    app.sections[0].items[0].number = None;
+    app.command_palette = Some(CommandPalette {
+        query: "submit editor".to_string(),
+        selected: 0,
+    });
+    let (tx, _rx) = mpsc::unbounded_channel();
+    let mut config = Config::default();
+    let paths = unique_test_paths("command-palette-submit-editor");
+    let store = SnapshotStore::new(paths.db_path.clone());
+
+    assert!(!handle_key_in_area_mut(
+        &mut app,
+        key(KeyCode::Enter),
+        &mut config,
+        &paths,
+        &store,
+        &tx,
+        None,
+    ));
+
+    assert!(app.command_palette.is_none());
+    assert!(app.comment_dialog.is_none());
+    assert!(app.posting_comment);
+    assert_eq!(app.status, "posting comment");
 }
 
 #[test]
@@ -17522,7 +17553,84 @@ fn ctrl_j_variant_also_submits_comment_dialog_for_terminals_without_enhanced_ent
         KeyCode::Char('\n'),
         crossterm::event::KeyModifiers::CONTROL
     )));
+    assert!(is_comment_submit_key(KeyEvent::new(
+        KeyCode::Char('m'),
+        crossterm::event::KeyModifiers::CONTROL
+    )));
     assert!(!is_comment_submit_key(key(KeyCode::Enter)));
+}
+
+#[test]
+fn alt_enter_variant_also_submits_for_tmux_without_enhanced_enter() {
+    assert!(is_comment_submit_key(alt_key(KeyCode::Enter)));
+    assert!(!is_comment_submit_key(alt_key(KeyCode::Char('m'))));
+}
+
+#[test]
+fn ctrl_o_variant_also_submits_for_tmux_without_enhanced_keys() {
+    assert!(is_comment_submit_key(ctrl_key(KeyCode::Char('o'))));
+    assert!(!is_comment_submit_key(key(KeyCode::Char('o'))));
+}
+
+#[test]
+fn ctrl_m_variant_submits_comment_dialog_instead_of_inserting_newline() {
+    let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
+    app.start_new_comment_dialog();
+    app.comment_dialog.as_mut().unwrap().body.set_text("hello");
+    let mut submitted = None;
+
+    app.handle_comment_dialog_key_with_submit(ctrl_key(KeyCode::Char('m')), None, |pending| {
+        submitted = Some(pending.body);
+    });
+
+    assert!(app.comment_dialog.is_none());
+    assert_eq!(submitted.as_deref(), Some("hello"));
+}
+
+#[test]
+fn ctrl_o_variant_submits_comment_dialog() {
+    let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
+    app.start_new_comment_dialog();
+    app.comment_dialog.as_mut().unwrap().body.set_text("hello");
+    let mut submitted = None;
+
+    app.handle_comment_dialog_key_with_submit(ctrl_key(KeyCode::Char('o')), None, |pending| {
+        submitted = Some(pending.body);
+    });
+
+    assert!(app.comment_dialog.is_none());
+    assert_eq!(submitted.as_deref(), Some("hello"));
+}
+
+#[test]
+fn custom_editor_submit_key_submits_comment_dialog() {
+    let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
+    app.editor_submit_key = normalized_editor_submit_key("Ctrl+T");
+    app.start_new_comment_dialog();
+    app.comment_dialog.as_mut().unwrap().body.set_text("hello");
+    let mut submitted = None;
+
+    app.handle_comment_dialog_key_with_submit(ctrl_key(KeyCode::Char('t')), None, |pending| {
+        submitted = Some(pending.body);
+    });
+
+    assert!(app.comment_dialog.is_none());
+    assert_eq!(submitted.as_deref(), Some("hello"));
+}
+
+#[test]
+fn alt_enter_variant_submits_comment_dialog() {
+    let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
+    app.start_new_comment_dialog();
+    app.comment_dialog.as_mut().unwrap().body.set_text("hello");
+    let mut submitted = None;
+
+    app.handle_comment_dialog_key_with_submit(alt_key(KeyCode::Enter), None, |pending| {
+        submitted = Some(pending.body);
+    });
+
+    assert!(app.comment_dialog.is_none());
+    assert_eq!(submitted.as_deref(), Some("hello"));
 }
 
 #[test]
@@ -19963,6 +20071,10 @@ fn key(code: KeyCode) -> KeyEvent {
 
 fn ctrl_key(code: KeyCode) -> KeyEvent {
     KeyEvent::new(code, crossterm::event::KeyModifiers::CONTROL)
+}
+
+fn alt_key(code: KeyCode) -> KeyEvent {
+    KeyEvent::new(code, crossterm::event::KeyModifiers::ALT)
 }
 
 fn cmd_key(code: KeyCode) -> KeyEvent {

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,6 +10,7 @@ use crate::state::{GlobalSearchSavedState, GlobalSearchState};
 use crate::theme::{ThemeName, ThemePreference};
 
 pub const DEFAULT_COMMAND_PALETTE_KEY: &str = ":";
+pub const DEFAULT_EDITOR_SUBMIT_KEY: &str = "Ctrl+O";
 pub const DEFAULT_LOG_LEVEL: &str = "info";
 pub const DEFAULT_REPO_REMOTE: &str = "origin";
 
@@ -31,6 +32,7 @@ pub struct Config {
 pub struct Defaults {
     pub view: SectionKind,
     pub command_palette_key: String,
+    pub editor_submit_key: String,
     pub theme: ThemePreference,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub theme_name: Option<ThemeName>,
@@ -625,6 +627,7 @@ impl Default for Defaults {
         Self {
             view: SectionKind::PullRequests,
             command_palette_key: DEFAULT_COMMAND_PALETTE_KEY.to_string(),
+            editor_submit_key: DEFAULT_EDITOR_SUBMIT_KEY.to_string(),
             theme: ThemePreference::Auto,
             theme_name: None,
             log_level: DEFAULT_LOG_LEVEL.to_string(),
@@ -1123,6 +1126,7 @@ mod tests {
 
         assert_eq!(config.defaults.view, SectionKind::PullRequests);
         assert_eq!(config.defaults.command_palette_key, ":");
+        assert_eq!(config.defaults.editor_submit_key, "Ctrl+O");
         assert_eq!(config.defaults.theme, ThemePreference::Dark);
         assert_eq!(config.defaults.log_level, "debug");
         assert_eq!(config.defaults.pr_per_page, 50);
@@ -1175,6 +1179,19 @@ mod tests {
         .expect("custom command palette key should parse");
 
         assert_eq!(config.defaults.command_palette_key, "Ctrl+L");
+    }
+
+    #[test]
+    fn parses_custom_editor_submit_key() {
+        let config = toml::from_str::<Config>(
+            r#"
+            [defaults]
+            editor_submit_key = "Ctrl+T"
+            "#,
+        )
+        .expect("custom editor submit key should parse");
+
+        assert_eq!(config.defaults.editor_submit_key, "Ctrl+T");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Enable `Ctrl+Enter` handling variants and add `Ctrl+O` as a reliable built-in editor submit shortcut.
- Add configurable `[defaults].editor_submit_key` so users can choose an additional submit shortcut for editor dialogs.
- Add a `Submit Editor` command palette action and update help, footer hints, README, and docs shortcut text.
- Try to enable tmux `extended-keys` while ghr is running, restoring the previous tmux option on exit.

## Root Cause

Under tmux, some terminal/client combinations collapse `Ctrl+Enter` to the same carriage-return sequence as plain `Enter`, so crossterm cannot always distinguish the enhanced key event. The new fallback shortcuts and command palette action keep editor submission reachable even when tmux does not forward enhanced `Ctrl+Enter` events.

## Validation

- `cargo fmt`
- `cargo check`
- `cargo test`
- `cargo test --locked`
- `git diff --check`

Addresses #61.