### PR TITLE
Add octocrab auth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,7 +62,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -73,7 +73,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -81,6 +81,26 @@ name = "anyhow"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+
+[[package]]
+name = "arc-swap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "atomic"
@@ -92,16 +112,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bit-set"
@@ -156,6 +194,39 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "camino"
+version = "1.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2d30e4173c4026932d51d31d6b0613b1fd3014bf3f9f8943d4ba139c437ba0"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0061da739915fae12ea00e16397555ed4371a6bb285431aab930f61b0aa4ba"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "castaway"
@@ -263,12 +334,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -329,6 +416,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -346,6 +445,33 @@ checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
 dependencies = [
  "lab",
  "phf",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -389,6 +515,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -426,7 +563,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -447,7 +586,18 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -460,10 +610,69 @@ dependencies = [
 ]
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "equivalent"
@@ -478,7 +687,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -511,6 +720,22 @@ dependencies = [
  "bit-set",
  "regex",
 ]
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filedescriptor"
@@ -558,6 +783,15 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "futures"
@@ -655,6 +889,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -673,8 +908,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -712,13 +949,16 @@ dependencies = [
  "crossterm",
  "dirs",
  "futures",
+ "http",
  "md5",
+ "octocrab",
  "open",
  "pulldown-cmark",
  "ratatui",
  "rusqlite",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "tokio",
  "toml",
  "tracing",
@@ -726,6 +966,17 @@ dependencies = [
  "tracing-subscriber",
  "tui-textarea-2",
  "unicode-width",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core",
+ "subtle",
 ]
 
 [[package]]
@@ -779,6 +1030,143 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "http"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-serde"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f056c8559e3757392c8d091e796416e4649d8e49e88b8d76df6c002f05027fd"
+dependencies = [
+ "http",
+ "serde",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "log",
+ "rustls",
+ "rustls-native-certs",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "libc",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -803,6 +1191,88 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -813,6 +1283,27 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -901,6 +1392,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "10.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
+dependencies = [
+ "base64",
+ "ed25519-dalek",
+ "getrandom 0.2.17",
+ "hmac",
+ "js-sys",
+ "p256",
+ "p384",
+ "pem",
+ "rand",
+ "rsa",
+ "serde",
+ "serde_json",
+ "sha2",
+ "signature",
+ "simple_asn1",
+ "zeroize",
+]
+
+[[package]]
 name = "kasuari"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -922,6 +1437,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -934,6 +1452,12 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
@@ -969,6 +1493,12 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "litrs"
@@ -1061,7 +1591,7 @@ dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1093,7 +1623,33 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand",
+ "smallvec",
+ "zeroize",
 ]
 
 [[package]]
@@ -1114,12 +1670,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1129,6 +1705,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "octocrab"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27be39870c558e1fbc5a5f8d4a29aa916268c1dbcb9d467f2a9bbab35598060e"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "base64",
+ "bytes",
+ "cargo_metadata",
+ "cfg-if",
+ "chrono",
+ "futures",
+ "futures-util",
+ "getrandom 0.2.17",
+ "http",
+ "http-body",
+ "http-body-util",
+ "http-serde",
+ "hyper",
+ "hyper-rustls",
+ "hyper-timeout",
+ "hyper-util",
+ "jsonwebtoken",
+ "percent-encoding",
+ "pin-project",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "snafu",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tracing",
+ "url",
+ "web-time",
 ]
 
 [[package]]
@@ -1154,6 +1771,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1166,6 +1789,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
 ]
 
 [[package]]
@@ -1190,6 +1837,31 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
@@ -1287,10 +1959,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
 
 [[package]]
 name = "pkg-config"
@@ -1305,10 +2018,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "prettyplease"
@@ -1318,6 +2049,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -1375,6 +2115,18 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
  "rand_core",
 ]
 
@@ -1383,6 +2135,9 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "ratatui"
@@ -1519,6 +2274,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rsqlite-vfs"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1562,7 +2361,54 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1578,16 +2424,75 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "serde"
@@ -1633,11 +2538,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
  "serde",
 ]
 
@@ -1699,6 +2627,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core",
+]
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
 name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1717,6 +2667,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "snafu"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e84b3f4eacbf3a1ce05eac6763b4d629d60cbc94d632e4092c54ade71f1e1a2"
