### PR TITLE
Fix tab issues in diff view

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -146,7 +146,9 @@ use status::{
 };
 use switchers::*;
 use tasks::*;
-use text::{display_width, display_width_char, normalize_text, truncate_inline, truncate_text};
+use text::{
+    display_width, display_width_char, expand_tabs, normalize_text, truncate_inline, truncate_text,
+};
 
 const NO_SELECTED_COMMENT_INDEX: usize = usize::MAX;
 const NO_SELECTED_CHECK_RUN_INDEX: usize = usize::MAX;

--- a/src/app/details.rs
+++ b/src/app/details.rs
@@ -9,6 +9,7 @@ const DESCRIPTION_BODY_PADDING: usize = 2;
 const BLOCK_COPY_BUTTON_LABEL: &str = "copy";
 const INLINE_COMMENT_MARKER: &str = "💬 ";
 const INLINE_COMMENT_MULTIPLE_MARKER: &str = "💬* ";
+const DIFF_TAB_WIDTH: usize = 4;
 
 #[derive(Debug, Clone)]
 pub(super) struct DetailsDocument {
@@ -2068,7 +2069,10 @@ pub(super) fn push_diff_line(
     segments.extend([
         DetailSegment::styled(marker, style),
         DetailSegment::styled(" ", style),
-        DetailSegment::styled(truncate_inline(&line.text, content_width), style),
+        DetailSegment::styled(
+            truncate_inline(&expand_tabs(&line.text, DIFF_TAB_WIDTH), content_width),
+            style,
+        ),
     ]);
     builder.push_line(segments);
 }

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -236,6 +236,45 @@ fn diff_document_renders_lazygit_style_gutter() {
 }
 
 #[test]
+fn diff_document_expands_tabs_in_source_lines() {
+    let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
+    app.show_diff();
+    app.diffs.insert(
+        "1".to_string(),
+        DiffState::Loaded(
+            parse_pull_request_diff(
+                "diff --git a/src/lib.rs b/src/lib.rs\n\
+--- a/src/lib.rs\n\
++++ b/src/lib.rs\n\
+@@ -0,0 +1,2 @@\n\
++\tif enabled {\n\
++\t\tprintln!(\"ready\");\n",
+            )
+            .expect("parse diff"),
+        ),
+    );
+
+    let rendered_lines = build_details_document(&app, 96)
+        .lines
+        .iter()
+        .map(Line::to_string)
+        .collect::<Vec<_>>();
+    let first_added = rendered_lines
+        .iter()
+        .find(|line| line.contains("if enabled"))
+        .expect("first tabbed diff line");
+    let second_added = rendered_lines
+        .iter()
+        .find(|line| line.contains("println!"))
+        .expect("second tabbed diff line");
+
+    assert!(!first_added.contains('\t'));
+    assert!(!second_added.contains('\t'));
+    assert!(first_added.contains("│ +     if enabled {"));
+    assert!(second_added.contains("│ +         println!(\"ready\");"));
+}
+
+#[test]
 fn diff_file_header_links_to_head_branch_near_selected_line() {
     let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
     app.show_diff();

--- a/src/app/text.rs
+++ b/src/app/text.rs
@@ -32,6 +32,48 @@ pub(super) fn normalize_text(text: &str) -> String {
         .to_string()
 }
 
+pub(super) fn expand_tabs(text: &str, tab_width: usize) -> String {
+    let tab_width = tab_width.max(1);
+    let mut expanded = String::new();
+    let mut column = 0_usize;
+    let mut last_char_width = None;
+
+    for ch in text.chars() {
+        match ch {
+            '\t' => {
+                let spaces = tab_width - (column % tab_width);
+                for _ in 0..spaces {
+                    expanded.push(' ');
+                }
+                column += spaces;
+                last_char_width = Some(spaces);
+            }
+            '\n' => {
+                expanded.push(ch);
+                column = 0;
+                last_char_width = None;
+            }
+            '\u{fe0f}' => {
+                expanded.push(ch);
+                if let Some(previous_width) = last_char_width
+                    && previous_width < 2
+                {
+                    column += 2 - previous_width;
+                    last_char_width = Some(2);
+                }
+            }
+            _ => {
+                expanded.push(ch);
+                let char_width = display_width_char(ch);
+                column += char_width;
+                last_char_width = Some(char_width);
+            }
+        }
+    }
+
+    expanded
+}
+
 pub(super) fn truncate_text(text: &str, max_chars: usize) -> String {
     if text.chars().count() <= max_chars {
         return text.to_string();


### PR DESCRIPTION
ghr collapses tabs to zero width in the diff view, making source code harder to read.

Related to #71