+dependencies = [
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
 name = "sqlite-wasm-rs"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1727,6 +2724,12 @@ dependencies = [
  "rsqlite-vfs",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "static_assertions"
@@ -1762,6 +2765,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "symlink"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1787,6 +2796,23 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1935,6 +2961,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tokio"
 version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1945,8 +2981,9 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
+ "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1958,6 +2995,29 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -2002,11 +3062,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags 2.11.1",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -2076,6 +3185,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "tui-textarea-2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2143,6 +3258,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2185,6 +3325,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
 dependencies = [
  "utf8parse",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
 ]
 
 [[package]]
@@ -2288,6 +3437,17 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2445,12 +3605,85 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
@@ -2553,6 +3786,129 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,13 +21,16 @@ clap = { version = "4", features = ["derive"] }
 crossterm = "0.29"
 dirs = "6"
 futures = "0.3"
+http = "1"
 md5 = "0.8"
+octocrab = { version = "0.54", default-features = false, features = ["default-client", "follow-redirect", "jwt-rust-crypto", "retry", "rustls", "rustls-ring", "timeout", "tracing"] }
 open = "5"
 pulldown-cmark = "0.13"
 ratatui = "0.30"
 rusqlite = { version = "0.40", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+serde_urlencoded = "0.7"
 tokio = { version = "1", features = ["macros", "process", "rt-multi-thread", "sync", "time"] }
 toml = "0.8"
 tracing = "0.1"

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Press `?` in the TUI for the live shortcut reference. The top-right status shows
 | `Ctrl+X` in editor dialogs | Delete the current line |
 | `Ctrl+Z` / `Cmd+Z` in editor dialogs | Undo text edits |
 | `Ctrl+R` / `Cmd+Shift+Z` in editor dialogs | Redo text edits |
-| `r` | Refresh from GitHub |
+| `r` | Refresh the active tab first, then run a full background refresh |
 | `q` / `Ctrl+C` | Save UI state and quit |
 
 ## Commands

--- a/README.md
+++ b/README.md
@@ -32,16 +32,32 @@
 - Built-in `auto` plus named light and dark color themes configured through `defaults.theme` / `defaults.theme_name`; `auto` follows the macOS appearance when available.
 - UI state persistence under `~/.ghr`, including focus, selected item, scroll position, split ratio, and diff mode.
 - Local state under `~/.ghr`: config, SQLite snapshot database, logs, and UI state.
-- Uses the GitHub CLI for authentication, API access, and browser opening behavior.
+- Supports direct GitHub API access with a personal access token, or the GitHub CLI as a compatible fallback.
 
-## Requirements
+## Authentication
 
-- GitHub CLI [gh](https://cli.github.com/)
-- An authenticated GitHub CLI session:
+Choose either authentication method:
+
+1. Set a [personal access token (classic)](https://github.com/settings/tokens):
+
+```bash
+export GHR_GITHUB_TOKEN=ghp_...
+ghr
+```
+
+   For full access to private repositories, select the classic `repo` scope. For public repositories only, use `public_repo` together with `notifications`. The `workflow` scope is not required because ghr does not modify workflow files. GitHub's notification endpoints accept the `notifications` or `repo` scope, and linked private issues, pull requests, and commits require `repo`.
+
+   `GH_TOKEN` and `GITHUB_TOKEN` are also recognized. `GHR_GITHUB_TOKEN` takes precedence. Tokens are read from the environment and are never written to `~/.ghr/config.toml`. Treat the token like a password and give it an expiration date.
+
+   Fine-grained PATs (`github_pat_...`) provide partial repository access, but are not recommended for the complete ghr experience. GitHub's Notifications API does not support fine-grained PATs, so Inbox loading and read/done/mute actions will fail. Fine-grained PATs are also limited to one resource owner, cannot access multiple organizations at once, may not support every Checks API operation, and can require organization approval or a shorter lifetime. See GitHub's documentation for [notification authentication](https://docs.github.com/en/rest/activity/notifications) and [fine-grained PAT limitations](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#fine-grained-personal-access-tokens-limitations).
+
+2. Install [GitHub CLI](https://cli.github.com/) and authenticate it:
 
 ```bash
 gh auth login
 ```
+
+GitHub CLI is not required in PAT mode. Local checkout uses the matching repository remote with ordinary `git` commands.
 
 ## Installation
 
@@ -69,9 +85,14 @@ Install the latest release binary on Windows PowerShell:
 irm https://raw.githubusercontent.com/chenyukang/ghr/main/install.ps1 | iex
 ```
 
-Then authenticate GitHub CLI and run ghr:
+Then set a token or authenticate GitHub CLI and run ghr:
 
 ```bash
+# PAT mode, without GitHub CLI
+export GHR_GITHUB_TOKEN=ghp_...
+ghr
+
+# Or GitHub CLI mode
 gh auth login
 ghr
 
@@ -88,7 +109,7 @@ curl -fsSL https://raw.githubusercontent.com/chenyukang/ghr/main/install.sh | GH
 
 ## Usage
 
-Run `ghr` from any terminal after `gh auth login`. When started inside a Git checkout with a GitHub remote, ghr adds that repository as a local project tab automatically.
+Run `ghr` after setting a token or completing `gh auth login`. When started inside a Git checkout with a GitHub remote, ghr adds that repository as a local project tab automatically.
 
 ## Keybindings
 
@@ -130,7 +151,7 @@ Press `?` in the TUI for the live shortcut reference. The top-right status shows
 | `m` | Toggle terminal text selection mode; in diff details, begin a review range |
 | `M` | Open a merge confirmation for the selected PR, defaulting to merge commits |
 | `C` | Open a close or reopen confirmation for the selected issue or PR |
-| `X` | Open a confirmation to run `gh pr checkout <number> --repo <owner/repo>` from the matching local checkout |
+| `X` | Open a local PR checkout confirmation; PAT mode uses `git`, while GitHub CLI mode uses `gh pr checkout` |
 | `F` | Rerun failed checks for the selected PR |
 | `U` | Open an update-branch confirmation for the selected PR |
 | `m` / `s` / `r` in merge confirmation | Choose merge, squash, or rebase before confirming |
@@ -196,6 +217,8 @@ Local PR checkout:
 
 - Press `X` on a pull request in the list or Details pane, then confirm with `y` or `Enter`.
 - Pull request Details show the remote branch as a clickable link when GitHub provides it.
+- In PAT mode, ghr fetches `refs/pull/<number>/head` from the matching Git remote and checks out `pr/<number>`; GitHub CLI is not required.
+- An existing `pr/<number>` branch is only fast-forwarded. If it has diverged, ghr leaves it untouched and reports the conflict.
 - Checkout runs from the matching local repository directory. Set `local_dir` on a repo entry to make the target explicit:
 
 ```toml

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Press `?` in the TUI for the live shortcut reference. The top-right status shows
 | `m` | Toggle terminal text selection mode; in diff details, begin a review range |
 | `M` | Open a merge confirmation for the selected PR, defaulting to merge commits |
 | `C` | Open a close or reopen confirmation for the selected issue or PR |
-| `X` | Open a local PR checkout confirmation; PAT mode uses `git`, while GitHub CLI mode uses `gh pr checkout` |
+| `X` | Open a local PR checkout confirmation using ordinary `git` commands |
 | `F` | Rerun failed checks for the selected PR |
 | `U` | Open an update-branch confirmation for the selected PR |
 | `m` / `s` / `r` in merge confirmation | Choose merge, squash, or rebase before confirming |
@@ -217,7 +217,7 @@ Local PR checkout:
 
 - Press `X` on a pull request in the list or Details pane, then confirm with `y` or `Enter`.
 - Pull request Details show the remote branch as a clickable link when GitHub provides it.
-- In PAT mode, ghr fetches `refs/pull/<number>/head` from the matching Git remote and checks out `pr/<number>`; GitHub CLI is not required.
+- ghr fetches `refs/pull/<number>/head` from the matching Git remote and checks out `pr/<number>`; GitHub CLI is not required for checkout.
 - An existing `pr/<number>` branch is only fast-forwarded. If it has diverged, ghr leaves it untouched and reports the conflict.
 - Checkout runs from the matching local repository directory. Set `local_dir` on a repo entry to make the target explicit:
 
@@ -233,7 +233,7 @@ show_issues = true
 ```
 
 - If `local_dir` is not set, `ghr` tries the directory where it was launched when that directory has a GitHub remote for the pull request repository. If neither path matches, `ghr` shows a hint instead of running checkout.
-- Creating a pull request from `local_dir` runs a local preflight before pushing or calling `gh pr create`. It blocks with a dialog when the title is empty, the checkout has moved branches, the worktree is dirty, the head has no commit, no matching GitHub push remote exists, or the branch has no commits ahead of the local base branch.
+- Creating a pull request from `local_dir` runs a local preflight before pushing and calling the GitHub API. It blocks with a dialog when the title is empty, the checkout has moved branches, the worktree is dirty, the head has no commit, no matching GitHub push remote exists, or the branch has no commits ahead of the local base branch.
 
 Mouse behavior:
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -87,7 +87,7 @@
           <p>
             ghr shows the local SQLite snapshot immediately, refreshes the
             active view first, then quietly keeps other PR and issue sections
-            warm through the GitHub CLI.
+            warm through the selected GitHub API backend.
           </p>
         </article>
         <article>

--- a/docs/script.js
+++ b/docs/script.js
@@ -1,7 +1,7 @@
 const shortcuts = [
   ["General", ":", "Open the command palette and fuzzy-search commands; recently run commands appear first"],
   ["General", "?", "Open the live help reference"],
-  ["General", "r", "Refresh dashboard data from GitHub"],
+  ["General", "r", "Refresh the active tab first, then run a full background refresh"],
   ["General", "q / Ctrl+C", "Save UI state and quit"],
   ["General", "1 / 2 / 3 / 4", "Focus ghr, Sections, List, or Details"],
   ["General", "Tab / Shift+Tab", "Switch list/details focus, or move within focused ghr/Sections tabs"],

--- a/docs/script.js
+++ b/docs/script.js
@@ -65,7 +65,7 @@ const shortcuts = [
   ["Details", "c / a", "Add a comment in conversation mode"],
   ["Diff", "q / Esc", "Return to the state before opening diff mode"],
   ["Diff", "Tab / Shift+Tab", "Switch focus between changed files and the file diff"],
-  ["Diff Files", "j / k / Up / Down", "Choose a changed file"],
+  ["Diff Files", "j / k / n / p / Up / Down", "Choose a changed file"],
   ["Diff Files", "PgUp / PgDown or u / d", "Move by a visible file page"],
   ["Diff Files", "[ / ]", "Previous or next changed file"],
   ["Diff Files", "Enter / 4", "Focus the file diff"],

--- a/docs/script.js
+++ b/docs/script.js
@@ -29,7 +29,7 @@ const shortcuts = [
   ["Issue/PR", "t", "Change or clear milestone"],
   ["Pull Request", "M", "Open merge confirmation"],
   ["Pull Request", "C", "Close or reopen"],
-  ["Pull Request", "X", "Checkout PR locally with gh pr checkout"],
+  ["Pull Request", "X", "Checkout PR locally with git or gh"],
   ["Pull Request", "F", "Rerun failed checks"],
   ["Pull Request", "U", "Update PR branch"],
   ["Pull Request", "D", "Toggle draft or ready for review"],

--- a/docs/script.js
+++ b/docs/script.js
@@ -29,7 +29,7 @@ const shortcuts = [
   ["Issue/PR", "t", "Change or clear milestone"],
   ["Pull Request", "M", "Open merge confirmation"],
   ["Pull Request", "C", "Close or reopen"],
-  ["Pull Request", "X", "Checkout PR locally with git or gh"],
+  ["Pull Request", "X", "Checkout PR locally with git"],
   ["Pull Request", "F", "Rerun failed checks"],
   ["Pull Request", "U", "Update PR branch"],
   ["Pull Request", "D", "Toggle draft or ready for review"],

--- a/install.ps1
+++ b/install.ps1
@@ -118,7 +118,7 @@ try {
     }
 
     Write-Host "ghr install: installed $Tag to $Destination"
-    Write-Host "Next: gh auth login"
+    Write-Host "Next: set GHR_GITHUB_TOKEN, or run: gh auth login"
     Write-Host "Run:  ghr"
 } finally {
     Remove-Item -Recurse -Force $TempDir -ErrorAction SilentlyContinue

--- a/install.sh
+++ b/install.sh
@@ -207,5 +207,5 @@ case ":$PATH:" in
 esac
 
 echo "ghr install: installed $tag to $install_dir/$bin_name"
-echo "Next: gh auth login"
+echo "Next: set GHR_GITHUB_TOKEN, or run: gh auth login"
 echo "Run:  ghr"

--- a/packaging/homebrew/Formula/ghr-cli.rb
+++ b/packaging/homebrew/Formula/ghr-cli.rb
@@ -34,7 +34,7 @@ class GhrCli < Formula
   end
 
   def caveats
-    "Run `gh auth login` before starting ghr."
+    "Set GHR_GITHUB_TOKEN environment variable, or run `gh auth login`, before starting ghr."
   end
 
   test do

--- a/packaging/homebrew/update-formula.sh
+++ b/packaging/homebrew/update-formula.sh
@@ -77,7 +77,7 @@ class GhrCli < Formula
   end
 
   def caveats
-    "Run \`gh auth login\` before starting ghr."
+    "Set GHR_GITHUB_TOKEN environment variable, or run \`gh auth login\`, before starting ghr."
   end
 
   test do

--- a/src/app.rs
+++ b/src/app.rs
@@ -34,7 +34,7 @@ use ratatui::widgets::{
 use ratatui::{Frame, Terminal};
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
-use tracing::{debug, error, warn};
+use tracing::{debug, warn};
 
 use crate::config::{
     Config, CurrentRepoRemotePrompt, DEFAULT_COMMAND_PALETTE_KEY, DEFAULT_EDITOR_SUBMIT_KEY,
@@ -64,7 +64,6 @@ use crate::github::{
     unsubscribe_notification_thread, update_issue_assignees, update_item_subscription,
     update_pull_request_branch, with_background_github_priority,
 };
-use crate::log::{fail_gh_request_to_start, finish_gh_request, start_gh_request};
 use crate::model::{
     ActionHints, CheckRunSummary, CheckSummary, CommentPreview, CommentPreviewKind, EditorDraft,
     FailedCheckRunSummary, ItemKind, Milestone, PullRequestBranch, PullRequestReviewActor,
@@ -1962,55 +1961,8 @@ fn startup_setup_dialog() -> Option<SetupDialog> {
         return None;
     }
 
-    let gh_request = start_gh_request("gh", "gh --version", None);
-    debug!(command = "gh --version", "gh request started");
-    let result = Command::new("gh")
-        .env("GH_PROMPT_DISABLED", "1")
-        .arg("--version")
-        .output();
-    match &result {
-        Ok(output) => {
-            finish_gh_request(gh_request, output);
-            debug!(
-                command = "gh --version",
-                status = %output.status,
-                success = output.status.success(),
-                stdout_bytes = output.stdout.len(),
-                stderr_bytes = output.stderr.len(),
-                "gh request finished"
-            );
-            if !output.status.success() {
-                error!(
-                    command = "gh --version",
-                    status = %output.status,
-                    message = %gh_version_output_message(output),
-                    stdout_bytes = output.stdout.len(),
-                    stderr_bytes = output.stderr.len(),
-                    "gh request returned failure"
-                );
-            }
-        }
-        Err(error) => {
-            fail_gh_request_to_start(gh_request, error);
-            debug!(
-                command = "gh --version",
-                error = %error,
-                "gh request failed to start"
-            );
-            error!(
-                command = "gh --version",
-                error = %error,
-                "gh request failed to start"
-            );
-        }
-    }
+    let result = crate::github_gh::version_output();
     startup_setup_dialog_from_gh_probe(result.map(|_| ()))
-}
-
-fn gh_version_output_message(output: &std::process::Output) -> String {
-    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    if stderr.is_empty() { stdout } else { stderr }
 }
 
 fn startup_setup_dialog_from_gh_probe(result: io::Result<()>) -> Option<SetupDialog> {

--- a/src/app.rs
+++ b/src/app.rs
@@ -1551,6 +1551,7 @@ struct AppState {
     status: String,
     refreshing: bool,
     current_refresh_scope: RefreshScope,
+    pending_full_refresh_after_view: bool,
     section_page_loading: Option<SectionPageLoading>,
     last_refresh_request: Instant,
     idle_sweep_refreshing: bool,
@@ -1993,6 +1994,19 @@ async fn run_loop(
         }
 
         needs_draw |= drain_app_messages(app, rx);
+        let started_pending_full_refresh = if app.take_pending_full_refresh_after_view() {
+            start_refresh(
+                config.clone(),
+                store.clone(),
+                tx.clone(),
+                RefreshPriority::Background,
+                RefreshScope::Full,
+            );
+            needs_draw = true;
+            true
+        } else {
+            false
+        };
         needs_draw |= app.ensure_current_details_loading(tx);
         needs_draw |= app.ensure_current_comments_auto_refresh(tx);
         needs_draw |= app.ensure_current_diff_loading(tx);
@@ -2004,7 +2018,8 @@ async fn run_loop(
         needs_draw |= app.dismiss_expired_message_dialog(Instant::now());
         needs_draw |= app.refresh_auto_theme(config, Instant::now());
 
-        if !app.refreshing
+        if !started_pending_full_refresh
+            && !app.refreshing
             && config.defaults.refetch_interval_seconds > 0
             && app.last_refresh_request.elapsed().as_secs()
                 >= config.defaults.refetch_interval_seconds
@@ -2016,7 +2031,7 @@ async fn run_loop(
                 RefreshPriority::Background,
                 RefreshScope::View(app.active_view.clone()),
             );
-        } else if app.should_start_idle_sweep(config) {
+        } else if !started_pending_full_refresh && app.should_start_idle_sweep(config) {
             start_idle_sweep(
                 config.clone(),
                 store.clone(),
@@ -2954,6 +2969,7 @@ impl AppState {
             status: "loading snapshot; background refresh started".to_string(),
             refreshing: false,
             current_refresh_scope: RefreshScope::Full,
+            pending_full_refresh_after_view: false,
             section_page_loading: None,
             last_refresh_request: Instant::now(),
             idle_sweep_refreshing: false,
@@ -3638,6 +3654,18 @@ impl AppState {
             (Some(error), None) => refresh_error_status(1, Some(error)),
             (_, Some(error)) => format!("snapshot save failed: {error}"),
         };
+    }
+
+    fn queue_full_refresh_after_view(&mut self) {
+        self.pending_full_refresh_after_view = true;
+    }
+
+    fn take_pending_full_refresh_after_view(&mut self) -> bool {
+        if self.refreshing {
+            return false;
+        }
+
+        std::mem::take(&mut self.pending_full_refresh_after_view)
     }
 
     fn handle_msg(&mut self, message: AppMsg) {

--- a/src/app.rs
+++ b/src/app.rs
@@ -1958,7 +1958,7 @@ fn should_show_startup_dialog(cached: &HashMap<String, SectionSnapshot>) -> bool
 }
 
 fn startup_setup_dialog() -> Option<SetupDialog> {
-    if crate::github_api::token_available() {
+    if !crate::github_api::selected_backend().supports_cli_commands() {
         return None;
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -127,11 +127,13 @@ use layout::{
     split_percent_from_column, splitter_contains,
 };
 use participants::*;
+#[cfg(test)]
+use pr_checkout::run_git_pr_checkout_ref;
 use pr_checkout::{
     PrCheckoutPlan, PrCheckoutResult, checkout_directory_notice, configured_local_dir_for_repo,
     current_git_branch_for_directory, ensure_directory_tracks_configured_repo,
-    resolve_pr_checkout_directory, resolve_pull_request_head_ref, run_pr_checkout,
-    validate_pr_create_preflight,
+    resolve_pr_checkout_directory, resolve_pr_checkout_remote, resolve_pull_request_head_ref,
+    run_pr_checkout, validate_pr_create_preflight,
 };
 use render::*;
 use runtime::*;
@@ -1956,6 +1958,10 @@ fn should_show_startup_dialog(cached: &HashMap<String, SectionSnapshot>) -> bool
 }
 
 fn startup_setup_dialog() -> Option<SetupDialog> {
+    if crate::github_api::token_available() {
+        return None;
+    }
+
     let gh_request = start_gh_request("gh", "gh --version", None);
     debug!(command = "gh --version", "gh request started");
     let result = Command::new("gh")
@@ -3467,10 +3473,10 @@ impl AppState {
         self.startup_dialog = None;
         self.status = match dialog {
             SetupDialog::MissingGh => {
-                "GitHub CLI missing: install `gh`, then run `gh auth login`".to_string()
+                "GitHub auth required: set a token or install `gh`".to_string()
             }
             SetupDialog::AuthRequired => {
-                "GitHub CLI auth required: run `gh auth login`".to_string()
+                "GitHub authentication failed: check the token or `gh auth login`".to_string()
             }
         };
     }
@@ -8624,6 +8630,14 @@ impl AppState {
                 return;
             }
         };
+        let remote = match resolve_pr_checkout_remote(config, &directory, &item.repo) {
+            Ok(remote) => remote,
+            Err(error) => {
+                self.message_dialog = Some(message_dialog("Checkout Unavailable", error));
+                self.status = "pull request checkout unavailable".to_string();
+                return;
+            }
+        };
         let branch = self
             .action_hints
             .get(&item.id)
@@ -8648,7 +8662,11 @@ impl AppState {
         self.pr_action_dialog = Some(PrActionDialog {
             item,
             action: PrAction::Checkout,
-            checkout: Some(PrCheckoutPlan { directory, branch }),
+            checkout: Some(PrCheckoutPlan {
+                directory,
+                branch,
+                remote,
+            }),
             summary: Vec::new(),
             merge_method: MergeMethod::default(),
         });

--- a/src/app/command_palette.rs
+++ b/src/app/command_palette.rs
@@ -178,7 +178,7 @@ pub(super) fn command_palette_commands(
             "Refresh",
             "r",
             "General",
-            "Refresh dashboard data from GitHub",
+            "Refresh the active tab first, then run a full background refresh",
             PaletteAction::Refresh,
         ),
         palette_command(

--- a/src/app/dialogs.rs
+++ b/src/app/dialogs.rs
@@ -4624,7 +4624,7 @@ pub(super) fn help_dialog_content(command_palette_key: &str) -> Vec<Line<'static
         help_heading("Diff Files"),
         help_key_line("3", "focus the changed-file list"),
         help_key_line("Tab / Shift+Tab", "focus the file diff"),
-        help_key_line("j/k or Up/Down", "choose a changed file"),
+        help_key_line("j/k/n/p or Up/Down", "choose a changed file"),
         help_key_line("PgDown/PgUp", "move by visible file page"),
         help_key_line("h / l", "page diff down/up across files"),
         help_key_line("[ / ]", "previous / next changed file"),

--- a/src/app/dialogs.rs
+++ b/src/app/dialogs.rs
@@ -4513,11 +4513,15 @@ pub(super) fn help_dialog_max_scroll_for_lines(line_count: usize, area: Rect) ->
 pub(super) fn setup_dialog_content(dialog: SetupDialog) -> (&'static str, Vec<Line<'static>>) {
     match dialog {
         SetupDialog::MissingGh => (
-            "GitHub CLI Required",
+            "GitHub Authentication Required",
             vec![
-                Line::from("ghr uses GitHub CLI for authentication and GitHub API access."),
+                Line::from("ghr needs either a GitHub token or an authenticated GitHub CLI."),
                 Line::from(""),
-                Line::from("Install GitHub CLI: https://cli.github.com/"),
+                Line::from("Use a personal access token without installing gh:"),
+                command_line("export GHR_GITHUB_TOKEN=github_pat_..."),
+                Line::from("GH_TOKEN and GITHUB_TOKEN are also supported."),
+                Line::from(""),
+                Line::from("Or install GitHub CLI: https://cli.github.com/"),
                 command_line("macOS: brew install gh"),
                 command_line("Debian/Ubuntu: sudo apt install gh"),
                 Line::from("Linux package details:"),
@@ -4531,14 +4535,13 @@ pub(super) fn setup_dialog_content(dialog: SetupDialog) -> (&'static str, Vec<Li
             ],
         ),
         SetupDialog::AuthRequired => (
-            "GitHub Login Required",
+            "GitHub Authentication Failed",
             vec![
-                Line::from("GitHub CLI is installed, but it is not authenticated."),
+                Line::from("The configured token or GitHub CLI login was rejected."),
                 Line::from(""),
-                Line::from("Run this in your terminal:"),
+                Line::from("Check GHR_GITHUB_TOKEN, GH_TOKEN, or GITHUB_TOKEN."),
+                Line::from("Or authenticate GitHub CLI:"),
                 command_line("gh auth login"),
-                Line::from(""),
-                Line::from("You can also launch ghr with GH_TOKEN set."),
                 Line::from("After setup, press Esc and then r to refresh."),
                 Line::from("Esc: close and use cached data    q: quit"),
             ],

--- a/src/app/dialogs.rs
+++ b/src/app/dialogs.rs
@@ -4518,7 +4518,7 @@ pub(super) fn setup_dialog_content(dialog: SetupDialog) -> (&'static str, Vec<Li
                 Line::from("ghr needs either a GitHub token or an authenticated GitHub CLI."),
                 Line::from(""),
                 Line::from("Use a personal access token without installing gh:"),
-                command_line("export GHR_GITHUB_TOKEN=github_pat_..."),
+                command_line("export GHR_GITHUB_TOKEN=ghp_..."),
                 Line::from("GH_TOKEN and GITHUB_TOKEN are also supported."),
                 Line::from(""),
                 Line::from("Or install GitHub CLI: https://cli.github.com/"),

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -888,7 +888,16 @@ pub(super) fn trigger_refresh(
     store: &SnapshotStore,
     tx: &UnboundedSender<AppMsg>,
 ) {
-    trigger_refresh_scope(app, config, store, tx, RefreshScope::Full);
+    if !app.refreshing {
+        app.queue_full_refresh_after_view();
+    }
+    trigger_refresh_scope(
+        app,
+        config,
+        store,
+        tx,
+        RefreshScope::View(app.active_view.clone()),
+    );
 }
 
 pub(super) fn trigger_refresh_scope(

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -825,8 +825,8 @@ pub(super) fn handle_diff_file_list_key(
         KeyCode::Char('Y') => {
             app.start_reviewer_dialog_with_store(ReviewerAction::Remove, Some(store), Some(tx))
         }
-        KeyCode::Down | KeyCode::Char('j') => app.move_diff_file(1),
-        KeyCode::Up | KeyCode::Char('k') => app.move_diff_file(-1),
+        KeyCode::Down | KeyCode::Char('j') | KeyCode::Char('n') => app.move_diff_file(1),
+        KeyCode::Up | KeyCode::Char('k') | KeyCode::Char('p') => app.move_diff_file(-1),
         KeyCode::PageDown | KeyCode::Char('d') => {
             app.move_diff_file(diff_file_page_delta(app, area, 1));
         }

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -888,15 +888,31 @@ pub(super) fn trigger_refresh(
     store: &SnapshotStore,
     tx: &UnboundedSender<AppMsg>,
 ) {
+    trigger_refresh_scope(app, config, store, tx, RefreshScope::Full);
+}
+
+pub(super) fn trigger_refresh_scope(
+    app: &mut AppState,
+    config: &Config,
+    store: &SnapshotStore,
+    tx: &UnboundedSender<AppMsg>,
+    scope: RefreshScope,
+) {
     if app.refreshing {
         app.status = "refresh already running".to_string();
     } else {
+        #[cfg(test)]
+        {
+            let _ = (config, store, RefreshPriority::User);
+            let _ = tx.send(AppMsg::RefreshStarted { scope });
+        }
+        #[cfg(not(test))]
         start_refresh(
             config.clone(),
             store.clone(),
             tx.clone(),
             RefreshPriority::User,
-            RefreshScope::Full,
+            scope,
         );
     }
 }

--- a/src/app/pr_checkout.rs
+++ b/src/app/pr_checkout.rs
@@ -1,4 +1,3 @@
-use std::io;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 
@@ -7,7 +6,6 @@ use tracing::{debug, error};
 
 use super::text::truncate_text;
 use crate::config::{Config, github_repo_from_remote_url};
-use crate::log::{fail_gh_request_to_start, finish_gh_request, start_gh_request};
 use crate::model::{PullRequestBranch, WorkItem};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -29,104 +27,7 @@ pub(super) async fn run_pr_checkout(
     directory: PathBuf,
     remote: String,
 ) -> std::result::Result<PrCheckoutResult, String> {
-    if crate::github_api::token_available() {
-        return run_git_pr_checkout(item, directory, remote).await;
-    }
-    run_gh_pr_checkout(item, directory).await
-}
-
-async fn run_gh_pr_checkout(
-    item: WorkItem,
-    directory: PathBuf,
-) -> std::result::Result<PrCheckoutResult, String> {
-    let number = item
-        .number
-        .ok_or_else(|| "selected item has no pull request number".to_string())?;
-    let args = pr_checkout_command_args(&item.repo, number);
-    let command = pr_checkout_command_display(&args);
-    let gh_request = start_gh_request("gh", command.clone(), Some(&directory));
-    debug!(
-        command = %command,
-        cwd = %directory.display(),
-        "gh request started"
-    );
-    let output = TokioCommand::new("gh")
-        .env("GH_PROMPT_DISABLED", "1")
-        .current_dir(&directory)
-        .args(&args)
-        .output()
-        .await
-        .map_err(|error| {
-            fail_gh_request_to_start(gh_request.clone(), &error);
-            debug!(
-                command = %command,
-                cwd = %directory.display(),
-                error = %error,
-                "gh request failed to start"
-            );
-            error!(
-                command = %command,
-                cwd = %directory.display(),
-                error = %error,
-                "gh request failed to start"
-            );
-            if error.kind() == io::ErrorKind::NotFound {
-                format!(
-                    "GitHub CLI `gh` is required for local checkout. Install it, run `gh auth login`, then retry.\n\n{}\n\nTried: {command}",
-                    checkout_directory_notice(&directory),
-                )
-            } else {
-                format!(
-                    "failed to run {command}: {error}\n\n{}",
-                    checkout_directory_notice(&directory),
-                )
-            }
-        })?;
-    finish_gh_request(gh_request, &output);
-    debug!(
-        command = %command,
-        cwd = %directory.display(),
-        status = %output.status,
-        success = output.status.success(),
-        stdout_bytes = output.stdout.len(),
-        stderr_bytes = output.stderr.len(),
-        "gh request finished"
-    );
-
-    let output_text = command_output_text(&output.stdout, &output.stderr);
-    if !output.status.success() {
-        let detail = if output_text.is_empty() {
-            "gh did not return any output".to_string()
-        } else {
-            output_text
-        };
-        error!(
-            command = %command,
-            cwd = %directory.display(),
-            status = %output.status,
-            message = %truncate_text(&detail, 900),
-            stdout_bytes = output.stdout.len(),
-            stderr_bytes = output.stderr.len(),
-            "gh request returned failure"
-        );
-        return Err(format!(
-            "{} failed.\n\n{}\n\n{}",
-            command,
-            checkout_directory_notice(&directory),
-            truncate_text(&detail, 900),
-        ));
-    }
-
-    let output = if output_text.is_empty() {
-        "gh pr checkout completed successfully.".to_string()
-    } else {
-        truncate_text(&output_text, 900)
-    };
-    Ok(PrCheckoutResult {
-        command,
-        directory,
-        output,
-    })
+    run_git_pr_checkout(item, directory, remote).await
 }
 
 async fn run_git_pr_checkout(
@@ -305,20 +206,6 @@ fn git_is_ancestor(
             command_output_text(&output.stdout, &output.stderr)
         )),
     }
-}
-
-pub(super) fn pr_checkout_command_args(repository: &str, number: u64) -> Vec<String> {
-    vec![
-        "pr".to_string(),
-        "checkout".to_string(),
-        number.to_string(),
-        "--repo".to_string(),
-        repository.to_string(),
-    ]
-}
-
-pub(super) fn pr_checkout_command_display(args: &[String]) -> String {
-    format!("gh {}", args.join(" "))
 }
 
 pub(super) fn command_output_text(stdout: &[u8], stderr: &[u8]) -> String {

--- a/src/app/pr_checkout.rs
+++ b/src/app/pr_checkout.rs
@@ -21,9 +21,21 @@ pub(super) struct PrCheckoutResult {
 pub(super) struct PrCheckoutPlan {
     pub(super) directory: PathBuf,
     pub(super) branch: Option<PullRequestBranch>,
+    pub(super) remote: String,
 }
 
 pub(super) async fn run_pr_checkout(
+    item: WorkItem,
+    directory: PathBuf,
+    remote: String,
+) -> std::result::Result<PrCheckoutResult, String> {
+    if crate::github_api::token_available() {
+        return run_git_pr_checkout(item, directory, remote).await;
+    }
+    run_gh_pr_checkout(item, directory).await
+}
+
+async fn run_gh_pr_checkout(
     item: WorkItem,
     directory: PathBuf,
 ) -> std::result::Result<PrCheckoutResult, String> {
@@ -117,6 +129,184 @@ pub(super) async fn run_pr_checkout(
     })
 }
 
+async fn run_git_pr_checkout(
+    item: WorkItem,
+    directory: PathBuf,
+    remote: String,
+) -> std::result::Result<PrCheckoutResult, String> {
+    let number = item
+        .number
+        .ok_or_else(|| "selected item has no pull request number".to_string())?;
+    run_git_pr_checkout_ref(&item.repo, number, directory, remote).await
+}
+
+pub(super) async fn run_git_pr_checkout_ref(
+    repository: &str,
+    number: u64,
+    directory: PathBuf,
+    remote: String,
+) -> std::result::Result<PrCheckoutResult, String> {
+    ensure_clean_worktree(&directory).map_err(|error| {
+        format!(
+            "Cannot checkout {}/pull/{number} with git.\n\n{}\n\n{error}",
+            repository,
+            checkout_directory_notice(&directory)
+        )
+    })?;
+
+    let fetched_ref = format!("refs/ghr/pull/{number}/head");
+    let local_branch = format!("pr/{number}");
+    let local_ref = format!("refs/heads/{local_branch}");
+    let refspec = format!("+refs/pull/{number}/head:{fetched_ref}");
+    let mut commands = Vec::new();
+    let mut output = Vec::new();
+
+    run_checkout_git_command(
+        &directory,
+        &["fetch", "--no-tags", &remote, &refspec],
+        &mut commands,
+        &mut output,
+    )
+    .await?;
+
+    if !git_ref_exists(&directory, &local_ref) {
+        run_checkout_git_command(
+            &directory,
+            &["switch", "--create", &local_branch, &fetched_ref],
+            &mut commands,
+            &mut output,
+        )
+        .await?;
+    } else if git_is_ancestor(&directory, &local_ref, &fetched_ref)? {
+        run_checkout_git_command(
+            &directory,
+            &["switch", &local_branch],
+            &mut commands,
+            &mut output,
+        )
+        .await?;
+        run_checkout_git_command(
+            &directory,
+            &["merge", "--ff-only", &fetched_ref],
+            &mut commands,
+            &mut output,
+        )
+        .await?;
+    } else if git_is_ancestor(&directory, &fetched_ref, &local_ref)? {
+        run_checkout_git_command(
+            &directory,
+            &["switch", &local_branch],
+            &mut commands,
+            &mut output,
+        )
+        .await?;
+        output.push(format!(
+            "Local branch {local_branch} already contains the fetched PR head."
+        ));
+    } else {
+        return Err(format!(
+            "Local branch {local_branch} has diverged from {}/pull/{number}. Rename or delete that local branch, then retry.\n\n{}",
+            repository,
+            checkout_directory_notice(&directory)
+        ));
+    }
+
+    Ok(PrCheckoutResult {
+        command: commands.join("\n"),
+        directory,
+        output: if output.is_empty() {
+            format!("Checked out pull request #{number} as {local_branch}.")
+        } else {
+            truncate_text(&output.join("\n"), 900)
+        },
+    })
+}
+
+async fn run_checkout_git_command(
+    directory: &Path,
+    args: &[&str],
+    commands: &mut Vec<String>,
+    messages: &mut Vec<String>,
+) -> std::result::Result<(), String> {
+    let command = format!("git {}", args.join(" "));
+    debug!(
+        command = %command,
+        cwd = %directory.display(),
+        "git checkout command started"
+    );
+    let output = TokioCommand::new("git")
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .current_dir(directory)
+        .args(args)
+        .output()
+        .await
+        .map_err(|error| {
+            error!(
+                command = %command,
+                cwd = %directory.display(),
+                error = %error,
+                "git checkout command failed to start"
+            );
+            format!(
+                "failed to run {command}: {error}\n\n{}",
+                checkout_directory_notice(directory)
+            )
+        })?;
+    let message = command_output_text(&output.stdout, &output.stderr);
+    debug!(
+        command = %command,
+        cwd = %directory.display(),
+        status = %output.status,
+        success = output.status.success(),
+        stdout_bytes = output.stdout.len(),
+        stderr_bytes = output.stderr.len(),
+        "git checkout command finished"
+    );
+    if !output.status.success() {
+        let detail = if message.is_empty() {
+            "git did not return any output".to_string()
+        } else {
+            truncate_text(&message, 900)
+        };
+        error!(
+            command = %command,
+            cwd = %directory.display(),
+            status = %output.status,
+            message = %detail,
+            "git checkout command returned failure"
+        );
+        return Err(format!(
+            "{command} failed.\n\n{}\n\n{detail}",
+            checkout_directory_notice(directory)
+        ));
+    }
+    commands.push(command);
+    if !message.is_empty() {
+        messages.push(message);
+    }
+    Ok(())
+}
+
+fn git_is_ancestor(
+    directory: &Path,
+    ancestor: &str,
+    descendant: &str,
+) -> std::result::Result<bool, String> {
+    let output = git_output(
+        directory,
+        &["merge-base", "--is-ancestor", ancestor, descendant],
+    )?;
+    match output.status.code() {
+        Some(0) => Ok(true),
+        Some(1) => Ok(false),
+        _ => Err(format!(
+            "git merge-base --is-ancestor {ancestor} {descendant} failed in {}: {}",
+            directory.display(),
+            command_output_text(&output.stdout, &output.stderr)
+        )),
+    }
+}
+
 pub(super) fn pr_checkout_command_args(repository: &str, number: u64) -> Vec<String> {
     vec![
         "pr".to_string(),
@@ -177,6 +367,44 @@ pub(super) fn resolve_pr_checkout_directory(
         )
     })?;
     Ok(cwd)
+}
+
+pub(super) fn resolve_pr_checkout_remote(
+    config: &Config,
+    directory: &Path,
+    repository: &str,
+) -> std::result::Result<String, String> {
+    if let Some(remote) = config
+        .repos
+        .iter()
+        .find(|repo| repo.repo.eq_ignore_ascii_case(repository))
+        .and_then(|repo| repo.remote.as_deref())
+        .map(str::trim)
+        .filter(|remote| !remote.is_empty())
+    {
+        return match git_remote_repo(directory, remote) {
+            Some(repo) if repo.eq_ignore_ascii_case(repository) => Ok(remote.to_string()),
+            Some(repo) => Err(format!(
+                "{} remote {remote} points at {repo}, expected {repository}.",
+                directory.display()
+            )),
+            None => Err(format!(
+                "{} has no GitHub remote named {remote}.",
+                directory.display()
+            )),
+        };
+    }
+
+    git_remotes_for_directory(directory)?
+        .into_iter()
+        .find(|(_, repo)| repo.eq_ignore_ascii_case(repository))
+        .map(|(remote, _)| remote)
+        .ok_or_else(|| {
+            format!(
+                "{} has no Git remote for {repository}.",
+                directory.display()
+            )
+        })
 }
 
 pub(super) fn configured_local_dir_for_repo(config: &Config, repository: &str) -> Option<PathBuf> {

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -1415,7 +1415,7 @@ pub(super) fn footer_focus_primary_shortcuts(app: &AppState) -> Vec<Span<'static
         }
         FocusTarget::List => {
             if app.details_mode == DetailsMode::Diff {
-                push_footer_pair(&mut spans, "j/k", "file", Color::Cyan);
+                push_footer_pair(&mut spans, "j/k/n/p", "file", Color::Cyan);
                 push_footer_pair(&mut spans, "tab", "diff", Color::Cyan);
                 push_footer_pair(&mut spans, "enter", "diff", Color::Cyan);
                 push_footer_pair(&mut spans, "esc", "back", Color::Cyan);

--- a/src/app/runtime.rs
+++ b/src/app/runtime.rs
@@ -1,7 +1,5 @@
 use super::*;
 use crate::log::{GhLogEntry, recent_gh_log_entries};
-#[cfg(not(test))]
-use crate::log::{fail_gh_request_to_start, finish_gh_request, start_gh_request};
 
 pub(super) fn info_lines(app: &AppState, config: &Config, paths: &Paths) -> Vec<String> {
     let cwd = std::env::current_dir()
@@ -359,23 +357,8 @@ fn github_auth_summary() -> String {
         return format!("PAT via {name}");
     }
 
-    let gh_request = start_gh_request("gh", "gh --version", None);
-    debug!(command = "gh --version", "gh request started");
-    let output = Command::new("gh")
-        .env("GH_PROMPT_DISABLED", "1")
-        .arg("--version")
-        .output();
-    match output {
+    match crate::github_gh::version_output() {
         Ok(output) => {
-            finish_gh_request(gh_request, &output);
-            debug!(
-                command = "gh --version",
-                status = %output.status,
-                success = output.status.success(),
-                stdout_bytes = output.stdout.len(),
-                stderr_bytes = output.stderr.len(),
-                "gh request finished"
-            );
             if output.status.success() {
                 String::from_utf8_lossy(&output.stdout)
                     .lines()
@@ -385,14 +368,6 @@ fn github_auth_summary() -> String {
                     .unwrap_or("installed")
                     .to_string()
             } else {
-                error!(
-                    command = "gh --version",
-                    status = %output.status,
-                    message = %gh_version_output_message(&output),
-                    stdout_bytes = output.stdout.len(),
-                    stderr_bytes = output.stderr.len(),
-                    "gh request returned failure"
-                );
                 let stderr = String::from_utf8_lossy(&output.stderr);
                 stderr
                     .lines()
@@ -403,26 +378,6 @@ fn github_auth_summary() -> String {
                     .to_string()
             }
         }
-        Err(error) => {
-            fail_gh_request_to_start(gh_request, &error);
-            debug!(
-                command = "gh --version",
-                error = %error,
-                "gh request failed to start"
-            );
-            error!(
-                command = "gh --version",
-                error = %error,
-                "gh request failed to start"
-            );
-            format!("unavailable ({error})")
-        }
+        Err(error) => format!("unavailable ({error})"),
     }
-}
-
-#[cfg(not(test))]
-fn gh_version_output_message(output: &std::process::Output) -> String {
-    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    if stderr.is_empty() { stdout } else { stderr }
 }

--- a/src/app/runtime.rs
+++ b/src/app/runtime.rs
@@ -20,7 +20,7 @@ pub(super) fn info_lines(app: &AppState, config: &Config, paths: &Paths) -> Vec<
         .iter()
         .map(|section| section.items.len())
         .sum::<usize>();
-    let gh_version = github_cli_version_summary();
+    let github_auth = github_auth_summary();
     let gh_log_entries = recent_gh_log_entries();
 
     vec![
@@ -33,7 +33,7 @@ pub(super) fn info_lines(app: &AppState, config: &Config, paths: &Paths) -> Vec<
         ),
         format!("pid: {}", std::process::id()),
         format!("process memory: {}", process_memory_summary()),
-        format!("gh: {gh_version}"),
+        format!("GitHub auth: {github_auth}"),
         String::new(),
         "terminal".to_string(),
         format!("TERM: {}", env_summary("TERM")),
@@ -349,12 +349,16 @@ fn format_kib(kib: u64) -> String {
 }
 
 #[cfg(test)]
-fn github_cli_version_summary() -> String {
+fn github_auth_summary() -> String {
     "not checked in tests".to_string()
 }
 
 #[cfg(not(test))]
-fn github_cli_version_summary() -> String {
+fn github_auth_summary() -> String {
+    if let Some(name) = crate::github_api::token_env_name() {
+        return format!("PAT via {name}");
+    }
+
     let gh_request = start_gh_request("gh", "gh --version", None);
     debug!(command = "gh --version", "gh request started");
     let output = Command::new("gh")

--- a/src/app/status.rs
+++ b/src/app/status.rs
@@ -11,12 +11,12 @@ pub(super) fn refresh_error_status(count: usize, first_error: Option<&str>) -> S
         return format!("refresh complete with {count} failed section(s)");
     };
 
-    if first_error.contains("GitHub CLI `gh` is required") {
-        return "GitHub CLI missing: install `gh`, then run `gh auth login`".to_string();
+    if missing_github_auth_backend(first_error) {
+        return "GitHub auth required: set GHR_GITHUB_TOKEN or install `gh`".to_string();
     }
 
-    if first_error.contains("Run `gh auth login`") {
-        return "GitHub CLI auth required: run `gh auth login`".to_string();
+    if github_auth_failed(first_error) {
+        return "GitHub authentication failed: check the token or run `gh auth login`".to_string();
     }
 
     if is_github_search_rate_limit(first_error) {
@@ -29,12 +29,12 @@ pub(super) fn refresh_error_status(count: usize, first_error: Option<&str>) -> S
 }
 
 pub(super) fn compact_error_label(error: &str) -> String {
-    if error.contains("GitHub CLI `gh` is required") {
-        return "GitHub CLI missing".to_string();
+    if missing_github_auth_backend(error) {
+        return "GitHub authentication missing".to_string();
     }
 
-    if error.contains("Run `gh auth login`") {
-        return "GitHub CLI auth required".to_string();
+    if github_auth_failed(error) {
+        return "GitHub authentication failed".to_string();
     }
 
     if is_github_search_rate_limit(error) {
@@ -50,15 +50,26 @@ pub(super) fn compact_error_label(error: &str) -> String {
 }
 
 pub(super) fn setup_dialog_from_error(error: &str) -> Option<SetupDialog> {
-    if error.contains("GitHub CLI `gh` is required") {
+    if missing_github_auth_backend(error) {
         return Some(SetupDialog::MissingGh);
     }
 
-    if error.contains("Run `gh auth login`") {
+    if github_auth_failed(error) {
         return Some(SetupDialog::AuthRequired);
     }
 
     None
+}
+
+fn missing_github_auth_backend(error: &str) -> bool {
+    error.contains("No GitHub authentication backend is available")
+        || error.contains("GitHub CLI `gh` is required")
+}
+
+fn github_auth_failed(error: &str) -> bool {
+    error.contains("Run `gh auth login`")
+        || error.contains("HTTP 401")
+        || error.to_ascii_lowercase().contains("bad credentials")
 }
 
 pub(super) fn message_dialog(title: impl Into<String>, body: impl Into<String>) -> MessageDialog {
@@ -145,7 +156,7 @@ pub(super) fn pr_action_success_body(action: PrAction, _item_kind: ItemKind) -> 
         PrAction::Approve => "GitHub accepted the approval. Refreshing details.",
         PrAction::EnableAutoMerge => "GitHub enabled auto-merge. Refreshing details.",
         PrAction::DisableAutoMerge => "GitHub disabled auto-merge. Refreshing details.",
-        PrAction::Checkout => "GitHub CLI checked out the pull request locally.",
+        PrAction::Checkout => "The pull request was checked out locally.",
         PrAction::RerunFailedChecks => {
             "GitHub accepted the failed-check rerun request. Refreshing details."
         }

--- a/src/app/switchers.rs
+++ b/src/app/switchers.rs
@@ -523,16 +523,14 @@ impl AppState {
             .repo_name_for_repo(&candidate.repo)
             .map(str::to_string)
             .unwrap_or_else(|| candidate.repo.clone());
+        let view = repo_view_key(&name);
         self.add_project_view_from_config(config, &name);
-        self.switch_project_view(repo_view_key(&name));
+        self.switch_project_view(view.clone());
         self.status = format!(
             "current repo remote: {} -> {}",
             candidate.remote, candidate.repo
         );
-        #[cfg(not(test))]
-        trigger_refresh(self, config, store, tx);
-        #[cfg(test)]
-        let _ = (store, tx);
+        trigger_refresh_scope(self, config, store, tx, RefreshScope::View(view));
     }
 
     pub(super) fn dismiss_project_add_dialog(&mut self) {
@@ -656,14 +654,12 @@ impl AppState {
             return;
         }
 
+        let view = repo_view_key(&name);
         self.add_project_view_from_config(config, &name);
-        self.switch_project_view(repo_view_key(&name));
+        self.switch_project_view(view.clone());
         self.project_add_dialog = None;
         self.status = format!("project added: {name}");
-        #[cfg(not(test))]
-        trigger_refresh(self, config, store, tx);
-        #[cfg(test)]
-        let _ = (store, tx);
+        trigger_refresh_scope(self, config, store, tx, RefreshScope::View(view));
     }
 
     pub(super) fn add_project_view_from_config(&mut self, config: &Config, name: &str) {

--- a/src/app/tasks.rs
+++ b/src/app/tasks.rs
@@ -946,7 +946,7 @@ pub(super) fn start_pr_action(
                 });
                 return;
             };
-            let result = run_pr_checkout(item, checkout.directory).await;
+            let result = run_pr_checkout(item, checkout.directory, checkout.remote).await;
             let _ = tx.send(AppMsg::PrCheckoutFinished { result });
             return;
         }

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -5831,7 +5831,7 @@ fn project_add_saves_repo_to_config_and_adds_menu_tab() {
     let mut config = Config::default();
     config.save(&paths.config_path).expect("save config");
     let mut app = AppState::new(SectionKind::PullRequests, configured_sections(&config));
-    let (tx, _rx) = mpsc::unbounded_channel();
+    let (tx, mut rx) = mpsc::unbounded_channel();
     let store = SnapshotStore::new(std::path::PathBuf::from("/tmp/ghr-test-unused.db"));
 
     app.show_project_add_dialog();
@@ -5867,6 +5867,13 @@ fn project_add_saves_repo_to_config_and_adds_menu_tab() {
         vec!["Issues", "Pull Requests"]
     );
     assert_eq!(app.status, "project added: ghr");
+    let refresh = rx.try_recv().expect("project add should start a refresh");
+    match refresh {
+        AppMsg::RefreshStarted { scope } => {
+            assert_eq!(scope, RefreshScope::View("repo:ghr".to_string()));
+        }
+        _ => panic!("expected refresh start after project add"),
+    }
 
     let saved = Config::load_or_create(&paths.config_path).expect("load saved config");
     assert_eq!(saved.repos.len(), 1);

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -105,14 +105,21 @@ fn fuzzy_score_matches_ordered_subsequence() {
 fn refresh_error_status_guides_missing_gh_and_auth() {
     assert_eq!(
         refresh_error_status(3, Some("GitHub CLI `gh` is required but was not found.")),
-        "GitHub CLI missing: install `gh`, then run `gh auth login`"
+        "GitHub auth required: set GHR_GITHUB_TOKEN or install `gh`"
     );
     assert_eq!(
         refresh_error_status(
             3,
             Some("GitHub CLI is installed but not authenticated. Run `gh auth login`.")
         ),
-        "GitHub CLI auth required: run `gh auth login`"
+        "GitHub authentication failed: check the token or run `gh auth login`"
+    );
+    assert_eq!(
+        refresh_error_status(
+            3,
+            Some("GitHub API request failed: HTTP 401: Bad credentials")
+        ),
+        "GitHub authentication failed: check the token or run `gh auth login`"
     );
     assert_eq!(
         refresh_error_status(3, Some("HTTP 403: API rate limit exceeded")),
@@ -2470,6 +2477,10 @@ fn setup_dialog_from_error_classifies_gh_setup_failures() {
         Some(SetupDialog::AuthRequired)
     );
     assert_eq!(setup_dialog_from_error("HTTP 500"), None);
+    assert_eq!(
+        setup_dialog_from_error("GitHub API request failed: HTTP 401: Bad credentials"),
+        Some(SetupDialog::AuthRequired)
+    );
 }
 
 #[test]
@@ -2526,7 +2537,7 @@ fn startup_setup_dialog_sets_status_without_initializing_dialog() {
     assert_eq!(app.startup_dialog, None);
     assert_eq!(
         app.status,
-        "GitHub CLI missing: install `gh`, then run `gh auth login`"
+        "GitHub auth required: set a token or install `gh`"
     );
 }
 
@@ -2547,7 +2558,7 @@ fn refresh_failure_opens_setup_dialog() {
     assert_eq!(app.startup_dialog, None);
     assert_eq!(
         app.status,
-        "GitHub CLI missing: install `gh`, then run `gh auth login`"
+        "GitHub auth required: set GHR_GITHUB_TOKEN or install `gh`"
     );
 }
 
@@ -7116,6 +7127,7 @@ fn setup_dialog_content_contains_actionable_commands() {
     assert!(missing_text.contains("brew install gh"));
     assert!(missing_text.contains("sudo apt install gh"));
     assert!(missing_text.contains("gh auth login"));
+    assert!(missing_text.contains("GHR_GITHUB_TOKEN"));
 
     let (_title, auth_lines) = setup_dialog_content(SetupDialog::AuthRequired);
     let auth_text = auth_lines
@@ -7125,6 +7137,7 @@ fn setup_dialog_content_contains_actionable_commands() {
         .join("\n");
     assert!(auth_text.contains("gh auth login"));
     assert!(auth_text.contains("GH_TOKEN"));
+    assert!(auth_text.contains("GHR_GITHUB_TOKEN"));
 }
 
 #[test]
@@ -13084,6 +13097,21 @@ fn configured_repo_remote_is_used_when_validating_local_dir() {
 }
 
 #[test]
+fn checkout_remote_uses_matching_base_repo_remote() {
+    let local_dir = checkout_test_fork_repo_dir_on_branch(
+        "feature/upstream-base",
+        "Officeyutong/tentacle",
+        "nervosnetwork/tentacle",
+    );
+
+    assert_eq!(
+        resolve_pr_checkout_remote(&Config::default(), &local_dir, "nervosnetwork/tentacle")
+            .expect("matching remote"),
+        "upstream"
+    );
+}
+
+#[test]
 fn capital_n_in_pr_repo_without_local_dir_shows_hint() {
     let section = SectionSnapshot {
         key: "repo:ghr:pull_requests:Pull Requests".to_string(),
@@ -14009,6 +14037,96 @@ fn pr_checkout_command_construction_uses_repo_and_number() {
     assert_eq!(
         pr_checkout_command_display(&args),
         "gh pr checkout 123 --repo rust-lang/rust"
+    );
+}
+
+#[tokio::test]
+async fn pat_checkout_fetches_pull_ref_and_fast_forwards_local_branch() {
+    let directory = checkout_test_repo_dir();
+    let remote_dir = directory.with_extension("bare.git");
+    std::fs::create_dir_all(&remote_dir).expect("create bare remote directory");
+    run_checkout_test_git(&remote_dir, &["init", "--bare", "-q"]);
+
+    run_checkout_test_git(&directory, &["config", "user.email", "ghr@example.com"]);
+    run_checkout_test_git(&directory, &["config", "user.name", "ghr test"]);
+    run_checkout_test_git(&directory, &["checkout", "-q", "-b", "main"]);
+    std::fs::write(directory.join("README.md"), "base\n").expect("write base file");
+    run_checkout_test_git(&directory, &["add", "README.md"]);
+    run_checkout_test_git(&directory, &["commit", "-q", "-m", "base"]);
+    run_checkout_test_git(&directory, &["checkout", "-q", "-b", "feature"]);
+    std::fs::write(directory.join("feature.txt"), "first\n").expect("write feature file");
+    run_checkout_test_git(&directory, &["add", "feature.txt"]);
+    run_checkout_test_git(&directory, &["commit", "-q", "-m", "feature one"]);
+    run_checkout_test_git(
+        &directory,
+        &[
+            "remote",
+            "set-url",
+            "origin",
+            &remote_dir.display().to_string(),
+        ],
+    );
+    run_checkout_test_git(
+        &directory,
+        &["push", "-q", "origin", "main:refs/heads/main"],
+    );
+    run_checkout_test_git(
+        &directory,
+        &["push", "-q", "origin", "feature:refs/pull/19/head"],
+    );
+    run_checkout_test_git(&directory, &["checkout", "-q", "main"]);
+
+    let first = run_git_pr_checkout_ref(
+        "chenyukang/ghr",
+        19,
+        directory.clone(),
+        "origin".to_string(),
+    )
+    .await
+    .expect("initial PAT checkout");
+
+    assert_eq!(
+        current_git_branch_for_directory(&directory).expect("current branch"),
+        "pr/19"
+    );
+    assert!(
+        first
+            .command
+            .contains("git fetch --no-tags origin +refs/pull/19/head:refs/ghr/pull/19/head")
+    );
+
+    run_checkout_test_git(&directory, &["checkout", "-q", "feature"]);
+    std::fs::write(directory.join("feature.txt"), "second\n").expect("update feature file");
+    run_checkout_test_git(&directory, &["add", "feature.txt"]);
+    run_checkout_test_git(&directory, &["commit", "-q", "-m", "feature two"]);
+    let updated_head = checkout_test_git_text(&directory, &["rev-parse", "HEAD"]);
+    run_checkout_test_git(
+        &directory,
+        &["push", "-q", "origin", "feature:refs/pull/19/head"],
+    );
+    run_checkout_test_git(&directory, &["checkout", "-q", "main"]);
+
+    let second = run_git_pr_checkout_ref(
+        "chenyukang/ghr",
+        19,
+        directory.clone(),
+        "origin".to_string(),
+    )
+    .await
+    .expect("fast-forward PAT checkout");
+
+    assert_eq!(
+        current_git_branch_for_directory(&directory).expect("current branch"),
+        "pr/19"
+    );
+    assert_eq!(
+        checkout_test_git_text(&directory, &["rev-parse", "HEAD"]),
+        updated_head
+    );
+    assert!(
+        second
+            .command
+            .contains("git merge --ff-only refs/ghr/pull/19/head")
     );
 }
 
@@ -20561,6 +20679,25 @@ fn run_checkout_test_git(dir: &std::path::Path, args: &[&str]) {
         args.join(" "),
         command_output_text(&output.stdout, &output.stderr)
     );
+}
+
+fn checkout_test_git_text(dir: &std::path::Path, args: &[&str]) -> String {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(args)
+        .output()
+        .expect("run git");
+    assert!(
+        output.status.success(),
+        "git {} failed: {}",
+        args.join(" "),
+        command_output_text(&output.stdout, &output.stderr)
+    );
+    String::from_utf8(output.stdout)
+        .expect("git output utf-8")
+        .trim()
+        .to_string()
 }
 
 fn many_items_section(count: u64) -> SectionSnapshot {

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1,7 +1,5 @@
 use super::layout::{body_area, body_areas};
-use super::pr_checkout::{
-    command_output_text, pr_checkout_command_args, pr_checkout_command_display,
-};
+use super::pr_checkout::command_output_text;
 use super::*;
 use crate::log::{clear_gh_log_entries, fail_gh_request_to_start, start_gh_request};
 use crate::model::CommentPreviewKind;
@@ -128,26 +126,25 @@ fn refresh_error_status_guides_missing_gh_and_auth() {
 }
 
 #[test]
-fn compact_error_label_hides_long_gh_command_context() {
-    let error = "gh search prs --json number,title,body,repository,author,createdAt,updatedAt,url,state,isDraft,labels,commentsCount --limit 500 -- repo:rust-lang/rust is:open failed: HTTP 403: API rate limit exceeded for user ID 230646";
+fn compact_error_label_hides_long_github_request_context() {
+    let error = "gh api --method GET search/issues -f q=is:pr repo:rust-lang/rust is:open -f per_page=100 failed: HTTP 403: API rate limit exceeded for user ID 230646";
 
     assert_eq!(compact_error_label(error), "GitHub search rate limited");
-    assert!(!compact_error_label(error).contains("--json"));
+    assert!(!compact_error_label(error).contains("--method"));
 }
 
 #[test]
 fn error_chain_message_keeps_gh_failure_detail() {
-    let error = anyhow::anyhow!(
-        "gh pr create --repo owner/repo --head feature failed: a pull request already exists"
-    )
-    .context("failed to create pull request in owner/repo");
+    let error =
+        anyhow::anyhow!("GitHub API request failed: HTTP 422: a pull request already exists")
+            .context("failed to create pull request in owner/repo");
     let message = error_chain_message(error);
 
     assert!(message.contains("failed to create pull request in owner/repo"));
     assert!(message.contains("a pull request already exists"));
     assert_eq!(
         operation_error_body(&message),
-        "a pull request already exists"
+        "HTTP 422: a pull request already exists"
     );
 }
 
@@ -13462,7 +13459,7 @@ fn issue_create_failure_restores_dialog_for_retry() {
 }
 
 #[test]
-fn pull_request_create_failure_shows_gh_detail_and_restores_dialog() {
+fn pull_request_create_failure_shows_api_detail_and_restores_dialog() {
     let local_dir = checkout_test_repo_dir_on_branch("feature/pr-body");
     let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
     let dialog = PrCreateDialog {
@@ -13487,7 +13484,7 @@ fn pull_request_create_failure_shows_gh_detail_and_restores_dialog() {
     });
 
     app.handle_msg(AppMsg::PullRequestCreated {
-            result: Err("failed to create pull request in chenyukang/ghr: gh pr create --repo chenyukang/ghr --head feature/pr-body failed: a pull request for branch \"feature/pr-body\" already exists: https://github.com/chenyukang/ghr/pull/42".to_string()),
+            result: Err("failed to create pull request in chenyukang/ghr: GitHub API request failed: HTTP 422: a pull request for branch \"feature/pr-body\" already exists: https://github.com/chenyukang/ghr/pull/42".to_string()),
         });
 
     assert!(!app.pr_creating);
@@ -14020,28 +14017,8 @@ fn checkout_confirmation_submits_selected_action() {
     ));
 }
 
-#[test]
-fn pr_checkout_command_construction_uses_repo_and_number() {
-    let args = pr_checkout_command_args("rust-lang/rust", 123);
-
-    assert_eq!(
-        args,
-        vec![
-            "pr".to_string(),
-            "checkout".to_string(),
-            "123".to_string(),
-            "--repo".to_string(),
-            "rust-lang/rust".to_string(),
-        ]
-    );
-    assert_eq!(
-        pr_checkout_command_display(&args),
-        "gh pr checkout 123 --repo rust-lang/rust"
-    );
-}
-
 #[tokio::test]
-async fn pat_checkout_fetches_pull_ref_and_fast_forwards_local_branch() {
+async fn git_checkout_fetches_pull_ref_and_fast_forwards_local_branch() {
     let directory = checkout_test_repo_dir();
     let remote_dir = directory.with_extension("bare.git");
     std::fs::create_dir_all(&remote_dir).expect("create bare remote directory");
@@ -15871,7 +15848,7 @@ fn pr_checkout_finished_shows_success_output() {
 
     app.handle_msg(AppMsg::PrCheckoutFinished {
         result: Ok(PrCheckoutResult {
-            command: "gh pr checkout 1 --repo rust-lang/rust".to_string(),
+            command: "git fetch --no-tags origin +refs/pull/1/head:refs/ghr/pull/1/head\ngit switch --create pr/1 refs/ghr/pull/1/head".to_string(),
             directory: PathBuf::from("/tmp/rust"),
             output: "Switched to branch 'diagnostics'".to_string(),
         }),
@@ -15885,8 +15862,9 @@ fn pr_checkout_finished_shows_success_output() {
     assert!(
         dialog
             .body
-            .contains("gh pr checkout 1 --repo rust-lang/rust")
+            .contains("git fetch --no-tags origin +refs/pull/1/head")
     );
+    assert!(dialog.body.contains("git switch --create pr/1"));
     assert!(dialog.body.contains("Checkout runs from /tmp/rust."));
     assert!(dialog.body.contains("Switched to branch"));
     assert_eq!(dialog.kind, MessageDialogKind::Success);
@@ -15902,7 +15880,7 @@ fn pr_checkout_failure_opens_message_dialog() {
 
     app.handle_msg(AppMsg::PrCheckoutFinished {
             result: Err(
-                "gh pr checkout 1 --repo rust-lang/rust failed.\n\nCheckout runs from /tmp.\n\nfatal: not a git repository"
+                "git fetch --no-tags origin +refs/pull/1/head:refs/ghr/pull/1/head failed.\n\nCheckout runs from /tmp.\n\nfatal: not a git repository"
                     .to_string(),
             ),
         });

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -2322,6 +2322,26 @@ diff --git a/src/github.rs b/src/github.rs
 
     assert!(!handle_key(
         &mut app,
+        key(KeyCode::Char('n')),
+        &config,
+        &store,
+        &tx
+    ));
+    assert_eq!(app.selected_diff_file.get("1"), Some(&1));
+    assert_eq!(app.focus, FocusTarget::List);
+
+    assert!(!handle_key(
+        &mut app,
+        key(KeyCode::Char('p')),
+        &config,
+        &store,
+        &tx
+    ));
+    assert_eq!(app.selected_diff_file.get("1"), Some(&0));
+    assert_eq!(app.focus, FocusTarget::List);
+
+    assert!(!handle_key(
+        &mut app,
         key(KeyCode::Char('j')),
         &config,
         &store,
@@ -4309,6 +4329,7 @@ fn help_dialog_content_lists_core_shortcuts() {
     assert!(text.contains("@ / -"));
     assert!(text.contains("add a reaction"));
     assert!(text.contains("Ctrl+Enter / Ctrl+O"));
+    assert!(text.contains("j/k/n/p or Up/Down"));
     assert!(!text.contains("Reaction Dialog"));
 }
 
@@ -6913,7 +6934,7 @@ fn footer_switches_shortcuts_for_each_focus_region() {
 
     app.focus_list();
     let diff_list = footer_line(&app, &paths).to_string();
-    assert!(diff_list.contains("j/k file  tab diff  enter diff"));
+    assert!(diff_list.contains("j/k/n/p file  tab diff  enter diff"));
     assert!(!diff_list.contains("m text-select"));
 }
 

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -2595,6 +2595,64 @@ fn refresh_finished_resets_background_refresh_interval() {
 }
 
 #[test]
+fn manual_refresh_starts_with_active_view_scope() {
+    let inbox = SectionSnapshot::empty(SectionKind::Notifications, "All", "is:unread");
+    assert_manual_refresh_scope(
+        AppState::new(SectionKind::Notifications, vec![inbox]),
+        "notifications",
+    );
+
+    assert_manual_refresh_scope(
+        AppState::new(SectionKind::PullRequests, vec![test_section()]),
+        "pull_requests",
+    );
+
+    let issues = SectionSnapshot::empty(SectionKind::Issues, "Issues", "is:open");
+    assert_manual_refresh_scope(AppState::new(SectionKind::Issues, vec![issues]), "issues");
+
+    let repo_view = repo_view_key("Fiber");
+    let repo_section = SectionSnapshot::empty_for_view(
+        repo_view.clone(),
+        SectionKind::PullRequests,
+        "Pull Requests",
+        "repo:nervosnetwork/fiber is:open",
+    );
+    let mut app = AppState::new(SectionKind::PullRequests, vec![repo_section]);
+    app.switch_view(repo_view);
+    assert_manual_refresh_scope(app, "repo:Fiber");
+}
+
+#[test]
+fn manual_refresh_queues_full_refresh_after_active_view_finishes() {
+    let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
+    let config = Config::default();
+    let store = SnapshotStore::new(std::path::PathBuf::from("/tmp/ghr-test-unused.db"));
+    let (tx, mut rx) = mpsc::unbounded_channel();
+
+    trigger_refresh(&mut app, &config, &store, &tx);
+    let AppMsg::RefreshStarted { scope } = rx
+        .try_recv()
+        .expect("manual refresh should start current view")
+    else {
+        panic!("expected refresh start after manual refresh");
+    };
+    assert_eq!(scope, RefreshScope::View("pull_requests".to_string()));
+
+    app.handle_msg(AppMsg::RefreshStarted { scope });
+    assert!(app.refreshing);
+    assert!(!app.take_pending_full_refresh_after_view());
+
+    app.handle_msg(AppMsg::RefreshFinished {
+        sections: Vec::new(),
+        save_error: None,
+    });
+
+    assert!(!app.refreshing);
+    assert!(app.take_pending_full_refresh_after_view());
+    assert!(!app.take_pending_full_refresh_after_view());
+}
+
+#[test]
 fn idle_sweep_merges_non_active_sections_without_changing_status() {
     let pull_requests = test_section();
     let mut issue_item = work_item("issue-1", "rust-lang/rust", 1, "old issue", None);
@@ -20472,6 +20530,22 @@ fn test_section() -> SectionSnapshot {
         refreshed_at: None,
         error: None,
     }
+}
+
+fn assert_manual_refresh_scope(mut app: AppState, expected_view: &str) {
+    let config = Config::default();
+    let store = SnapshotStore::new(std::path::PathBuf::from("/tmp/ghr-test-unused.db"));
+    let (tx, mut rx) = mpsc::unbounded_channel();
+
+    trigger_refresh(&mut app, &config, &store, &tx);
+    let AppMsg::RefreshStarted { scope } = rx
+        .try_recv()
+        .expect("manual refresh should start current view")
+    else {
+        panic!("expected refresh start after manual refresh");
+    };
+
+    assert_eq!(scope, RefreshScope::View(expected_view.to_string()));
 }
 
 fn test_diff_file(path: &str, additions: usize, deletions: usize) -> DiffFile {

--- a/src/github.rs
+++ b/src/github.rs
@@ -57,14 +57,6 @@ impl MergeMethod {
         }
     }
 
-    pub fn gh_flag(self) -> &'static str {
-        match self {
-            Self::Merge => "--merge",
-            Self::Squash => "--squash",
-            Self::Rebase => "--rebase",
-        }
-    }
-
     pub fn next(self) -> Self {
         match self {
             Self::Merge => Self::Squash,
@@ -296,24 +288,6 @@ fn truncate_gh_output_message(message: &str) -> String {
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct SearchItemRaw {
-    author: Option<SearchAuthorRaw>,
-    assignees: Option<Vec<SearchAuthorRaw>>,
-    body: Option<String>,
-    comments_count: Option<u64>,
-    created_at: Option<DateTime<Utc>>,
-    is_draft: Option<bool>,
-    labels: Option<Vec<SearchLabelRaw>>,
-    number: u64,
-    repository: SearchRepositoryRaw,
-    state: Option<String>,
-    title: String,
-    updated_at: Option<DateTime<Utc>>,
-    url: String,
-}
-
-#[derive(Debug, Deserialize)]
 struct SearchAuthorRaw {
     login: String,
 }
@@ -336,12 +310,6 @@ struct RepositoryAssigneeRaw {
 #[derive(Debug, Deserialize)]
 struct UserSearchRaw {
     items: Vec<SearchAuthorRaw>,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct SearchRepositoryRaw {
-    name_with_owner: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -877,23 +845,6 @@ enum PullRequestCheckContextRaw {
 #[derive(Debug, Deserialize)]
 struct PullRequestViewerReviewRaw {
     state: Option<String>,
-}
-
-#[derive(Debug, Deserialize)]
-struct PullRequestCheckStatusRaw {
-    bucket: Option<String>,
-    description: Option<String>,
-    link: Option<String>,
-    name: Option<String>,
-    state: Option<String>,
-    workflow: Option<String>,
-}
-
-#[derive(Debug, Default, PartialEq, Eq)]
-struct FailedCheckRunDiscovery {
-    runs: Vec<FailedCheckRunSummary>,
-    check_runs: Vec<CheckRunSummary>,
-    unmapped_failed_checks: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1503,32 +1454,10 @@ async fn fetch_search_items_for_query(
     limit: usize,
     exclude_repos: &[String],
 ) -> Result<Vec<WorkItem>> {
-    if crate::github_api::token_available() {
-        return fetch_search_items_with_pat(kind, &filters, limit, exclude_repos).await;
-    }
-
-    let subcommand = match kind {
-        SectionKind::PullRequests => "prs",
-        SectionKind::Issues => "issues",
-        SectionKind::Notifications => bail!("notifications are not fetched via search"),
-    };
-
-    let fields = search_fields(kind);
-
-    let args = search_args(subcommand, fields, &filters, limit);
-
-    let output = run_gh_json(&args).await?;
-    let items = serde_json::from_str::<Vec<SearchItemRaw>>(&output)
-        .with_context(|| format!("failed to parse gh search {subcommand} output"))?;
-
-    Ok(items
-        .into_iter()
-        .filter(|item| !is_excluded_repo(&item.repository.name_with_owner, exclude_repos))
-        .map(|item| search_item_to_work_item(kind, item))
-        .collect())
+    fetch_search_items_with_api(kind, &filters, limit, exclude_repos).await
 }
 
-async fn fetch_search_items_with_pat(
+async fn fetch_search_items_with_api(
     kind: SectionKind,
     filters: &str,
     limit: usize,
@@ -1551,24 +1480,6 @@ async fn fetch_search_items_with_pat(
 
     items.truncate(limit);
     Ok(items)
-}
-
-fn search_args(subcommand: &str, fields: &str, filters: &str, limit: usize) -> Vec<String> {
-    let limit = search_command_limit(limit);
-    let mut args = vec![
-        "search".to_string(),
-        subcommand.to_string(),
-        "--json".to_string(),
-        fields.to_string(),
-        "--limit".to_string(),
-        limit.to_string(),
-    ];
-    let query_tokens = search_filter_tokens(filters);
-    if !query_tokens.is_empty() {
-        args.push("--".to_string());
-        args.extend(query_tokens);
-    }
-    args
 }
 
 fn search_command_limit(limit: usize) -> usize {
@@ -1823,18 +1734,6 @@ fn is_plain_search_term(token: &str) -> bool {
     }
     let token = token.strip_prefix('-').unwrap_or(token);
     !token.contains(':')
-}
-
-fn search_fields(kind: SectionKind) -> &'static str {
-    match kind {
-        SectionKind::PullRequests => {
-            "number,title,body,repository,author,assignees,createdAt,updatedAt,url,state,isDraft,labels,commentsCount"
-        }
-        SectionKind::Issues => {
-            "number,title,body,repository,author,assignees,createdAt,updatedAt,url,state,labels,commentsCount"
-        }
-        SectionKind::Notifications => unreachable!("notifications are not fetched via search"),
-    }
 }
 
 pub async fn fetch_comments(
@@ -2283,7 +2182,7 @@ async fn fetch_paginated_api_array_output_without_slurp(
 }
 
 async fn gh_api_slurp_supported() -> bool {
-    if crate::github_api::token_available() {
+    if !crate::github_api::selected_backend().supports_cli_commands() {
         return false;
     }
     *GH_API_SLURP_SUPPORTED
@@ -2436,6 +2335,11 @@ async fn comment_viewer_login(context: &'static str) -> Option<String> {
 }
 
 pub async fn fetch_pull_request_action_hints(repository: &str, number: u64) -> Result<ActionHints> {
+    let pr = fetch_pull_request_action(repository, number).await?;
+    Ok(pull_request_action_hints(&pr))
+}
+
+async fn fetch_pull_request_action(repository: &str, number: u64) -> Result<PullRequestActionRaw> {
     let (owner, name) = split_repository(repository)?;
     let query = r#"
 query($owner: String!, $name: String!, $number: Int!) {
@@ -2542,129 +2446,28 @@ query($owner: String!, $name: String!, $number: Int!) {
         .repository
         .and_then(|repository| repository.pull_request)
         .ok_or_else(|| anyhow!("pull request {repository}#{number} was not found"))?;
-    let mut hints = pull_request_action_hints(&pr);
-    if crate::github_api::token_available() {
-        return Ok(hints);
-    }
-    match fetch_failed_check_runs_from_pr_checks(repository, number).await {
-        Ok(discovery) => {
-            if !discovery.check_runs.is_empty() {
-                hints.check_runs = discovery.check_runs;
-            }
-            merge_failed_check_runs(&mut hints.failed_check_runs, discovery.runs);
-        }
-        Err(error) => {
-            debug!(
-                repository,
-                number,
-                error = %error,
-                "failed to enrich pull request check hints from gh pr checks"
-            );
-        }
-    }
-    Ok(hints)
+    Ok(pr)
 }
 
 pub async fn rerun_failed_pull_request_checks(repository: &str, number: u64) -> Result<()> {
-    if crate::github_api::token_available() {
-        let hints = fetch_pull_request_action_hints(repository, number).await?;
-        if hints.failed_check_runs.is_empty() {
-            bail!("no failed GitHub Actions checks found for {repository}#{number}");
-        }
-        for run in hints.failed_check_runs {
-            run_gh_json(&[
-                "api".to_string(),
-                "-X".to_string(),
-                "POST".to_string(),
-                format!(
-                    "repos/{repository}/actions/runs/{}/rerun-failed-jobs",
-                    run.run_id
-                ),
-            ])
-            .await?;
-        }
-        return Ok(());
+    let hints = fetch_pull_request_action_hints(repository, number).await?;
+    if hints.failed_check_runs.is_empty() {
+        bail!("no failed GitHub Actions checks found for {repository}#{number}");
     }
-
-    let discovery = fetch_failed_check_runs_from_pr_checks(repository, number).await?;
-    if discovery.runs.is_empty() {
-        if discovery.unmapped_failed_checks.is_empty() {
-            bail!("no failed checks found for {repository}#{number}");
-        }
-        bail!(
-            "failed checks were found, but none linked to GitHub Actions workflow runs: {}",
-            discovery.unmapped_failed_checks.join(", ")
-        );
-    }
-
-    for run in &discovery.runs {
+    for run in hints.failed_check_runs {
         run_gh_json(&rerun_failed_check_run_args(repository, run.run_id)).await?;
     }
 
     Ok(())
 }
 
-async fn fetch_failed_check_runs_from_pr_checks(
-    repository: &str,
-    number: u64,
-) -> Result<FailedCheckRunDiscovery> {
-    let output = run_gh_pr_checks_json(&pr_checks_args(repository, number)).await?;
-    failed_check_runs_from_pr_checks_json(&output)
-        .with_context(|| format!("failed to parse PR checks for {repository}#{number}"))
-}
-
-fn pr_checks_args(repository: &str, number: u64) -> Vec<String> {
-    vec![
-        "pr".to_string(),
-        "checks".to_string(),
-        number.to_string(),
-        "--repo".to_string(),
-        repository.to_string(),
-        "--json".to_string(),
-        "name,state,bucket,workflow,link,description".to_string(),
-    ]
-}
-
 fn rerun_failed_check_run_args(repository: &str, run_id: u64) -> Vec<String> {
     vec![
-        "run".to_string(),
-        "rerun".to_string(),
-        run_id.to_string(),
-        "--failed".to_string(),
-        "--repo".to_string(),
-        repository.to_string(),
+        "api".to_string(),
+        "-X".to_string(),
+        "POST".to_string(),
+        format!("repos/{repository}/actions/runs/{run_id}/rerun-failed-jobs"),
     ]
-}
-
-async fn run_gh_pr_checks_json(args: &[String]) -> Result<String> {
-    let gh_request = debug_log_gh_request_started(args, None);
-    let output = Command::new("gh")
-        .env("GH_PROMPT_DISABLED", "1")
-        .args(args)
-        .output()
-        .await
-        .map_err(|error| {
-            log_gh_request_failed_to_start(gh_request.clone(), args, None, &error);
-            if error.kind() == ErrorKind::NotFound {
-                anyhow!("{}", gh_missing_message(args))
-            } else {
-                anyhow!("failed to run gh {}: {error}", args.join(" "))
-            }
-        })?;
-    debug_log_gh_request_finished(gh_request, args, None, &output);
-
-    if !output.status.success() {
-        log_gh_request_failed_result(args, None, &output);
-    }
-
-    if !output.status.success() && output.stdout.is_empty() {
-        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        let message = if stderr.is_empty() { stdout } else { stderr };
-        bail!("{}", gh_failure_message(args, &message));
-    }
-
-    String::from_utf8(output.stdout).context("gh output was not UTF-8")
 }
 
 pub async fn fetch_pull_request_diff(repository: &str, number: u64) -> Result<String> {
@@ -2806,39 +2609,45 @@ pub async fn create_pull_request(
     body: &str,
 ) -> Result<WorkItem> {
     push_pull_request_head(repository, local_dir, head).await?;
-    if crate::github_api::token_available() {
-        let repository_output =
-            run_gh_json(&["api".to_string(), format!("repos/{repository}")]).await?;
-        let repository_raw = serde_json::from_str::<RepositoryDefaultBranchRaw>(&repository_output)
-            .with_context(|| format!("failed to parse default branch for {repository}"))?;
-        let output = run_gh_json(&[
-            "api".to_string(),
-            "-X".to_string(),
-            "POST".to_string(),
-            format!("repos/{repository}/pulls"),
-            "-f".to_string(),
-            format!("head={head}"),
-            "-f".to_string(),
-            format!("base={}", repository_raw.default_branch),
-            "-f".to_string(),
-            format!("title={title}"),
-            "-f".to_string(),
-            format!("body={body}"),
-        ])
-        .await
-        .with_context(|| format!("failed to create pull request in {repository}"))?;
-        let created = serde_json::from_str::<CreatedPullRequestRaw>(&output)
-            .with_context(|| format!("failed to parse created pull request in {repository}"))?;
-        return fetch_created_pull_request(repository, created.number).await;
-    }
+    let repository_output =
+        run_gh_json(&["api".to_string(), format!("repos/{repository}")]).await?;
+    let repository_raw = serde_json::from_str::<RepositoryDefaultBranchRaw>(&repository_output)
+        .with_context(|| format!("failed to parse default branch for {repository}"))?;
+    let output = run_gh_json(&create_pull_request_api_args(
+        repository,
+        head,
+        &repository_raw.default_branch,
+        title,
+        body,
+    ))
+    .await
+    .with_context(|| format!("failed to create pull request in {repository}"))?;
+    let created = serde_json::from_str::<CreatedPullRequestRaw>(&output)
+        .with_context(|| format!("failed to parse created pull request in {repository}"))?;
+    fetch_created_pull_request(repository, created.number).await
+}
 
-    let args = create_pull_request_args(repository, head, title, body);
-    let output = run_gh_text_in_dir(&args, local_dir)
-        .await
-        .with_context(|| format!("failed to create pull request in {repository}"))?;
-    let number = pull_request_number_from_create_output(&output)
-        .ok_or_else(|| anyhow!("gh pr create did not return a pull request URL"))?;
-    fetch_created_pull_request(repository, number).await
+fn create_pull_request_api_args(
+    repository: &str,
+    head: &str,
+    base: &str,
+    title: &str,
+    body: &str,
+) -> Vec<String> {
+    vec![
+        "api".to_string(),
+        "-X".to_string(),
+        "POST".to_string(),
+        format!("repos/{repository}/pulls"),
+        "-f".to_string(),
+        format!("head={head}"),
+        "-f".to_string(),
+        format!("base={base}"),
+        "-f".to_string(),
+        format!("title={title}"),
+        "-f".to_string(),
+        format!("body={body}"),
+    ]
 }
 
 async fn fetch_created_pull_request(repository: &str, number: u64) -> Result<WorkItem> {
@@ -2849,21 +2658,6 @@ async fn fetch_created_pull_request(repository: &str, number: u64) -> Result<Wor
     let raw = serde_json::from_str::<SearchApiIssueRaw>(&issue_output)
         .with_context(|| format!("failed to parse created pull request {repository}#{number}"))?;
     Ok(search_api_item_to_work_item(SectionKind::PullRequests, raw))
-}
-
-fn create_pull_request_args(repository: &str, head: &str, title: &str, body: &str) -> Vec<String> {
-    vec![
-        "pr".to_string(),
-        "create".to_string(),
-        "--repo".to_string(),
-        repository.to_string(),
-        "--head".to_string(),
-        head.to_string(),
-        "--title".to_string(),
-        title.to_string(),
-        "--body".to_string(),
-        body.to_string(),
-    ]
 }
 
 async fn push_pull_request_head(repository: &str, local_dir: &Path, head: &str) -> Result<()> {
@@ -2962,21 +2756,6 @@ fn git_push_pull_request_head_args(remote: &str, branch: &str) -> Vec<String> {
         remote.to_string(),
         format!("HEAD:refs/heads/{branch}"),
     ]
-}
-
-fn pull_request_number_from_create_output(output: &str) -> Option<u64> {
-    output.split_whitespace().find_map(|token| {
-        let token = token.trim_matches(|ch: char| matches!(ch, '"' | '\'' | ')' | '(' | ',' | '.'));
-        let marker = "/pull/";
-        let start = token.find(marker)?.saturating_add(marker.len());
-        let number = token[start..]
-            .chars()
-            .take_while(|ch| ch.is_ascii_digit())
-            .collect::<String>();
-        (!number.is_empty())
-            .then(|| number.parse::<u64>().ok())
-            .flatten()
-    })
 }
 
 pub async fn fetch_open_milestones(repository: &str) -> Result<Vec<Milestone>> {
@@ -3424,58 +3203,35 @@ pub async fn edit_item_metadata(
 }
 
 pub async fn merge_pull_request(repository: &str, number: u64, method: MergeMethod) -> Result<()> {
-    if crate::github_api::token_available() {
-        let output = run_gh_json(&[
-            "api".to_string(),
-            "-X".to_string(),
-            "PUT".to_string(),
-            format!("repos/{repository}/pulls/{number}/merge"),
-            "-f".to_string(),
-            format!("merge_method={}", method.label()),
-        ])
-        .await?;
-        let result = serde_json::from_str::<MergePullRequestRaw>(&output)
-            .with_context(|| format!("failed to parse merge response for {repository}#{number}"))?;
-        if !result.merged {
-            bail!(
-                "failed to merge {repository}#{number}: {}",
-                result
-                    .message
-                    .unwrap_or_else(|| "GitHub rejected the merge".to_string())
-            );
-        }
-        return Ok(());
-    }
-
     ensure_pull_request_can_merge(repository, number).await?;
-    run_gh_json(&merge_pull_request_args(repository, number, method)).await?;
+    let output = run_gh_json(&merge_pull_request_api_args(repository, number, method)).await?;
+    let result = serde_json::from_str::<MergePullRequestRaw>(&output)
+        .with_context(|| format!("failed to parse merge response for {repository}#{number}"))?;
+    if !result.merged {
+        bail!(
+            "failed to merge {repository}#{number}: {}",
+            result
+                .message
+                .unwrap_or_else(|| "GitHub rejected the merge".to_string())
+        );
+    }
     Ok(())
 }
 
-fn merge_pull_request_args(repository: &str, number: u64, method: MergeMethod) -> Vec<String> {
+fn merge_pull_request_api_args(repository: &str, number: u64, method: MergeMethod) -> Vec<String> {
     vec![
-        "pr".to_string(),
-        "merge".to_string(),
-        number.to_string(),
-        "--repo".to_string(),
-        repository.to_string(),
-        method.gh_flag().to_string(),
+        "api".to_string(),
+        "-X".to_string(),
+        "PUT".to_string(),
+        format!("repos/{repository}/pulls/{number}/merge"),
+        "-f".to_string(),
+        format!("merge_method={}", method.label()),
     ]
 }
 
 async fn ensure_pull_request_can_merge(repository: &str, number: u64) -> Result<()> {
-    let output = run_gh_json(&[
-        "pr".to_string(),
-        "view".to_string(),
-        number.to_string(),
-        "--repo".to_string(),
-        repository.to_string(),
-        "--json".to_string(),
-        "state,isDraft,mergeStateStatus,reviewDecision,statusCheckRollup".to_string(),
-    ])
-    .await?;
-    let status = serde_json::from_str::<PullRequestMergeStatusRaw>(&output)
-        .with_context(|| format!("failed to parse merge status for {repository}#{number}"))?;
+    let action = fetch_pull_request_action(repository, number).await?;
+    let status = pull_request_merge_status_from_action(&action);
     if let Some(message) = pull_request_merge_blocker_message(repository, number, &status) {
         bail!("{message}");
     }
@@ -3483,78 +3239,33 @@ async fn ensure_pull_request_can_merge(repository: &str, number: u64) -> Result<
 }
 
 pub async fn close_pull_request(repository: &str, number: u64) -> Result<()> {
-    if crate::github_api::token_available() {
-        return set_issue_state(repository, number, "closed").await;
-    }
-    run_gh_json(&[
-        "pr".to_string(),
-        "close".to_string(),
-        number.to_string(),
-        "--repo".to_string(),
-        repository.to_string(),
-    ])
-    .await?;
-    Ok(())
+    set_issue_state(repository, number, "closed").await
 }
 
 pub async fn reopen_pull_request(repository: &str, number: u64) -> Result<()> {
-    if crate::github_api::token_available() {
-        return set_issue_state(repository, number, "open").await;
-    }
-    run_gh_json(&[
-        "pr".to_string(),
-        "reopen".to_string(),
-        number.to_string(),
-        "--repo".to_string(),
-        repository.to_string(),
-    ])
-    .await?;
-    Ok(())
+    set_issue_state(repository, number, "open").await
 }
 
 pub async fn close_issue(repository: &str, number: u64) -> Result<()> {
-    if crate::github_api::token_available() {
-        return set_issue_state(repository, number, "closed").await;
-    }
-    run_gh_json(&[
-        "issue".to_string(),
-        "close".to_string(),
-        number.to_string(),
-        "--repo".to_string(),
-        repository.to_string(),
-    ])
-    .await?;
-    Ok(())
+    set_issue_state(repository, number, "closed").await
 }
 
 pub async fn reopen_issue(repository: &str, number: u64) -> Result<()> {
-    if crate::github_api::token_available() {
-        return set_issue_state(repository, number, "open").await;
-    }
-    run_gh_json(&[
-        "issue".to_string(),
-        "reopen".to_string(),
-        number.to_string(),
-        "--repo".to_string(),
-        repository.to_string(),
-    ])
-    .await?;
-    Ok(())
+    set_issue_state(repository, number, "open").await
 }
 
 pub async fn update_pull_request_branch(repository: &str, number: u64) -> Result<()> {
-    if crate::github_api::token_available() {
-        run_gh_json(&[
-            "api".to_string(),
-            "-X".to_string(),
-            "PUT".to_string(),
-            format!("repos/{repository}/pulls/{number}/update-branch"),
-        ])
-        .await?;
-        return Ok(());
-    }
-    run_gh_json(&update_pull_request_branch_args(repository, number)).await?;
+    run_gh_json(&update_pull_request_branch_api_args(repository, number)).await?;
     Ok(())
+}
+
+fn update_pull_request_branch_api_args(repository: &str, number: u64) -> Vec<String> {
+    vec![
+        "api".to_string(),
+        "-X".to_string(),
+        "PUT".to_string(),
+        format!("repos/{repository}/pulls/{number}/update-branch"),
+    ]
 }
 
 async fn set_issue_state(repository: &str, number: u64, state: &str) -> Result<()> {
@@ -3570,43 +3281,10 @@ async fn set_issue_state(repository: &str, number: u64, state: &str) -> Result<(
     Ok(())
 }
 
-fn update_pull_request_branch_args(repository: &str, number: u64) -> Vec<String> {
-    vec![
-        "pr".to_string(),
-        "update-branch".to_string(),
-        number.to_string(),
-        "--repo".to_string(),
-        repository.to_string(),
-    ]
-}
-
 pub async fn enable_pull_request_auto_merge(repository: &str, number: u64) -> Result<()> {
     ensure_pull_request_auto_merge_can_enable(repository, number).await?;
     let method = auto_merge_method_flag(repository).await?;
-    if crate::github_api::token_available() {
-        return update_pull_request_auto_merge(repository, number, Some(method)).await;
-    }
-    run_gh_json(&enable_pull_request_auto_merge_args(
-        repository, number, method,
-    ))
-    .await?;
-    Ok(())
-}
-
-fn enable_pull_request_auto_merge_args(
-    repository: &str,
-    number: u64,
-    method: &'static str,
-) -> Vec<String> {
-    vec![
-        "pr".to_string(),
-        "merge".to_string(),
-        number.to_string(),
-        "--repo".to_string(),
-        repository.to_string(),
-        method.to_string(),
-        "--auto".to_string(),
-    ]
+    update_pull_request_auto_merge(repository, number, Some(method)).await
 }
 
 async fn auto_merge_method_flag(repository: &str) -> Result<&'static str> {
@@ -3644,22 +3322,7 @@ fn repository_merge_method_flag(
 
 pub async fn disable_pull_request_auto_merge(repository: &str, number: u64) -> Result<()> {
     ensure_pull_request_auto_merge_can_disable(repository, number).await?;
-    if crate::github_api::token_available() {
-        return update_pull_request_auto_merge(repository, number, None).await;
-    }
-    run_gh_json(&disable_pull_request_auto_merge_args(repository, number)).await?;
-    Ok(())
-}
-
-fn disable_pull_request_auto_merge_args(repository: &str, number: u64) -> Vec<String> {
-    vec![
-        "pr".to_string(),
-        "merge".to_string(),
-        number.to_string(),
-        "--repo".to_string(),
-        repository.to_string(),
-        "--disable-auto".to_string(),
-    ]
+    update_pull_request_auto_merge(repository, number, None).await
 }
 
 async fn ensure_pull_request_auto_merge_can_enable(repository: &str, number: u64) -> Result<()> {
@@ -3682,24 +3345,18 @@ async fn fetch_pull_request_auto_merge_status(
     repository: &str,
     number: u64,
 ) -> Result<PullRequestAutoMergeStatusRaw> {
-    if crate::github_api::token_available() {
-        let output = run_gh_json(&[
-            "api".to_string(),
-            format!("repos/{repository}/pulls/{number}"),
-        ])
-        .await?;
-        let raw = serde_json::from_str::<PullRequestRestStatusRaw>(&output).with_context(|| {
-            format!("failed to parse auto-merge status for {repository}#{number}")
-        })?;
-        return Ok(PullRequestAutoMergeStatusRaw {
-            auto_merge_request: raw.auto_merge,
-            is_draft: raw.draft,
-            state: raw.state,
-        });
-    }
-    let output = run_gh_json(&pull_request_auto_merge_status_args(repository, number)).await?;
-    serde_json::from_str::<PullRequestAutoMergeStatusRaw>(&output)
-        .with_context(|| format!("failed to parse auto-merge status for {repository}#{number}"))
+    let output = run_gh_json(&[
+        "api".to_string(),
+        format!("repos/{repository}/pulls/{number}"),
+    ])
+    .await?;
+    let raw = serde_json::from_str::<PullRequestRestStatusRaw>(&output)
+        .with_context(|| format!("failed to parse auto-merge status for {repository}#{number}"))?;
+    Ok(PullRequestAutoMergeStatusRaw {
+        auto_merge_request: raw.auto_merge,
+        is_draft: raw.draft,
+        state: raw.state,
+    })
 }
 
 async fn update_pull_request_auto_merge(
@@ -3737,18 +3394,6 @@ async fn update_pull_request_auto_merge(
     request.append(&mut args);
     run_gh_json(&request).await?;
     Ok(())
-}
-
-fn pull_request_auto_merge_status_args(repository: &str, number: u64) -> Vec<String> {
-    vec![
-        "pr".to_string(),
-        "view".to_string(),
-        number.to_string(),
-        "--repo".to_string(),
-        repository.to_string(),
-        "--json".to_string(),
-        "state,isDraft,autoMergeRequest".to_string(),
-    ]
 }
 
 fn pull_request_auto_merge_enable_blocker(
@@ -3859,19 +3504,11 @@ fn assignee_api_args(
 }
 
 pub async fn convert_pull_request_to_draft(repository: &str, number: u64) -> Result<()> {
-    if crate::github_api::token_available() {
-        return set_pull_request_draft_state(repository, number, true).await;
-    }
-    run_gh_json(&pull_request_ready_args(repository, number, true)).await?;
-    Ok(())
+    set_pull_request_draft_state(repository, number, true).await
 }
 
 pub async fn mark_pull_request_ready_for_review(repository: &str, number: u64) -> Result<()> {
-    if crate::github_api::token_available() {
-        return set_pull_request_draft_state(repository, number, false).await;
-    }
-    run_gh_json(&pull_request_ready_args(repository, number, false)).await?;
-    Ok(())
+    set_pull_request_draft_state(repository, number, false).await
 }
 
 async fn set_pull_request_draft_state(repository: &str, number: u64, draft: bool) -> Result<()> {
@@ -4094,20 +3731,6 @@ fn parse_subscribable_viewer_subscription(
     }
     .ok_or_else(|| anyhow!("subscription target {repository}#{number} was not found"))?;
     Ok(node.viewer_subscription)
-}
-
-fn pull_request_ready_args(repository: &str, number: u64, undo: bool) -> Vec<String> {
-    let mut args = vec![
-        "pr".to_string(),
-        "ready".to_string(),
-        number.to_string(),
-        "--repo".to_string(),
-        repository.to_string(),
-    ];
-    if undo {
-        args.push("--undo".to_string());
-    }
-    args
 }
 
 fn parse_issue_item_output(
@@ -4902,8 +4525,15 @@ async fn run_gh_json_raw(args: &[String]) -> Result<String> {
 }
 
 async fn run_gh_json_raw_once(args: &[String]) -> Result<String> {
-    if crate::github_api::token_available() && args.first().is_some_and(|arg| arg == "api") {
-        return crate::github_api::run_api_args(args).await;
+    if args.first().map(String::as_str) != Some("api") {
+        bail!("GitHub backend expected a `gh api` request");
+    }
+    if matches!(
+        crate::github_api::selected_backend(),
+        crate::github_api::GitHubBackend::DirectApi
+    ) {
+        let request = crate::github_api::parse_api_args(args)?;
+        return crate::github_api::run_direct_request(&request).await;
     }
 
     let gh_request = debug_log_gh_request_started(args, None);
@@ -4935,7 +4565,6 @@ async fn run_gh_json_raw_once(args: &[String]) -> Result<String> {
 
 fn is_retryable_gh_json_request(args: &[String]) -> bool {
     match args.first().map(String::as_str) {
-        Some("search") => true,
         Some("api") if args.get(1).is_some_and(|arg| arg == "graphql") => !args.iter().any(|arg| {
             arg.trim_start_matches("query=")
                 .trim_start()
@@ -4998,40 +4627,6 @@ fn is_retryable_gh_json_error(error: &str) -> bool {
     .any(|needle| error.contains(needle))
 }
 
-async fn run_gh_text_in_dir(args: &[String], directory: &Path) -> Result<String> {
-    let _guard = UserGhRequestGuard::new();
-    let gh_request = debug_log_gh_request_started(args, Some(directory));
-    let output = Command::new("gh")
-        .env("GH_PROMPT_DISABLED", "1")
-        .current_dir(directory)
-        .args(args)
-        .output()
-        .await
-        .map_err(|error| {
-            log_gh_request_failed_to_start(gh_request.clone(), args, Some(directory), &error);
-            if error.kind() == ErrorKind::NotFound {
-                anyhow!("{}", gh_missing_message(args))
-            } else {
-                anyhow!(
-                    "failed to run gh {} in {}: {error}",
-                    args.join(" "),
-                    directory.display()
-                )
-            }
-        })?;
-    debug_log_gh_request_finished(gh_request, args, Some(directory), &output);
-
-    if !output.status.success() {
-        log_gh_request_failed_result(args, Some(directory), &output);
-        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        let message = if stderr.is_empty() { stdout } else { stderr };
-        bail!("{}", gh_failure_message(args, &message));
-    }
-
-    String::from_utf8(output.stdout).context("gh output was not UTF-8")
-}
-
 async fn run_git_text_in_dir(args: &[String], directory: &Path) -> Result<String> {
     let command = format!("git {}", args.join(" "));
     debug!(command = %command, cwd = %directory.display(), "git request started");
@@ -5082,12 +4677,6 @@ async fn run_git_text_in_dir(args: &[String], directory: &Path) -> Result<String
 }
 
 fn gh_missing_message(args: &[String]) -> String {
-    if let Some(token_env) = crate::github_api::token_env_name() {
-        return format!(
-            "This operation is not yet supported by the PAT backend selected through {token_env}, and GitHub CLI `gh` was not found. Tried: gh {}",
-            args.join(" ")
-        );
-    }
     format!(
         "No GitHub authentication backend is available: set GHR_GITHUB_TOKEN (GH_TOKEN and GITHUB_TOKEN are also supported), or install GitHub CLI from https://cli.github.com/ and run `gh auth login`. Tried: gh {}",
         args.join(" ")
@@ -5111,6 +4700,50 @@ fn is_gh_not_found_error(error: &anyhow::Error) -> bool {
         let message = cause.to_string();
         message.contains("HTTP 404") || message.contains("Not Found (HTTP 404)")
     })
+}
+
+fn pull_request_merge_status_from_action(
+    action: &PullRequestActionRaw,
+) -> PullRequestMergeStatusRaw {
+    let status_check_rollup = action
+        .status_check_rollup
+        .as_ref()
+        .and_then(|rollup| rollup.contexts.as_ref())
+        .and_then(|contexts| contexts.nodes.as_ref())
+        .map(|nodes| {
+            nodes
+                .iter()
+                .filter_map(|node| match node {
+                    PullRequestCheckContextRaw::CheckRun {
+                        conclusion, status, ..
+                    } => Some(PullRequestCheckRaw {
+                        conclusion: conclusion.clone(),
+                        status: status.clone(),
+                    }),
+                    PullRequestCheckContextRaw::StatusContext { state } => {
+                        let state = state.clone();
+                        let completed =
+                            matches!(state.as_deref(), Some("SUCCESS" | "FAILURE" | "ERROR"));
+                        Some(PullRequestCheckRaw {
+                            conclusion: completed.then_some(state.clone()).flatten(),
+                            status: Some(if completed {
+                                "COMPLETED".to_string()
+                            } else {
+                                state.unwrap_or_else(|| "PENDING".to_string())
+                            }),
+                        })
+                    }
+                    PullRequestCheckContextRaw::Other => None,
+                })
+                .collect()
+        });
+    PullRequestMergeStatusRaw {
+        is_draft: action.is_draft,
+        merge_state_status: action.merge_state_status.clone(),
+        review_decision: action.review_decision.clone(),
+        state: action.state.clone(),
+        status_check_rollup,
+    }
 }
 
 fn pull_request_merge_blocker_message(
@@ -5181,9 +4814,10 @@ fn check_rollup_counts(status: &PullRequestMergeStatusRaw) -> (usize, usize) {
     let mut pending = 0;
     for check in status.status_check_rollup.as_deref().unwrap_or(&[]) {
         match check.conclusion.as_deref() {
-            Some("FAILURE" | "CANCELLED" | "TIMED_OUT" | "ACTION_REQUIRED" | "STARTUP_FAILURE") => {
-                failing += 1
-            }
+            Some(
+                "FAILURE" | "ERROR" | "CANCELLED" | "TIMED_OUT" | "ACTION_REQUIRED"
+                | "STARTUP_FAILURE",
+            ) => failing += 1,
             Some(_) => {}
             None => {
                 if !matches!(check.status.as_deref(), Some("COMPLETED")) {
@@ -5601,65 +5235,6 @@ fn failed_check_runs_from_rollup(
     runs
 }
 
-fn failed_check_runs_from_pr_checks_json(output: &str) -> Result<FailedCheckRunDiscovery> {
-    let checks = serde_json::from_str::<Vec<PullRequestCheckStatusRaw>>(output)?;
-    let mut discovery = FailedCheckRunDiscovery::default();
-
-    for check in checks {
-        let name = check
-            .name
-            .as_deref()
-            .and_then(non_empty_string)
-            .unwrap_or_else(|| "unknown check".to_string());
-        if pr_check_should_show(&check) {
-            discovery.check_runs.push(CheckRunSummary {
-                name: name.clone(),
-                workflow: check.workflow.as_deref().and_then(non_empty_string),
-                state: check.state.as_deref().and_then(non_empty_string),
-                bucket: check.bucket.as_deref().and_then(non_empty_string),
-                link: check.link.as_deref().and_then(non_empty_string),
-                description: check.description.as_deref().and_then(non_empty_string),
-            });
-        }
-        if !pr_check_failed(&check) {
-            continue;
-        }
-        let Some(run_id) = check.link.as_deref().and_then(actions_run_id_from_url) else {
-            push_unique_string(&mut discovery.unmapped_failed_checks, name);
-            continue;
-        };
-        add_failed_check_run(&mut discovery.runs, run_id, check.workflow, name);
-    }
-
-    Ok(discovery)
-}
-
-fn pr_check_should_show(check: &PullRequestCheckStatusRaw) -> bool {
-    if let Some(bucket) = check.bucket.as_deref().and_then(non_empty_string) {
-        return !matches_normalized(Some(&bucket), &["pass"]);
-    }
-    check.state.as_deref().and_then(non_empty_string).is_some()
-        && !matches_normalized(check.state.as_deref(), &["pass", "success"])
-}
-
-fn pr_check_failed(check: &PullRequestCheckStatusRaw) -> bool {
-    matches_normalized(check.bucket.as_deref(), &["fail", "cancel"])
-        || matches_normalized(
-            check.state.as_deref(),
-            &[
-                "fail",
-                "failure",
-                "error",
-                "cancel",
-                "cancelled",
-                "canceled",
-                "timed_out",
-                "action_required",
-                "startup_failure",
-            ],
-        )
-}
-
 fn check_run_should_show(conclusion: Option<&str>, status: Option<&str>) -> bool {
     match conclusion {
         Some(value) => !value.eq_ignore_ascii_case("SUCCESS"),
@@ -5721,17 +5296,6 @@ fn actions_run_id_from_url(url: &str) -> Option<u64> {
     digits.parse().ok()
 }
 
-fn merge_failed_check_runs(
-    target: &mut Vec<FailedCheckRunSummary>,
-    source: Vec<FailedCheckRunSummary>,
-) {
-    for run in source {
-        for check in run.checks {
-            add_failed_check_run(target, run.run_id, run.workflow.clone(), check);
-        }
-    }
-}
-
 fn add_failed_check_run(
     runs: &mut Vec<FailedCheckRunSummary>,
     run_id: u64,
@@ -5783,49 +5347,6 @@ fn is_gh_auth_error(message: &str) -> bool {
     ]
     .iter()
     .any(|needle| normalized.contains(needle))
-}
-
-fn search_item_to_work_item(kind: SectionKind, item: SearchItemRaw) -> WorkItem {
-    let item_kind = match kind {
-        SectionKind::PullRequests => ItemKind::PullRequest,
-        SectionKind::Issues => ItemKind::Issue,
-        SectionKind::Notifications => ItemKind::Notification,
-    };
-    let repo = item.repository.name_with_owner;
-    let labels = item
-        .labels
-        .unwrap_or_default()
-        .into_iter()
-        .map(|label| label.name)
-        .collect::<Vec<_>>();
-    let assignees = assignees_from_raw(item.assignees);
-
-    WorkItem {
-        id: format!("{repo}#{}", item.number),
-        kind: item_kind,
-        repo,
-        number: Some(item.number),
-        title: item.title,
-        body: item.body.filter(|body| !body.trim().is_empty()),
-        author: item.author.map(|author| author.login),
-        state: item.state,
-        url: item.url,
-        created_at: item.created_at,
-        updated_at: item.updated_at,
-        last_read_at: None,
-        labels,
-        reactions: ReactionSummary::default(),
-        milestone: None,
-        assignees,
-        comments: item.comments_count,
-        unread: None,
-        reason: None,
-        extra: item
-            .is_draft
-            .filter(|is_draft| *is_draft)
-            .map(|_| "draft".to_string()),
-        viewer_subscription: None,
-    }
 }
 
 fn search_api_item_to_work_item(kind: SectionKind, item: SearchApiIssueRaw) -> WorkItem {
@@ -6333,13 +5854,6 @@ mod tests {
             "-f".to_string(),
             "query=query { viewer { login } }".to_string(),
         ]));
-        assert!(is_retryable_gh_json_request(&[
-            "search".to_string(),
-            "prs".to_string(),
-            "--json".to_string(),
-            "number,title".to_string(),
-        ]));
-
         assert!(!is_retryable_gh_json_request(&[
             "api".to_string(),
             "-X".to_string(),
@@ -6369,49 +5883,7 @@ mod tests {
     }
 
     #[test]
-    fn search_args_put_flags_before_query_separator() {
-        let args = search_args(
-            "prs",
-            "number,title",
-            "reviewed-by:chenyukang -author:chenyukang sort:created-desc",
-            50,
-        );
-
-        assert_eq!(
-            args,
-            vec![
-                "search",
-                "prs",
-                "--json",
-                "number,title",
-                "--limit",
-                "50",
-                "--",
-                "reviewed-by:chenyukang",
-                "-author:chenyukang",
-                "sort:created-desc"
-            ]
-        );
-    }
-
-    #[test]
-    fn search_args_cap_limit_to_github_search_result_window() {
-        let args = search_args("issues", "number,title", "repo:rust-lang/rust is:open", 500);
-
-        assert_eq!(
-            args,
-            vec![
-                "search",
-                "issues",
-                "--json",
-                "number,title",
-                "--limit",
-                "500",
-                "--",
-                "repo:rust-lang/rust",
-                "is:open"
-            ]
-        );
+    fn search_limit_is_clamped_to_github_search_result_window() {
         assert_eq!(search_command_limit(0), 1);
         assert_eq!(search_command_limit(50), 50);
         assert_eq!(search_command_limit(101), 101);
@@ -6573,18 +6045,6 @@ mod tests {
 
         assert!(jobs.is_empty());
         assert_eq!(next_cursor, 5);
-    }
-
-    #[test]
-    fn pull_request_ready_args_toggle_ready_and_draft() {
-        assert_eq!(
-            pull_request_ready_args("owner/repo", 42, false),
-            vec!["pr", "ready", "42", "--repo", "owner/repo"]
-        );
-        assert_eq!(
-            pull_request_ready_args("owner/repo", 42, true),
-            vec!["pr", "ready", "42", "--repo", "owner/repo", "--undo"]
-        );
     }
 
     #[test]
@@ -7316,14 +6776,6 @@ mod tests {
     }
 
     #[test]
-    fn search_fields_include_body_for_preview() {
-        assert!(search_fields(SectionKind::PullRequests).contains("body"));
-        assert!(search_fields(SectionKind::Issues).contains("body"));
-        assert!(search_fields(SectionKind::PullRequests).contains("createdAt"));
-        assert!(search_fields(SectionKind::Issues).contains("createdAt"));
-    }
-
-    #[test]
     fn paginated_comments_are_flattened_sorted_oldest_first_and_not_truncated() {
         let output = r##"
         [
@@ -7746,7 +7198,7 @@ mod tests {
     #[test]
     fn auth_errors_are_rewritten_with_login_hint() {
         let message = gh_failure_message(
-            &["search".to_string(), "prs".to_string()],
+            &["api".to_string(), "user".to_string()],
             "To get started with GitHub CLI, please run: gh auth login",
         );
 
@@ -7755,69 +7207,68 @@ mod tests {
     }
 
     #[test]
-    fn merge_pull_request_args_default_to_merge_flag() {
+    fn merge_pull_request_uses_rest_api() {
         assert_eq!(
-            merge_pull_request_args("owner/repo", 42, MergeMethod::default()),
+            merge_pull_request_api_args("owner/repo", 42, MergeMethod::default()),
             vec![
-                "pr".to_string(),
-                "merge".to_string(),
-                "42".to_string(),
-                "--repo".to_string(),
-                "owner/repo".to_string(),
-                "--merge".to_string(),
+                "api".to_string(),
+                "-X".to_string(),
+                "PUT".to_string(),
+                "repos/owner/repo/pulls/42/merge".to_string(),
+                "-f".to_string(),
+                "merge_method=merge".to_string(),
             ]
+        );
+        assert_eq!(
+            merge_pull_request_api_args("owner/repo", 42, MergeMethod::Squash).last(),
+            Some(&"merge_method=squash".to_string())
+        );
+        assert_eq!(
+            merge_pull_request_api_args("owner/repo", 42, MergeMethod::Rebase).last(),
+            Some(&"merge_method=rebase".to_string())
         );
     }
 
     #[test]
-    fn merge_pull_request_args_use_selected_method_flag() {
-        assert_eq!(
-            merge_pull_request_args("owner/repo", 42, MergeMethod::Squash).last(),
-            Some(&"--squash".to_string())
-        );
-        assert_eq!(
-            merge_pull_request_args("owner/repo", 42, MergeMethod::Rebase).last(),
-            Some(&"--rebase".to_string())
-        );
+    fn merge_preflight_maps_graphql_check_contexts() {
+        let action = serde_json::from_value::<PullRequestActionRaw>(serde_json::json!({
+            "state": "OPEN",
+            "isDraft": false,
+            "mergeStateStatus": "BLOCKED",
+            "reviewDecision": "APPROVED",
+            "statusCheckRollup": {
+                "contexts": {
+                    "totalCount": 3,
+                    "nodes": [
+                        {
+                            "__typename": "CheckRun",
+                            "conclusion": "FAILURE",
+                            "status": "COMPLETED"
+                        },
+                        {
+                            "__typename": "StatusContext",
+                            "state": "ERROR"
+                        },
+                        {
+                            "__typename": "StatusContext",
+                            "state": "PENDING"
+                        }
+                    ]
+                }
+            }
+        }))
+        .expect("valid pull request action");
+
+        let status = pull_request_merge_status_from_action(&action);
+        assert_eq!(check_rollup_counts(&status), (2, 1));
+        let message = pull_request_merge_blocker_message("owner/repo", 42, &status)
+            .expect("blocked pull request");
+        assert!(message.contains("2 check(s) failing"));
+        assert!(message.contains("1 check(s) pending"));
     }
 
     #[test]
-    fn auto_merge_commands_use_non_interactive_gh_pr_merge_flags() {
-        assert_eq!(
-            enable_pull_request_auto_merge_args("owner/repo", 42, "--merge"),
-            vec![
-                "pr",
-                "merge",
-                "42",
-                "--repo",
-                "owner/repo",
-                "--merge",
-                "--auto"
-            ]
-        );
-        assert_eq!(
-            disable_pull_request_auto_merge_args("owner/repo", 42),
-            vec![
-                "pr",
-                "merge",
-                "42",
-                "--repo",
-                "owner/repo",
-                "--disable-auto"
-            ]
-        );
-        assert_eq!(
-            pull_request_auto_merge_status_args("owner/repo", 42),
-            vec![
-                "pr",
-                "view",
-                "42",
-                "--repo",
-                "owner/repo",
-                "--json",
-                "state,isDraft,autoMergeRequest"
-            ]
-        );
+    fn repository_merge_methods_use_rest_api() {
         assert_eq!(
             repository_merge_methods_args("owner/repo"),
             vec![
@@ -8291,136 +7742,54 @@ mod tests {
     }
 
     #[test]
-    fn pr_checks_json_groups_failed_checks_by_actions_run() {
-        let output = r#"
-[
-  {
-    "bucket": "fail",
-    "description": "failed after 2m",
-    "link": "https://github.com/owner/repo/actions/runs/1001/job/1?pr=2",
-    "name": "test",
-    "state": "FAILURE",
-    "workflow": "CI"
-  },
-  {
-    "bucket": "fail",
-    "link": "https://github.com/owner/repo/actions/runs/1001/job/2?pr=2",
-    "name": "lint",
-    "state": "FAILURE",
-    "workflow": "CI"
-  },
-  {
-    "bucket": "pass",
-    "link": "https://github.com/owner/repo/actions/runs/1002/job/3?pr=2",
-    "name": "fmt",
-    "state": "SUCCESS",
-    "workflow": "CI"
-  },
-  {
-    "bucket": "fail",
-    "link": "https://example.com/checks/9",
-    "name": "external",
-    "state": "ERROR",
-    "workflow": null
-  }
-]
-"#;
-
-        let discovery = failed_check_runs_from_pr_checks_json(output).expect("valid checks");
-
-        assert_eq!(
-            discovery.runs,
-            vec![FailedCheckRunSummary {
-                run_id: 1001,
-                workflow: Some("CI".to_string()),
-                checks: vec!["test".to_string(), "lint".to_string()],
-            }]
-        );
-        assert_eq!(
-            discovery.check_runs,
-            vec![
-                CheckRunSummary {
-                    name: "test".to_string(),
-                    workflow: Some("CI".to_string()),
-                    state: Some("FAILURE".to_string()),
-                    bucket: Some("fail".to_string()),
-                    link: Some(
-                        "https://github.com/owner/repo/actions/runs/1001/job/1?pr=2".to_string()
-                    ),
-                    description: Some("failed after 2m".to_string()),
-                },
-                CheckRunSummary {
-                    name: "lint".to_string(),
-                    workflow: Some("CI".to_string()),
-                    state: Some("FAILURE".to_string()),
-                    bucket: Some("fail".to_string()),
-                    link: Some(
-                        "https://github.com/owner/repo/actions/runs/1001/job/2?pr=2".to_string()
-                    ),
-                    description: None,
-                },
-                CheckRunSummary {
-                    name: "external".to_string(),
-                    workflow: None,
-                    state: Some("ERROR".to_string()),
-                    bucket: Some("fail".to_string()),
-                    link: Some("https://example.com/checks/9".to_string()),
-                    description: None,
-                },
-            ]
-        );
-        assert_eq!(discovery.unmapped_failed_checks, vec!["external"]);
-    }
-
-    #[test]
-    fn rerun_failed_checks_commands_are_constructed_for_pr_and_run() {
-        assert_eq!(
-            pr_checks_args("owner/repo", 42),
-            vec![
-                "pr",
-                "checks",
-                "42",
-                "--repo",
-                "owner/repo",
-                "--json",
-                "name,state,bucket,workflow,link,description",
-            ]
-        );
+    fn rerun_failed_checks_uses_rest_api() {
         assert_eq!(
             rerun_failed_check_run_args("owner/repo", 1001),
-            vec!["run", "rerun", "1001", "--failed", "--repo", "owner/repo"]
-        );
-    }
-
-    #[test]
-    fn update_pull_request_branch_uses_gh_update_branch_command() {
-        assert_eq!(
-            update_pull_request_branch_args("owner/repo", 42),
             vec![
-                "pr".to_string(),
-                "update-branch".to_string(),
-                "42".to_string(),
-                "--repo".to_string(),
-                "owner/repo".to_string(),
+                "api",
+                "-X",
+                "POST",
+                "repos/owner/repo/actions/runs/1001/rerun-failed-jobs"
             ]
         );
     }
 
     #[test]
-    fn create_pull_request_args_use_repo_head_title_and_body() {
+    fn update_pull_request_branch_uses_rest_api() {
         assert_eq!(
-            create_pull_request_args("owner/repo", "feature/new-pr", "Add feature", "Body text"),
+            update_pull_request_branch_api_args("owner/repo", 42),
             vec![
-                "pr".to_string(),
-                "create".to_string(),
-                "--repo".to_string(),
-                "owner/repo".to_string(),
-                "--head".to_string(),
-                "feature/new-pr".to_string(),
-                "--title".to_string(),
-                "Add feature".to_string(),
-                "--body".to_string(),
-                "Body text".to_string(),
+                "api".to_string(),
+                "-X".to_string(),
+                "PUT".to_string(),
+                "repos/owner/repo/pulls/42/update-branch".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn create_pull_request_uses_rest_api() {
+        assert_eq!(
+            create_pull_request_api_args(
+                "owner/repo",
+                "feature/new-pr",
+                "main",
+                "Add feature",
+                "Body text"
+            ),
+            vec![
+                "api".to_string(),
+                "-X".to_string(),
+                "POST".to_string(),
+                "repos/owner/repo/pulls".to_string(),
+                "-f".to_string(),
+                "head=feature/new-pr".to_string(),
+                "-f".to_string(),
+                "base=main".to_string(),
+                "-f".to_string(),
+                "title=Add feature".to_string(),
+                "-f".to_string(),
+                "body=Body text".to_string(),
             ]
         );
     }
@@ -8474,24 +7843,13 @@ mod tests {
     }
 
     #[test]
-    fn pull_request_number_parses_from_create_output_url() {
-        assert_eq!(
-            pull_request_number_from_create_output("https://github.com/owner/repo/pull/42\n"),
-            Some(42)
-        );
-        assert_eq!(
-            pull_request_number_from_create_output(
-                "created https://github.com/owner/repo/pull/77."
-            ),
-            Some(77)
-        );
-    }
-
-    #[test]
     fn non_auth_gh_errors_keep_original_command_context() {
-        let message = gh_failure_message(&["search".to_string(), "issues".to_string()], "HTTP 500");
+        let message = gh_failure_message(
+            &["api".to_string(), "search/issues".to_string()],
+            "HTTP 500",
+        );
 
-        assert_eq!(message, "gh search issues failed: HTTP 500");
+        assert_eq!(message, "gh api search/issues failed: HTTP 500");
     }
 
     #[test]

--- a/src/github.rs
+++ b/src/github.rs
@@ -1,6 +1,5 @@
 use std::collections::{HashMap, HashSet};
 use std::future::Future;
-use std::io::ErrorKind;
 use std::path::Path;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
@@ -14,10 +13,6 @@ use tokio::time::sleep;
 use tracing::{debug, error, info, warn};
 
 use crate::config::{Config, SearchSection, github_repo_from_remote_url};
-use crate::log::{
-    GhLogRequest, fail_gh_request_to_start as record_gh_request_failed_to_start,
-    finish_gh_request as record_gh_request_finished, start_gh_request as record_gh_request_started,
-};
 use crate::model::{
     ActionHints, CheckRunSummary, CheckSummary, CommentPreview, CommentPreviewKind,
     FailedCheckRunSummary, ItemKind, MergeQueueInfo, Milestone, PullRequestBranch,
@@ -27,7 +22,6 @@ use crate::model::{
 };
 
 static VIEWER_LOGIN: OnceCell<String> = OnceCell::const_new();
-static GH_API_SLURP_SUPPORTED: OnceCell<bool> = OnceCell::const_new();
 static USER_GH_REQUESTS_IN_FLIGHT: AtomicUsize = AtomicUsize::new(0);
 
 const SEARCH_API_MAX_RESULTS: usize = 1000;
@@ -132,159 +126,6 @@ async fn wait_for_user_gh_requests() {
     while USER_GH_REQUESTS_IN_FLIGHT.load(Ordering::Acquire) > 0 {
         sleep(BACKGROUND_GH_YIELD_INTERVAL).await;
     }
-}
-
-fn gh_request_kind(args: &[String]) -> &'static str {
-    if args.first().is_some_and(|arg| arg == "api") {
-        "gh api"
-    } else {
-        "gh"
-    }
-}
-
-fn gh_command_display(args: &[String]) -> String {
-    format!("gh {}", args.join(" "))
-}
-
-fn debug_log_gh_request_started(args: &[String], directory: Option<&Path>) -> GhLogRequest {
-    let kind = gh_request_kind(args);
-    let command = gh_command_display(args);
-    if let Some(directory) = directory {
-        debug!(
-            kind,
-            command = %command,
-            cwd = %directory.display(),
-            "gh request started"
-        );
-    } else {
-        debug!(kind, command = %command, "gh request started");
-    }
-    record_gh_request_started(kind, command, directory)
-}
-
-fn debug_log_gh_request_finished(
-    request: GhLogRequest,
-    args: &[String],
-    directory: Option<&Path>,
-    output: &std::process::Output,
-) {
-    let kind = gh_request_kind(args);
-    let command = gh_command_display(args);
-    if let Some(directory) = directory {
-        debug!(
-            kind,
-            command = %command,
-            cwd = %directory.display(),
-            status = %output.status,
-            success = output.status.success(),
-            stdout_bytes = output.stdout.len(),
-            stderr_bytes = output.stderr.len(),
-            "gh request finished"
-        );
-    } else {
-        debug!(
-            kind,
-            command = %command,
-            status = %output.status,
-            success = output.status.success(),
-            stdout_bytes = output.stdout.len(),
-            stderr_bytes = output.stderr.len(),
-            "gh request finished"
-        );
-    }
-    record_gh_request_finished(request, output);
-}
-
-fn log_gh_request_failed_to_start(
-    request: GhLogRequest,
-    args: &[String],
-    directory: Option<&Path>,
-    error: &std::io::Error,
-) {
-    let kind = gh_request_kind(args);
-    let command = gh_command_display(args);
-    if let Some(directory) = directory {
-        debug!(
-            kind,
-            command = %command,
-            cwd = %directory.display(),
-            error = %error,
-            "gh request failed to start"
-        );
-        error!(
-            kind,
-            command = %command,
-            cwd = %directory.display(),
-            error = %error,
-            "gh request failed to start"
-        );
-    } else {
-        debug!(
-            kind,
-            command = %command,
-            error = %error,
-            "gh request failed to start"
-        );
-        error!(
-            kind,
-            command = %command,
-            error = %error,
-            "gh request failed to start"
-        );
-    }
-    record_gh_request_failed_to_start(request, error);
-}
-
-fn log_gh_request_failed_result(
-    args: &[String],
-    directory: Option<&Path>,
-    output: &std::process::Output,
-) {
-    let kind = gh_request_kind(args);
-    let command = gh_command_display(args);
-    if let Some(directory) = directory {
-        error!(
-            kind,
-            command = %command,
-            cwd = %directory.display(),
-            status = %output.status,
-            message = %gh_output_message(output),
-            stdout_bytes = output.stdout.len(),
-            stderr_bytes = output.stderr.len(),
-            "gh request returned failure"
-        );
-    } else {
-        error!(
-            kind,
-            command = %command,
-            status = %output.status,
-            message = %gh_output_message(output),
-            stdout_bytes = output.stdout.len(),
-            stderr_bytes = output.stderr.len(),
-            "gh request returned failure"
-        );
-    }
-}
-
-fn gh_output_message(output: &std::process::Output) -> String {
-    gh_output_message_from_parts(&output.stdout, &output.stderr)
-}
-
-fn gh_output_message_from_parts(stdout: &[u8], stderr: &[u8]) -> String {
-    let stderr = String::from_utf8_lossy(stderr).trim().to_string();
-    let stdout = String::from_utf8_lossy(stdout).trim().to_string();
-    let message = if stderr.is_empty() { stdout } else { stderr };
-    truncate_gh_output_message(&message)
-}
-
-fn truncate_gh_output_message(message: &str) -> String {
-    const MAX_CHARS: usize = 1200;
-    if message.chars().count() <= MAX_CHARS {
-        return message.to_string();
-    }
-    let mut truncated = message.chars().take(MAX_CHARS).collect::<String>();
-    truncated.push_str("...");
-    truncated
 }
 
 #[derive(Debug, Deserialize)]
@@ -1507,7 +1348,7 @@ async fn fetch_number_lookup_item(
     ];
     let output = match run_gh_json(&args).await {
         Ok(output) => output,
-        Err(error) if is_gh_not_found_error(&error) => return Ok(None),
+        Err(error) if is_github_not_found_error(&error) => return Ok(None),
         Err(error) => {
             return Err(error)
                 .with_context(|| format!("failed to fetch {repo}#{number} by number"));
@@ -2185,49 +2026,7 @@ async fn gh_api_slurp_supported() -> bool {
     if !crate::github_api::selected_backend().supports_cli_commands() {
         return false;
     }
-    *GH_API_SLURP_SUPPORTED
-        .get_or_init(detect_gh_api_slurp_support)
-        .await
-}
-
-async fn detect_gh_api_slurp_support() -> bool {
-    let args = vec!["api".to_string(), "--help".to_string()];
-    let gh_request = debug_log_gh_request_started(&args, None);
-    let output = Command::new("gh")
-        .env("GH_PROMPT_DISABLED", "1")
-        .args(&args)
-        .output()
-        .await;
-
-    match output {
-        Ok(output) if output.status.success() => {
-            debug_log_gh_request_finished(gh_request, &args, None, &output);
-            let stdout = String::from_utf8_lossy(&output.stdout);
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            gh_api_help_has_flag(&stdout, "--slurp") || gh_api_help_has_flag(&stderr, "--slurp")
-        }
-        Ok(output) => {
-            debug_log_gh_request_finished(gh_request, &args, None, &output);
-            debug!(
-                status = %output.status,
-                "failed to inspect gh api help for --slurp support; assuming supported"
-            );
-            true
-        }
-        Err(error) => {
-            log_gh_request_failed_to_start(gh_request, &args, None, &error);
-            debug!(
-                error = %error,
-                "failed to inspect gh api help for --slurp support; assuming supported"
-            );
-            true
-        }
-    }
-}
-
-fn gh_api_help_has_flag(help: &str, flag: &str) -> bool {
-    help.split(|ch: char| ch.is_whitespace() || matches!(ch, ',' | '[' | ']' | '(' | ')' | '`'))
-        .any(|token| token == flag)
+    crate::github_gh::api_slurp_supported().await
 }
 
 fn paginated_api_slurp_args(path: &str, accept_header: Option<&str>) -> Vec<String> {
@@ -4512,7 +4311,7 @@ async fn run_gh_json_raw(args: &[String]) -> Result<String> {
                     attempt = attempt + 1,
                     retry_in_ms = delay.as_millis(),
                     error = %error,
-                    command = %gh_command_display(args),
+                    command = %crate::github_gh::command_display(args),
                     "retrying transient gh request failure"
                 );
                 sleep(delay).await;
@@ -4528,39 +4327,13 @@ async fn run_gh_json_raw_once(args: &[String]) -> Result<String> {
     if args.first().map(String::as_str) != Some("api") {
         bail!("GitHub backend expected a `gh api` request");
     }
-    if matches!(
-        crate::github_api::selected_backend(),
-        crate::github_api::GitHubBackend::DirectApi
-    ) {
-        let request = crate::github_api::parse_api_args(args)?;
-        return crate::github_api::run_direct_request(&request).await;
+    match crate::github_api::selected_backend() {
+        crate::github_api::GitHubBackend::DirectApi => {
+            let request = crate::github_api::parse_api_args(args)?;
+            crate::github_api::run_direct_request(&request).await
+        }
+        crate::github_api::GitHubBackend::GitHubCli => crate::github_gh::run_api(args).await,
     }
-
-    let gh_request = debug_log_gh_request_started(args, None);
-    let output = Command::new("gh")
-        .env("GH_PROMPT_DISABLED", "1")
-        .args(args)
-        .output()
-        .await
-        .map_err(|error| {
-            log_gh_request_failed_to_start(gh_request.clone(), args, None, &error);
-            if error.kind() == ErrorKind::NotFound {
-                anyhow!("{}", gh_missing_message(args))
-            } else {
-                anyhow!("failed to run gh {}: {error}", args.join(" "))
-            }
-        })?;
-    debug_log_gh_request_finished(gh_request, args, None, &output);
-
-    if !output.status.success() {
-        log_gh_request_failed_result(args, None, &output);
-        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        let message = if stderr.is_empty() { stdout } else { stderr };
-        bail!("{}", gh_failure_message(args, &message));
-    }
-
-    String::from_utf8(output.stdout).context("gh output was not UTF-8")
 }
 
 fn is_retryable_gh_json_request(args: &[String]) -> bool {
@@ -4676,26 +4449,7 @@ async fn run_git_text_in_dir(args: &[String], directory: &Path) -> Result<String
     String::from_utf8(output.stdout).context("git output was not UTF-8")
 }
 
-fn gh_missing_message(args: &[String]) -> String {
-    format!(
-        "No GitHub authentication backend is available: set GHR_GITHUB_TOKEN (GH_TOKEN and GITHUB_TOKEN are also supported), or install GitHub CLI from https://cli.github.com/ and run `gh auth login`. Tried: gh {}",
-        args.join(" ")
-    )
-}
-
-fn gh_failure_message(args: &[String], message: &str) -> String {
-    if is_gh_auth_error(message) {
-        return format!(
-            "GitHub CLI is installed but not authenticated. Run `gh auth login`, then restart ghr. Original error from `gh {}`: {}",
-            args.join(" "),
-            message
-        );
-    }
-
-    format!("gh {} failed: {message}", args.join(" "))
-}
-
-fn is_gh_not_found_error(error: &anyhow::Error) -> bool {
+fn is_github_not_found_error(error: &anyhow::Error) -> bool {
     error.chain().any(|cause| {
         let message = cause.to_string();
         message.contains("HTTP 404") || message.contains("Not Found (HTTP 404)")
@@ -5333,22 +5087,6 @@ fn split_repository(repository: &str) -> Result<(&str, &str)> {
     Ok((owner, name))
 }
 
-fn is_gh_auth_error(message: &str) -> bool {
-    let normalized = message.to_ascii_lowercase();
-    [
-        "gh auth login",
-        "not authenticated",
-        "not logged in",
-        "authentication required",
-        "requires authentication",
-        "must authenticate",
-        "bad credentials",
-        "no oauth token",
-    ]
-    .iter()
-    .any(|needle| normalized.contains(needle))
-}
-
 fn search_api_item_to_work_item(kind: SectionKind, item: SearchApiIssueRaw) -> WorkItem {
     let item_kind = match kind {
         SectionKind::PullRequests => ItemKind::PullRequest,
@@ -5794,22 +5532,6 @@ mod tests {
 
         assert_eq!(priority, GhRequestPriority::Background);
         assert_eq!(current_gh_request_priority(), GhRequestPriority::User);
-    }
-
-    #[test]
-    fn gh_output_message_prefers_stderr() {
-        assert_eq!(
-            gh_output_message_from_parts(b"{\"state\":\"failure\"}", b"HTTP 403\n"),
-            "HTTP 403"
-        );
-    }
-
-    #[test]
-    fn gh_output_message_uses_stdout_when_stderr_is_empty() {
-        assert_eq!(
-            gh_output_message_from_parts(b"{\"state\":\"failure\"}\n", b""),
-            "{\"state\":\"failure\"}"
-        );
     }
 
     #[test]
@@ -6318,14 +6040,6 @@ mod tests {
                 "repos/owner/repo/milestones?state=open&per_page=100"
             ]
         );
-        assert!(gh_api_help_has_flag(
-            "      --slurp               Use an array of arrays for paginated responses",
-            "--slurp"
-        ));
-        assert!(!gh_api_help_has_flag(
-            "      --paginate            Fetch all pages",
-            "--slurp"
-        ));
         assert_eq!(
             paginated_api_slurp_args(
                 "repos/owner/repo/issues/1/comments?per_page=100",
@@ -7186,27 +6900,6 @@ mod tests {
     }
 
     #[test]
-    fn missing_backend_message_explains_token_and_cli_options() {
-        let message = gh_missing_message(&["api".to_string(), "user".to_string()]);
-
-        assert!(message.contains("No GitHub authentication backend is available"));
-        assert!(message.contains("GHR_GITHUB_TOKEN"));
-        assert!(message.contains("https://cli.github.com/"));
-        assert!(message.contains("gh auth login"));
-    }
-
-    #[test]
-    fn auth_errors_are_rewritten_with_login_hint() {
-        let message = gh_failure_message(
-            &["api".to_string(), "user".to_string()],
-            "To get started with GitHub CLI, please run: gh auth login",
-        );
-
-        assert!(message.contains("not authenticated"));
-        assert!(message.contains("Run `gh auth login`"));
-    }
-
-    #[test]
     fn merge_pull_request_uses_rest_api() {
         assert_eq!(
             merge_pull_request_api_args("owner/repo", 42, MergeMethod::default()),
@@ -7840,16 +7533,6 @@ mod tests {
                 "HEAD:refs/heads/feature/new-pr".to_string(),
             ]
         );
-    }
-
-    #[test]
-    fn non_auth_gh_errors_keep_original_command_context() {
-        let message = gh_failure_message(
-            &["api".to_string(), "search/issues".to_string()],
-            "HTTP 500",
-        );
-
-        assert_eq!(message, "gh api search/issues failed: HTTP 500");
     }
 
     #[test]

--- a/src/github.rs
+++ b/src/github.rs
@@ -902,6 +902,35 @@ struct PullRequestHeadRaw {
 }
 
 #[derive(Debug, Deserialize)]
+struct PullRequestNodeRaw {
+    node_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct PullRequestRestStatusRaw {
+    node_id: String,
+    state: Option<String>,
+    draft: Option<bool>,
+    auto_merge: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CreatedPullRequestRaw {
+    number: u64,
+}
+
+#[derive(Debug, Deserialize)]
+struct MergePullRequestRaw {
+    merged: bool,
+    message: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RepositoryDefaultBranchRaw {
+    default_branch: String,
+}
+
+#[derive(Debug, Deserialize)]
 struct PullRequestHeadRefRaw {
     sha: String,
 }
@@ -1474,6 +1503,10 @@ async fn fetch_search_items_for_query(
     limit: usize,
     exclude_repos: &[String],
 ) -> Result<Vec<WorkItem>> {
+    if crate::github_api::token_available() {
+        return fetch_search_items_with_pat(kind, &filters, limit, exclude_repos).await;
+    }
+
     let subcommand = match kind {
         SectionKind::PullRequests => "prs",
         SectionKind::Issues => "issues",
@@ -1493,6 +1526,31 @@ async fn fetch_search_items_for_query(
         .filter(|item| !is_excluded_repo(&item.repository.name_with_owner, exclude_repos))
         .map(|item| search_item_to_work_item(kind, item))
         .collect())
+}
+
+async fn fetch_search_items_with_pat(
+    kind: SectionKind,
+    filters: &str,
+    limit: usize,
+    exclude_repos: &[String],
+) -> Result<Vec<WorkItem>> {
+    let limit = search_command_limit(limit);
+    let page_size = search_api_page_size(limit);
+    let mut page = 1;
+    let mut items = Vec::new();
+
+    loop {
+        let result = fetch_search_page(kind, filters, page, page_size, exclude_repos).await?;
+        let total_count = result.total_count.unwrap_or(result.items.len());
+        items.extend(result.items);
+        if items.len() >= limit || page.saturating_mul(page_size) >= total_count {
+            break;
+        }
+        page += 1;
+    }
+
+    items.truncate(limit);
+    Ok(items)
 }
 
 fn search_args(subcommand: &str, fields: &str, filters: &str, limit: usize) -> Vec<String> {
@@ -2225,6 +2283,9 @@ async fn fetch_paginated_api_array_output_without_slurp(
 }
 
 async fn gh_api_slurp_supported() -> bool {
+    if crate::github_api::token_available() {
+        return false;
+    }
     *GH_API_SLURP_SUPPORTED
         .get_or_init(detect_gh_api_slurp_support)
         .await
@@ -2482,6 +2543,9 @@ query($owner: String!, $name: String!, $number: Int!) {
         .and_then(|repository| repository.pull_request)
         .ok_or_else(|| anyhow!("pull request {repository}#{number} was not found"))?;
     let mut hints = pull_request_action_hints(&pr);
+    if crate::github_api::token_available() {
+        return Ok(hints);
+    }
     match fetch_failed_check_runs_from_pr_checks(repository, number).await {
         Ok(discovery) => {
             if !discovery.check_runs.is_empty() {
@@ -2502,6 +2566,26 @@ query($owner: String!, $name: String!, $number: Int!) {
 }
 
 pub async fn rerun_failed_pull_request_checks(repository: &str, number: u64) -> Result<()> {
+    if crate::github_api::token_available() {
+        let hints = fetch_pull_request_action_hints(repository, number).await?;
+        if hints.failed_check_runs.is_empty() {
+            bail!("no failed GitHub Actions checks found for {repository}#{number}");
+        }
+        for run in hints.failed_check_runs {
+            run_gh_json(&[
+                "api".to_string(),
+                "-X".to_string(),
+                "POST".to_string(),
+                format!(
+                    "repos/{repository}/actions/runs/{}/rerun-failed-jobs",
+                    run.run_id
+                ),
+            ])
+            .await?;
+        }
+        return Ok(());
+    }
+
     let discovery = fetch_failed_check_runs_from_pr_checks(repository, number).await?;
     if discovery.runs.is_empty() {
         if discovery.unmapped_failed_checks.is_empty() {
@@ -2722,12 +2806,42 @@ pub async fn create_pull_request(
     body: &str,
 ) -> Result<WorkItem> {
     push_pull_request_head(repository, local_dir, head).await?;
+    if crate::github_api::token_available() {
+        let repository_output =
+            run_gh_json(&["api".to_string(), format!("repos/{repository}")]).await?;
+        let repository_raw = serde_json::from_str::<RepositoryDefaultBranchRaw>(&repository_output)
+            .with_context(|| format!("failed to parse default branch for {repository}"))?;
+        let output = run_gh_json(&[
+            "api".to_string(),
+            "-X".to_string(),
+            "POST".to_string(),
+            format!("repos/{repository}/pulls"),
+            "-f".to_string(),
+            format!("head={head}"),
+            "-f".to_string(),
+            format!("base={}", repository_raw.default_branch),
+            "-f".to_string(),
+            format!("title={title}"),
+            "-f".to_string(),
+            format!("body={body}"),
+        ])
+        .await
+        .with_context(|| format!("failed to create pull request in {repository}"))?;
+        let created = serde_json::from_str::<CreatedPullRequestRaw>(&output)
+            .with_context(|| format!("failed to parse created pull request in {repository}"))?;
+        return fetch_created_pull_request(repository, created.number).await;
+    }
+
     let args = create_pull_request_args(repository, head, title, body);
     let output = run_gh_text_in_dir(&args, local_dir)
         .await
         .with_context(|| format!("failed to create pull request in {repository}"))?;
     let number = pull_request_number_from_create_output(&output)
         .ok_or_else(|| anyhow!("gh pr create did not return a pull request URL"))?;
+    fetch_created_pull_request(repository, number).await
+}
+
+async fn fetch_created_pull_request(repository: &str, number: u64) -> Result<WorkItem> {
     let issue_path = format!("repos/{repository}/issues/{number}");
     let issue_output = run_gh_json(&["api".to_string(), issue_path])
         .await
@@ -3310,6 +3424,29 @@ pub async fn edit_item_metadata(
 }
 
 pub async fn merge_pull_request(repository: &str, number: u64, method: MergeMethod) -> Result<()> {
+    if crate::github_api::token_available() {
+        let output = run_gh_json(&[
+            "api".to_string(),
+            "-X".to_string(),
+            "PUT".to_string(),
+            format!("repos/{repository}/pulls/{number}/merge"),
+            "-f".to_string(),
+            format!("merge_method={}", method.label()),
+        ])
+        .await?;
+        let result = serde_json::from_str::<MergePullRequestRaw>(&output)
+            .with_context(|| format!("failed to parse merge response for {repository}#{number}"))?;
+        if !result.merged {
+            bail!(
+                "failed to merge {repository}#{number}: {}",
+                result
+                    .message
+                    .unwrap_or_else(|| "GitHub rejected the merge".to_string())
+            );
+        }
+        return Ok(());
+    }
+
     ensure_pull_request_can_merge(repository, number).await?;
     run_gh_json(&merge_pull_request_args(repository, number, method)).await?;
     Ok(())
@@ -3346,6 +3483,9 @@ async fn ensure_pull_request_can_merge(repository: &str, number: u64) -> Result<
 }
 
 pub async fn close_pull_request(repository: &str, number: u64) -> Result<()> {
+    if crate::github_api::token_available() {
+        return set_issue_state(repository, number, "closed").await;
+    }
     run_gh_json(&[
         "pr".to_string(),
         "close".to_string(),
@@ -3358,6 +3498,9 @@ pub async fn close_pull_request(repository: &str, number: u64) -> Result<()> {
 }
 
 pub async fn reopen_pull_request(repository: &str, number: u64) -> Result<()> {
+    if crate::github_api::token_available() {
+        return set_issue_state(repository, number, "open").await;
+    }
     run_gh_json(&[
         "pr".to_string(),
         "reopen".to_string(),
@@ -3370,6 +3513,9 @@ pub async fn reopen_pull_request(repository: &str, number: u64) -> Result<()> {
 }
 
 pub async fn close_issue(repository: &str, number: u64) -> Result<()> {
+    if crate::github_api::token_available() {
+        return set_issue_state(repository, number, "closed").await;
+    }
     run_gh_json(&[
         "issue".to_string(),
         "close".to_string(),
@@ -3382,6 +3528,9 @@ pub async fn close_issue(repository: &str, number: u64) -> Result<()> {
 }
 
 pub async fn reopen_issue(repository: &str, number: u64) -> Result<()> {
+    if crate::github_api::token_available() {
+        return set_issue_state(repository, number, "open").await;
+    }
     run_gh_json(&[
         "issue".to_string(),
         "reopen".to_string(),
@@ -3394,7 +3543,30 @@ pub async fn reopen_issue(repository: &str, number: u64) -> Result<()> {
 }
 
 pub async fn update_pull_request_branch(repository: &str, number: u64) -> Result<()> {
+    if crate::github_api::token_available() {
+        run_gh_json(&[
+            "api".to_string(),
+            "-X".to_string(),
+            "PUT".to_string(),
+            format!("repos/{repository}/pulls/{number}/update-branch"),
+        ])
+        .await?;
+        return Ok(());
+    }
     run_gh_json(&update_pull_request_branch_args(repository, number)).await?;
+    Ok(())
+}
+
+async fn set_issue_state(repository: &str, number: u64, state: &str) -> Result<()> {
+    run_gh_json(&[
+        "api".to_string(),
+        "-X".to_string(),
+        "PATCH".to_string(),
+        format!("repos/{repository}/issues/{number}"),
+        "-f".to_string(),
+        format!("state={state}"),
+    ])
+    .await?;
     Ok(())
 }
 
@@ -3411,6 +3583,9 @@ fn update_pull_request_branch_args(repository: &str, number: u64) -> Vec<String>
 pub async fn enable_pull_request_auto_merge(repository: &str, number: u64) -> Result<()> {
     ensure_pull_request_auto_merge_can_enable(repository, number).await?;
     let method = auto_merge_method_flag(repository).await?;
+    if crate::github_api::token_available() {
+        return update_pull_request_auto_merge(repository, number, Some(method)).await;
+    }
     run_gh_json(&enable_pull_request_auto_merge_args(
         repository, number, method,
     ))
@@ -3469,6 +3644,9 @@ fn repository_merge_method_flag(
 
 pub async fn disable_pull_request_auto_merge(repository: &str, number: u64) -> Result<()> {
     ensure_pull_request_auto_merge_can_disable(repository, number).await?;
+    if crate::github_api::token_available() {
+        return update_pull_request_auto_merge(repository, number, None).await;
+    }
     run_gh_json(&disable_pull_request_auto_merge_args(repository, number)).await?;
     Ok(())
 }
@@ -3504,9 +3682,61 @@ async fn fetch_pull_request_auto_merge_status(
     repository: &str,
     number: u64,
 ) -> Result<PullRequestAutoMergeStatusRaw> {
+    if crate::github_api::token_available() {
+        let output = run_gh_json(&[
+            "api".to_string(),
+            format!("repos/{repository}/pulls/{number}"),
+        ])
+        .await?;
+        let raw = serde_json::from_str::<PullRequestRestStatusRaw>(&output).with_context(|| {
+            format!("failed to parse auto-merge status for {repository}#{number}")
+        })?;
+        return Ok(PullRequestAutoMergeStatusRaw {
+            auto_merge_request: raw.auto_merge,
+            is_draft: raw.draft,
+            state: raw.state,
+        });
+    }
     let output = run_gh_json(&pull_request_auto_merge_status_args(repository, number)).await?;
     serde_json::from_str::<PullRequestAutoMergeStatusRaw>(&output)
         .with_context(|| format!("failed to parse auto-merge status for {repository}#{number}"))
+}
+
+async fn update_pull_request_auto_merge(
+    repository: &str,
+    number: u64,
+    method: Option<&str>,
+) -> Result<()> {
+    let output = run_gh_json(&[
+        "api".to_string(),
+        format!("repos/{repository}/pulls/{number}"),
+    ])
+    .await?;
+    let pull_request = serde_json::from_str::<PullRequestRestStatusRaw>(&output)
+        .with_context(|| format!("failed to parse pull request id for {repository}#{number}"))?;
+    let (mutation, mut args) = if let Some(method) = method {
+        let merge_method = method.trim_start_matches("--").to_ascii_uppercase();
+        (
+            "mutation($id: ID!, $method: PullRequestMergeMethod!) { enablePullRequestAutoMerge(input: {pullRequestId: $id, mergeMethod: $method}) { pullRequest { id } } }",
+            vec!["-F".to_string(), format!("method={merge_method}")],
+        )
+    } else {
+        (
+            "mutation($id: ID!) { disablePullRequestAutoMerge(input: {pullRequestId: $id}) { pullRequest { id } } }",
+            Vec::new(),
+        )
+    };
+    let mut request = vec![
+        "api".to_string(),
+        "graphql".to_string(),
+        "-f".to_string(),
+        format!("query={mutation}"),
+        "-F".to_string(),
+        format!("id={}", pull_request.node_id),
+    ];
+    request.append(&mut args);
+    run_gh_json(&request).await?;
+    Ok(())
 }
 
 fn pull_request_auto_merge_status_args(repository: &str, number: u64) -> Vec<String> {
@@ -3629,12 +3859,43 @@ fn assignee_api_args(
 }
 
 pub async fn convert_pull_request_to_draft(repository: &str, number: u64) -> Result<()> {
+    if crate::github_api::token_available() {
+        return set_pull_request_draft_state(repository, number, true).await;
+    }
     run_gh_json(&pull_request_ready_args(repository, number, true)).await?;
     Ok(())
 }
 
 pub async fn mark_pull_request_ready_for_review(repository: &str, number: u64) -> Result<()> {
+    if crate::github_api::token_available() {
+        return set_pull_request_draft_state(repository, number, false).await;
+    }
     run_gh_json(&pull_request_ready_args(repository, number, false)).await?;
+    Ok(())
+}
+
+async fn set_pull_request_draft_state(repository: &str, number: u64, draft: bool) -> Result<()> {
+    let output = run_gh_json(&[
+        "api".to_string(),
+        format!("repos/{repository}/pulls/{number}"),
+    ])
+    .await?;
+    let pull_request = serde_json::from_str::<PullRequestNodeRaw>(&output)
+        .with_context(|| format!("failed to parse pull request id for {repository}#{number}"))?;
+    let mutation = if draft {
+        "mutation($id: ID!) { convertPullRequestToDraft(input: {pullRequestId: $id}) { pullRequest { id } } }"
+    } else {
+        "mutation($id: ID!) { markPullRequestReadyForReview(input: {pullRequestId: $id}) { pullRequest { id } } }"
+    };
+    run_gh_json(&[
+        "api".to_string(),
+        "graphql".to_string(),
+        "-f".to_string(),
+        format!("query={mutation}"),
+        "-F".to_string(),
+        format!("id={}", pull_request.node_id),
+    ])
+    .await?;
     Ok(())
 }
 
@@ -4641,6 +4902,10 @@ async fn run_gh_json_raw(args: &[String]) -> Result<String> {
 }
 
 async fn run_gh_json_raw_once(args: &[String]) -> Result<String> {
+    if crate::github_api::token_available() && args.first().is_some_and(|arg| arg == "api") {
+        return crate::github_api::run_api_args(args).await;
+    }
+
     let gh_request = debug_log_gh_request_started(args, None);
     let output = Command::new("gh")
         .env("GH_PROMPT_DISABLED", "1")
@@ -4817,8 +5082,14 @@ async fn run_git_text_in_dir(args: &[String], directory: &Path) -> Result<String
 }
 
 fn gh_missing_message(args: &[String]) -> String {
+    if let Some(token_env) = crate::github_api::token_env_name() {
+        return format!(
+            "This operation is not yet supported by the PAT backend selected through {token_env}, and GitHub CLI `gh` was not found. Tried: gh {}",
+            args.join(" ")
+        );
+    }
     format!(
-        "GitHub CLI `gh` is required but was not found. Install it for your OS from https://cli.github.com/: macOS `brew install gh`, Fedora `sudo dnf install gh`, Arch `sudo pacman -S github-cli`, Debian/Ubuntu official apt setup at https://github.com/cli/cli/blob/trunk/docs/install_linux.md. Then run `gh auth login`. Tried: gh {}",
+        "No GitHub authentication backend is available: set GHR_GITHUB_TOKEN (GH_TOKEN and GITHUB_TOKEN are also supported), or install GitHub CLI from https://cli.github.com/ and run `gh auth login`. Tried: gh {}",
         args.join(" ")
     )
 }
@@ -7463,14 +7734,12 @@ mod tests {
     }
 
     #[test]
-    fn missing_gh_message_explains_install_and_login() {
+    fn missing_backend_message_explains_token_and_cli_options() {
         let message = gh_missing_message(&["api".to_string(), "user".to_string()]);
 
-        assert!(message.contains("GitHub CLI `gh` is required"));
-        assert!(message.contains("brew install gh"));
-        assert!(message.contains("sudo dnf install gh"));
-        assert!(message.contains("sudo pacman -S github-cli"));
-        assert!(message.contains("official apt setup"));
+        assert!(message.contains("No GitHub authentication backend is available"));
+        assert!(message.contains("GHR_GITHUB_TOKEN"));
+        assert!(message.contains("https://cli.github.com/"));
         assert!(message.contains("gh auth login"));
     }
 

--- a/src/github.rs
+++ b/src/github.rs
@@ -769,7 +769,11 @@ where
     if !searches.is_empty() {
         pace_search_refresh().await;
     }
-    let mut notifications = refresh_notification_sections(config).await;
+    let mut notifications = if refresh_scope_includes_notifications(&scope) {
+        refresh_notification_sections(config).await
+    } else {
+        Vec::new()
+    };
     for section in &notifications {
         on_section(section);
     }
@@ -837,6 +841,13 @@ fn refresh_scope_view(scope: &RefreshScope) -> Option<&str> {
     match scope {
         RefreshScope::Full => None,
         RefreshScope::View(view) => Some(view.as_str()),
+    }
+}
+
+fn refresh_scope_includes_notifications(scope: &RefreshScope) -> bool {
+    match scope {
+        RefreshScope::Full => true,
+        RefreshScope::View(view) => same_refresh_view_key(view, "notifications"),
     }
 }
 
@@ -5717,6 +5728,17 @@ mod tests {
         assert!(jobs.iter().all(|job| job.view == "repo:Fiber"));
         assert_eq!(jobs[0].kind, SectionKind::Issues);
         assert_eq!(jobs[1].kind, SectionKind::PullRequests);
+    }
+
+    #[test]
+    fn scoped_repo_refresh_does_not_include_notifications() {
+        assert!(refresh_scope_includes_notifications(&RefreshScope::Full));
+        assert!(refresh_scope_includes_notifications(&RefreshScope::View(
+            "notifications".to_string()
+        )));
+        assert!(!refresh_scope_includes_notifications(&RefreshScope::View(
+            "repo:Fiber".to_string()
+        )));
     }
 
     #[test]

--- a/src/github_api.rs
+++ b/src/github_api.rs
@@ -1,0 +1,390 @@
+use std::{env, sync::OnceLock};
+
+use anyhow::{Context, Result, anyhow, bail};
+use octocrab::Octocrab;
+use serde_json::{Map, Value};
+
+const TOKEN_ENV_VARS: [&str; 3] = ["GHR_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"];
+
+static CLIENT: OnceLock<std::result::Result<Octocrab, String>> = OnceLock::new();
+
+#[derive(Debug, Clone, PartialEq)]
+struct ApiRequest {
+    method: String,
+    path: String,
+    headers: Vec<(String, String)>,
+    fields: Map<String, Value>,
+    graphql: bool,
+}
+
+pub fn token_available() -> bool {
+    token_from_env().is_some()
+}
+
+pub fn token_env_name() -> Option<&'static str> {
+    TOKEN_ENV_VARS
+        .into_iter()
+        .find(|name| env::var(name).is_ok_and(|value| !value.trim().is_empty()))
+}
+
+pub async fn run_api_args(args: &[String]) -> Result<String> {
+    let request = parse_api_args(args)?;
+    let graphql = request.graphql;
+    let client = client()?;
+    let path = normalized_path(&request.path);
+
+    let response = if request.method == "GET" {
+        let path = append_query_fields(&path, &request.fields)?;
+        let headers = request_headers(&request.headers)?;
+        client._get_with_headers(path, Some(headers)).await?
+    } else {
+        let body = if request.graphql {
+            graphql_body(request.fields)?
+        } else {
+            Value::Object(request.fields)
+        };
+        match request.method.as_str() {
+            "POST" => client._post(path, Some(&body)).await?,
+            "PATCH" => client._patch(path, Some(&body)).await?,
+            "PUT" => client._put(path, Some(&body)).await?,
+            "DELETE" => client._delete(path, Some(&body)).await?,
+            method => bail!("PAT backend does not support GitHub API method {method}"),
+        }
+    };
+
+    let status = response.status();
+    let body = client
+        .body_to_string(response)
+        .await
+        .context("failed to read GitHub API response")?;
+    if !status.is_success() {
+        let message = github_error_message(&body);
+        bail!(
+            "GitHub API request failed: HTTP {}: {message}",
+            status.as_u16()
+        );
+    }
+    if graphql && let Some(message) = graphql_error_message(&body) {
+        bail!("GitHub GraphQL request failed: {message}");
+    }
+    Ok(body)
+}
+
+fn client() -> Result<&'static Octocrab> {
+    CLIENT
+        .get_or_init(|| {
+            let token = token_from_env().ok_or_else(|| {
+                "set GHR_GITHUB_TOKEN, GH_TOKEN, or GITHUB_TOKEN to use the PAT backend".to_string()
+            })?;
+            let mut builder = Octocrab::builder().personal_token(token);
+            if let Some(api_url) = github_api_url() {
+                builder = builder
+                    .base_uri(api_url)
+                    .map_err(|error| error.to_string())?;
+            }
+            builder.build().map_err(|error| error.to_string())
+        })
+        .as_ref()
+        .map_err(|message| anyhow!(message.clone()))
+}
+
+fn token_from_env() -> Option<String> {
+    TOKEN_ENV_VARS
+        .into_iter()
+        .find_map(|name| env::var(name).ok().filter(|value| !value.trim().is_empty()))
+}
+
+fn github_api_url() -> Option<String> {
+    ["GHR_GITHUB_API_URL", "GITHUB_API_URL"]
+        .into_iter()
+        .find_map(|name| env::var(name).ok().filter(|value| !value.trim().is_empty()))
+}
+
+fn parse_api_args(args: &[String]) -> Result<ApiRequest> {
+    if args.first().map(String::as_str) != Some("api") {
+        bail!("PAT backend expected a `gh api` request");
+    }
+
+    let mut method = None;
+    let mut path = None;
+    let mut headers = Vec::new();
+    let mut fields = Map::new();
+    let mut graphql = false;
+    let mut index = 1;
+    while index < args.len() {
+        match args[index].as_str() {
+            "graphql" => {
+                path = Some("graphql".to_string());
+                graphql = true;
+            }
+            "-X" | "--method" | "--request" => {
+                index += 1;
+                method = Some(required_arg(args, index, "HTTP method")?.to_ascii_uppercase());
+            }
+            "-H" | "--header" => {
+                index += 1;
+                headers.push(parse_header(required_arg(args, index, "header")?)?);
+            }
+            "-f" | "--raw-field" => {
+                index += 1;
+                insert_field(&mut fields, required_arg(args, index, "raw field")?, false)?;
+            }
+            "-F" | "--field" => {
+                index += 1;
+                insert_field(&mut fields, required_arg(args, index, "field")?, true)?;
+            }
+            "--jq" | "-q" | "--template" | "-t" => {
+                index += 1;
+                let _ = required_arg(args, index, "output selector")?;
+            }
+            "--paginate" | "--slurp" => {
+                bail!("PAT backend pagination must be handled by the caller");
+            }
+            arg if arg.starts_with('-') => {
+                bail!("PAT backend does not support gh api argument `{arg}`");
+            }
+            arg => {
+                if path.replace(arg.to_string()).is_some() {
+                    bail!("PAT backend received more than one GitHub API path");
+                }
+            }
+        }
+        index += 1;
+    }
+
+    let path = path.ok_or_else(|| anyhow!("PAT backend GitHub API path is missing"))?;
+    let method = method.unwrap_or_else(|| {
+        if graphql || !fields.is_empty() {
+            "POST".to_string()
+        } else {
+            "GET".to_string()
+        }
+    });
+    Ok(ApiRequest {
+        method,
+        path,
+        headers,
+        fields,
+        graphql,
+    })
+}
+
+fn required_arg<'a>(args: &'a [String], index: usize, name: &str) -> Result<&'a str> {
+    args.get(index)
+        .map(String::as_str)
+        .ok_or_else(|| anyhow!("PAT backend GitHub API {name} is missing"))
+}
+
+fn parse_header(input: &str) -> Result<(String, String)> {
+    let (name, value) = input
+        .split_once(':')
+        .ok_or_else(|| anyhow!("invalid GitHub API header `{input}`"))?;
+    Ok((name.trim().to_string(), value.trim().to_string()))
+}
+
+fn insert_field(fields: &mut Map<String, Value>, input: &str, typed: bool) -> Result<()> {
+    let (name, value) = input
+        .split_once('=')
+        .ok_or_else(|| anyhow!("invalid GitHub API field `{input}`"))?;
+    let value = if typed {
+        typed_value(value)
+    } else {
+        Value::String(value.to_string())
+    };
+    if let Some(name) = name.strip_suffix("[]") {
+        match fields
+            .entry(name.to_string())
+            .or_insert_with(|| Value::Array(Vec::new()))
+        {
+            Value::Array(values) => values.push(value),
+            _ => bail!("GitHub API field `{name}` mixes scalar and array values"),
+        }
+    } else {
+        fields.insert(name.to_string(), value);
+    }
+    Ok(())
+}
+
+fn typed_value(value: &str) -> Value {
+    match value {
+        "null" => Value::Null,
+        "true" => Value::Bool(true),
+        "false" => Value::Bool(false),
+        _ => value
+            .parse::<i64>()
+            .map(Value::from)
+            .unwrap_or_else(|_| Value::String(value.to_string())),
+    }
+}
+
+fn normalized_path(path: &str) -> String {
+    if path.starts_with('/') || path.starts_with("http://") || path.starts_with("https://") {
+        path.to_string()
+    } else {
+        format!("/{path}")
+    }
+}
+
+fn append_query_fields(path: &str, fields: &Map<String, Value>) -> Result<String> {
+    if fields.is_empty() {
+        return Ok(path.to_string());
+    }
+    let pairs = fields
+        .iter()
+        .flat_map(|(name, value)| match value {
+            Value::Array(values) => values
+                .iter()
+                .map(|value| (format!("{name}[]"), query_value(value)))
+                .collect::<Vec<_>>(),
+            value => vec![(name.clone(), query_value(value))],
+        })
+        .collect::<Vec<_>>();
+    let query = serde_urlencoded::to_string(pairs).context("failed to encode GitHub API query")?;
+    let separator = if path.contains('?') { '&' } else { '?' };
+    Ok(format!("{path}{separator}{query}"))
+}
+
+fn query_value(value: &Value) -> String {
+    match value {
+        Value::Null => "null".to_string(),
+        Value::Bool(value) => value.to_string(),
+        Value::Number(value) => value.to_string(),
+        Value::String(value) => value.clone(),
+        value => value.to_string(),
+    }
+}
+
+fn request_headers(values: &[(String, String)]) -> Result<http::HeaderMap> {
+    let mut headers = http::HeaderMap::new();
+    for (name, value) in values {
+        let name = http::header::HeaderName::try_from(name.as_str())
+            .with_context(|| format!("invalid GitHub API header name `{name}`"))?;
+        let value = http::header::HeaderValue::try_from(value.as_str())
+            .context("invalid GitHub API header value")?;
+        headers.insert(name, value);
+    }
+    Ok(headers)
+}
+
+fn graphql_body(mut fields: Map<String, Value>) -> Result<Value> {
+    let query = fields
+        .remove("query")
+        .and_then(|value| value.as_str().map(str::to_string))
+        .ok_or_else(|| anyhow!("PAT backend GraphQL query is missing"))?;
+    Ok(serde_json::json!({
+        "query": query,
+        "variables": fields,
+    }))
+}
+
+fn github_error_message(body: &str) -> String {
+    serde_json::from_str::<Value>(body)
+        .ok()
+        .and_then(|value| {
+            value
+                .get("message")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+        })
+        .unwrap_or_else(|| {
+            let body = body.trim();
+            if body.is_empty() {
+                "empty response".to_string()
+            } else {
+                body.to_string()
+            }
+        })
+}
+
+fn graphql_error_message(body: &str) -> Option<String> {
+    serde_json::from_str::<Value>(body)
+        .ok()?
+        .get("errors")?
+        .as_array()?
+        .iter()
+        .filter_map(|error| error.get("message").and_then(Value::as_str))
+        .map(str::to_string)
+        .reduce(|mut messages, message| {
+            messages.push_str("; ");
+            messages.push_str(&message);
+            messages
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn api_args_parse_graphql_variables() {
+        let request = parse_api_args(&strings(&[
+            "api",
+            "graphql",
+            "-f",
+            "query=query($number: Int!) { viewer { login } }",
+            "-F",
+            "number=57",
+            "-F",
+            "enabled=true",
+        ]))
+        .unwrap();
+
+        assert_eq!(request.method, "POST");
+        assert!(request.graphql);
+        assert_eq!(request.fields["number"], 57);
+        assert_eq!(request.fields["enabled"], true);
+    }
+
+    #[test]
+    fn api_args_collect_array_fields() {
+        let request = parse_api_args(&strings(&[
+            "api",
+            "-X",
+            "POST",
+            "repos/owner/repo/issues",
+            "-f",
+            "labels[]=bug",
+            "-f",
+            "labels[]=help wanted",
+        ]))
+        .unwrap();
+
+        assert_eq!(
+            request.fields["labels"],
+            serde_json::json!(["bug", "help wanted"])
+        );
+    }
+
+    #[test]
+    fn get_fields_are_encoded_as_query_parameters() {
+        let request = parse_api_args(&strings(&[
+            "api",
+            "--method",
+            "GET",
+            "search/issues",
+            "-f",
+            "q=repo:owner/repo is:pr",
+            "-f",
+            "per_page=20",
+        ]))
+        .unwrap();
+        let path = append_query_fields(&normalized_path(&request.path), &request.fields).unwrap();
+
+        assert!(path.starts_with("/search/issues?"));
+        assert!(path.contains("q=repo%3Aowner%2Frepo+is%3Apr"));
+        assert!(path.contains("per_page=20"));
+    }
+
+    #[test]
+    fn graphql_errors_are_not_treated_as_success() {
+        let body = r#"{"data":null,"errors":[{"message":"Bad credentials"},{"message":"denied"}]}"#;
+        assert_eq!(
+            graphql_error_message(body).as_deref(),
+            Some("Bad credentials; denied")
+        );
+    }
+
+    fn strings(values: &[&str]) -> Vec<String> {
+        values.iter().map(|value| value.to_string()).collect()
+    }
+}

--- a/src/github_api.rs
+++ b/src/github_api.rs
@@ -8,8 +8,20 @@ const TOKEN_ENV_VARS: [&str; 3] = ["GHR_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN
 
 static CLIENT: OnceLock<std::result::Result<Octocrab, String>> = OnceLock::new();
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GitHubBackend {
+    DirectApi,
+    GitHubCli,
+}
+
+impl GitHubBackend {
+    pub fn supports_cli_commands(self) -> bool {
+        matches!(self, Self::GitHubCli)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
-struct ApiRequest {
+pub struct ApiRequest {
     method: String,
     path: String,
     headers: Vec<(String, String)>,
@@ -17,18 +29,26 @@ struct ApiRequest {
     graphql: bool,
 }
 
-pub fn token_available() -> bool {
-    token_from_env().is_some()
+pub fn selected_backend() -> GitHubBackend {
+    if token_from_env().is_some() {
+        GitHubBackend::DirectApi
+    } else {
+        GitHubBackend::GitHubCli
+    }
 }
 
+#[cfg(not(test))]
 pub fn token_env_name() -> Option<&'static str> {
     TOKEN_ENV_VARS
         .into_iter()
         .find(|name| env::var(name).is_ok_and(|value| !value.trim().is_empty()))
 }
 
-pub async fn run_api_args(args: &[String]) -> Result<String> {
-    let request = parse_api_args(args)?;
+pub fn parse_api_args(args: &[String]) -> Result<ApiRequest> {
+    parse_api_args_impl(args)
+}
+
+pub async fn run_direct_request(request: &ApiRequest) -> Result<String> {
     let graphql = request.graphql;
     let client = client()?;
     let path = normalized_path(&request.path);
@@ -39,16 +59,16 @@ pub async fn run_api_args(args: &[String]) -> Result<String> {
         client._get_with_headers(path, Some(headers)).await?
     } else {
         let body = if request.graphql {
-            graphql_body(request.fields)?
+            graphql_body(request.fields.clone())?
         } else {
-            Value::Object(request.fields)
+            Value::Object(request.fields.clone())
         };
         match request.method.as_str() {
             "POST" => client._post(path, Some(&body)).await?,
             "PATCH" => client._patch(path, Some(&body)).await?,
             "PUT" => client._put(path, Some(&body)).await?,
             "DELETE" => client._delete(path, Some(&body)).await?,
-            method => bail!("PAT backend does not support GitHub API method {method}"),
+            method => bail!("direct GitHub API backend does not support method {method}"),
         }
     };
 
@@ -74,7 +94,8 @@ fn client() -> Result<&'static Octocrab> {
     CLIENT
         .get_or_init(|| {
             let token = token_from_env().ok_or_else(|| {
-                "set GHR_GITHUB_TOKEN, GH_TOKEN, or GITHUB_TOKEN to use the PAT backend".to_string()
+                "set GHR_GITHUB_TOKEN, GH_TOKEN, or GITHUB_TOKEN to use direct GitHub API access"
+                    .to_string()
             })?;
             let mut builder = Octocrab::builder().personal_token(token);
             if let Some(api_url) = github_api_url() {
@@ -100,9 +121,9 @@ fn github_api_url() -> Option<String> {
         .find_map(|name| env::var(name).ok().filter(|value| !value.trim().is_empty()))
 }
 
-fn parse_api_args(args: &[String]) -> Result<ApiRequest> {
+fn parse_api_args_impl(args: &[String]) -> Result<ApiRequest> {
     if args.first().map(String::as_str) != Some("api") {
-        bail!("PAT backend expected a `gh api` request");
+        bail!("direct GitHub API backend expected a `gh api` request");
     }
 
     let mut method = None;
@@ -138,21 +159,21 @@ fn parse_api_args(args: &[String]) -> Result<ApiRequest> {
                 let _ = required_arg(args, index, "output selector")?;
             }
             "--paginate" | "--slurp" => {
-                bail!("PAT backend pagination must be handled by the caller");
+                bail!("direct GitHub API pagination must be handled by the caller");
             }
             arg if arg.starts_with('-') => {
-                bail!("PAT backend does not support gh api argument `{arg}`");
+                bail!("direct GitHub API backend does not support gh api argument `{arg}`");
             }
             arg => {
                 if path.replace(arg.to_string()).is_some() {
-                    bail!("PAT backend received more than one GitHub API path");
+                    bail!("direct GitHub API backend received more than one API path");
                 }
             }
         }
         index += 1;
     }
 
-    let path = path.ok_or_else(|| anyhow!("PAT backend GitHub API path is missing"))?;
+    let path = path.ok_or_else(|| anyhow!("direct GitHub API path is missing"))?;
     let method = method.unwrap_or_else(|| {
         if graphql || !fields.is_empty() {
             "POST".to_string()
@@ -172,7 +193,7 @@ fn parse_api_args(args: &[String]) -> Result<ApiRequest> {
 fn required_arg<'a>(args: &'a [String], index: usize, name: &str) -> Result<&'a str> {
     args.get(index)
         .map(String::as_str)
-        .ok_or_else(|| anyhow!("PAT backend GitHub API {name} is missing"))
+        .ok_or_else(|| anyhow!("direct GitHub API {name} is missing"))
 }
 
 fn parse_header(input: &str) -> Result<(String, String)> {
@@ -270,7 +291,7 @@ fn graphql_body(mut fields: Map<String, Value>) -> Result<Value> {
     let query = fields
         .remove("query")
         .and_then(|value| value.as_str().map(str::to_string))
-        .ok_or_else(|| anyhow!("PAT backend GraphQL query is missing"))?;
+        .ok_or_else(|| anyhow!("direct GitHub API GraphQL query is missing"))?;
     Ok(serde_json::json!({
         "query": query,
         "variables": fields,

--- a/src/github_gh.rs
+++ b/src/github_gh.rs
@@ -1,0 +1,285 @@
+use std::io::{self, ErrorKind};
+use std::process::{Command as StdCommand, Output};
+
+use anyhow::{Context, Result, anyhow, bail};
+use tokio::process::Command as TokioCommand;
+use tokio::sync::OnceCell;
+use tracing::{debug, error};
+
+use crate::log::{GhLogRequest, fail_gh_request_to_start, finish_gh_request, start_gh_request};
+
+static API_SLURP_SUPPORTED: OnceCell<bool> = OnceCell::const_new();
+
+pub async fn run_api(args: &[String]) -> Result<String> {
+    if args.first().map(String::as_str) != Some("api") {
+        bail!("GitHub CLI backend expected a `gh api` request");
+    }
+
+    let request = log_request_started(args);
+    let output = TokioCommand::new("gh")
+        .env("GH_PROMPT_DISABLED", "1")
+        .args(args)
+        .output()
+        .await
+        .map_err(|error| {
+            log_request_failed_to_start(request.clone(), args, &error);
+            if error.kind() == ErrorKind::NotFound {
+                anyhow!("{}", missing_message(args))
+            } else {
+                anyhow!("failed to run {}: {error}", command_display(args))
+            }
+        })?;
+    log_request_finished(request, args, &output);
+
+    if !output.status.success() {
+        log_request_failed_result(args, &output);
+        bail!("{}", failure_message(args, &output_message(&output)));
+    }
+
+    String::from_utf8(output.stdout).context("gh output was not UTF-8")
+}
+
+pub async fn api_slurp_supported() -> bool {
+    *API_SLURP_SUPPORTED
+        .get_or_init(detect_api_slurp_support)
+        .await
+}
+
+pub fn version_output() -> io::Result<Output> {
+    let args = vec!["--version".to_string()];
+    let request = log_request_started(&args);
+    let result = StdCommand::new("gh")
+        .env("GH_PROMPT_DISABLED", "1")
+        .arg("--version")
+        .output();
+
+    match &result {
+        Ok(output) => {
+            log_request_finished(request, &args, output);
+            if !output.status.success() {
+                log_request_failed_result(&args, output);
+            }
+        }
+        Err(error) => log_request_failed_to_start(request, &args, error),
+    }
+
+    result
+}
+
+pub fn command_display(args: &[String]) -> String {
+    format!("gh {}", args.join(" "))
+}
+
+async fn detect_api_slurp_support() -> bool {
+    let args = vec!["api".to_string(), "--help".to_string()];
+    let request = log_request_started(&args);
+    let output = TokioCommand::new("gh")
+        .env("GH_PROMPT_DISABLED", "1")
+        .args(&args)
+        .output()
+        .await;
+
+    match output {
+        Ok(output) if output.status.success() => {
+            log_request_finished(request, &args, &output);
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            api_help_has_flag(&stdout, "--slurp") || api_help_has_flag(&stderr, "--slurp")
+        }
+        Ok(output) => {
+            log_request_finished(request, &args, &output);
+            debug!(
+                status = %output.status,
+                "failed to inspect gh api help for --slurp support; assuming supported"
+            );
+            true
+        }
+        Err(error) => {
+            log_request_failed_to_start(request, &args, &error);
+            debug!(
+                error = %error,
+                "failed to inspect gh api help for --slurp support; assuming supported"
+            );
+            true
+        }
+    }
+}
+
+fn api_help_has_flag(help: &str, flag: &str) -> bool {
+    help.split(|ch: char| ch.is_whitespace() || matches!(ch, ',' | '[' | ']' | '(' | ')' | '`'))
+        .any(|token| token == flag)
+}
+
+fn log_request_started(args: &[String]) -> GhLogRequest {
+    let kind = request_kind(args);
+    let command = command_display(args);
+    debug!(kind, command, "gh request started");
+    start_gh_request(kind, command, None)
+}
+
+fn log_request_finished(request: GhLogRequest, args: &[String], output: &std::process::Output) {
+    let kind = request_kind(args);
+    debug!(
+        kind,
+        command = %command_display(args),
+        status = %output.status,
+        success = output.status.success(),
+        stdout_bytes = output.stdout.len(),
+        stderr_bytes = output.stderr.len(),
+        "gh request finished"
+    );
+    finish_gh_request(request, output);
+}
+
+fn log_request_failed_to_start(
+    request: GhLogRequest,
+    args: &[String],
+    error_value: &std::io::Error,
+) {
+    let kind = request_kind(args);
+    let command = command_display(args);
+    debug!(kind, command, error = %error_value, "gh request failed to start");
+    error!(kind, command, error = %error_value, "gh request failed to start");
+    fail_gh_request_to_start(request, error_value);
+}
+
+fn log_request_failed_result(args: &[String], output: &std::process::Output) {
+    let kind = request_kind(args);
+    error!(
+        kind,
+        command = %command_display(args),
+        status = %output.status,
+        message = %output_message(output),
+        stdout_bytes = output.stdout.len(),
+        stderr_bytes = output.stderr.len(),
+        "gh request returned failure"
+    );
+}
+
+fn request_kind(args: &[String]) -> &'static str {
+    if args.first().is_some_and(|arg| arg == "api") {
+        "gh api"
+    } else {
+        "gh"
+    }
+}
+
+fn output_message(output: &std::process::Output) -> String {
+    output_message_from_parts(&output.stdout, &output.stderr)
+}
+
+fn output_message_from_parts(stdout: &[u8], stderr: &[u8]) -> String {
+    let stderr = String::from_utf8_lossy(stderr).trim().to_string();
+    let stdout = String::from_utf8_lossy(stdout).trim().to_string();
+    let message = if stderr.is_empty() { stdout } else { stderr };
+    truncate_output_message(&message)
+}
+
+fn truncate_output_message(message: &str) -> String {
+    const MAX_CHARS: usize = 1200;
+    if message.chars().count() <= MAX_CHARS {
+        return message.to_string();
+    }
+    let mut truncated = message.chars().take(MAX_CHARS).collect::<String>();
+    truncated.push_str("...");
+    truncated
+}
+
+fn missing_message(args: &[String]) -> String {
+    format!(
+        "No GitHub authentication backend is available: set GHR_GITHUB_TOKEN (GH_TOKEN and GITHUB_TOKEN are also supported), or install GitHub CLI from https://cli.github.com/ and run `gh auth login`. Tried: {}",
+        command_display(args)
+    )
+}
+
+fn failure_message(args: &[String], message: &str) -> String {
+    if is_auth_error(message) {
+        return format!(
+            "GitHub CLI is installed but not authenticated. Run `gh auth login`, then restart ghr. Original error from `{}`: {}",
+            command_display(args),
+            message
+        );
+    }
+
+    format!("{} failed: {message}", command_display(args))
+}
+
+fn is_auth_error(message: &str) -> bool {
+    let normalized = message.to_ascii_lowercase();
+    [
+        "gh auth login",
+        "not authenticated",
+        "not logged in",
+        "authentication required",
+        "requires authentication",
+        "must authenticate",
+        "bad credentials",
+        "no oauth token",
+    ]
+    .iter()
+    .any(|needle| normalized.contains(needle))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn output_message_prefers_stderr() {
+        assert_eq!(
+            output_message_from_parts(b"{\"state\":\"failure\"}", b"HTTP 403\n"),
+            "HTTP 403"
+        );
+    }
+
+    #[test]
+    fn output_message_uses_stdout_when_stderr_is_empty() {
+        assert_eq!(
+            output_message_from_parts(b"{\"state\":\"failure\"}\n", b""),
+            "{\"state\":\"failure\"}"
+        );
+    }
+
+    #[test]
+    fn api_help_flag_detection_matches_complete_flags() {
+        assert!(api_help_has_flag(
+            "      --slurp               Use an array of arrays for paginated responses",
+            "--slurp"
+        ));
+        assert!(!api_help_has_flag(
+            "      --paginate            Fetch all pages",
+            "--slurp"
+        ));
+    }
+
+    #[test]
+    fn missing_backend_message_explains_token_and_cli_options() {
+        let message = missing_message(&["api".to_string(), "user".to_string()]);
+
+        assert!(message.contains("No GitHub authentication backend is available"));
+        assert!(message.contains("GHR_GITHUB_TOKEN"));
+        assert!(message.contains("https://cli.github.com/"));
+        assert!(message.contains("gh auth login"));
+    }
+
+    #[test]
+    fn auth_errors_are_rewritten_with_login_hint() {
+        let message = failure_message(
+            &["api".to_string(), "user".to_string()],
+            "To get started with GitHub CLI, please run: gh auth login",
+        );
+
+        assert!(message.contains("not authenticated"));
+        assert!(message.contains("Run `gh auth login`"));
+    }
+
+    #[test]
+    fn non_auth_errors_keep_original_command_context() {
+        let message = failure_message(
+            &["api".to_string(), "search/issues".to_string()],
+            "HTTP 500",
+        );
+
+        assert_eq!(message, "gh api search/issues failed: HTTP 500");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod config;
 mod dirs;
 mod github;
 mod github_api;
+mod github_gh;
 mod log;
 mod model;
 mod snapshot;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod app;
 mod config;
 mod dirs;
 mod github;
+mod github_api;
 mod log;
 mod model;
 mod snapshot;


### PR DESCRIPTION
Add octocrab as a alternative auth mechanism, now if the environment `GHR_GITHUB_TOKEN` or `GITHUB_TOKEN` is set, `ghr` will try to use octocrab auth, don't need to depend on `gh`.

Fixes #57