### PR TITLE
feat: add linked pull request and linked issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ Open the command palette with `:` to fuzzy search and run commands. Recently run
 | `Saved Search Filter` | Pick a named saved PR/issue search filter from `config.toml` and run it |
 | `Set Color Theme` | Choose `auto` or a fixed color theme and save it to `config.toml` |
 | `Copy GitHub Link` | Copy the selected comment link, or the current PR/issue link, to the clipboard |
+| `Copy PR/Issue Link` | Copy the current PR/issue link to the clipboard, ignoring selected comments |
 | `Copy Content` | Copy the selected comment content, or the current PR/issue description, to the clipboard |
 | `Open Linked PR/Issue` | Open the first linked pull request or issue from the current item |
 | `Clear Cache` | Choose a local cache layer to clear: current section, current view, all list snapshots, suggestions, loaded details/diffs, or all cache |
@@ -305,18 +306,18 @@ include_read_notifications = true
 [[pr_sections]]
 title = "Needs Attention"
 queries = [
-  "is:open review-requested:@me archived:false sort:updated-desc",
-  "is:open assignee:@me archived:false sort:updated-desc",
-  "is:open mentions:@me archived:false sort:updated-desc",
+  "is:open review-requested:@me archived:false sort:created-desc",
+  "is:open assignee:@me archived:false sort:created-desc",
+  "is:open mentions:@me archived:false sort:created-desc",
 ]
 
 [[pr_sections]]
 title = "My Pull Requests"
-filters = "is:open author:@me archived:false sort:updated-desc"
+filters = "is:open author:@me archived:false sort:created-desc"
 
 [[pr_sections]]
 title = "Reviewed"
-filters = "is:open reviewed-by:@me -author:@me archived:false sort:updated-desc"
+filters = "is:open reviewed-by:@me -author:@me archived:false sort:created-desc"
 
 [[saved_search_filters]]
 name = "my rust prs"
@@ -329,7 +330,7 @@ sort = "created_at"
 exclude_repos = ["some-org/archive-*"]
 ```
 
-Use `filters` for a single GitHub search query. Use `queries` when a section should merge several GitHub searches into one deduplicated list. Label filters can be written directly in either form, for example `filters = "is:open label:bug archived:false sort:updated-desc"` or `label:"good first issue"` for labels with spaces.
+Use `filters` for a single GitHub search query. Use `queries` when a section should merge several GitHub searches into one deduplicated list. Label filters can be written directly in either form, for example `filters = "is:open label:bug archived:false sort:created-desc"` or `label:"good first issue"` for labels with spaces.
 
 Use `[[repos]]` to add repository tabs to the top bar. Each configured repo shows its `name` as a top-level tab; inside that tab, `show_issues` and `show_prs` control whether the sections are shown as `Issues` and `Pull Requests`. Repo tabs default to open issues and open PRs, with `Issues` shown first. Set `labels` to filter both repo issue and PR lists, or use `issue_labels` / `pr_labels` for kind-specific filters.
 

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Open the command palette with `:` to fuzzy search and run commands. Recently run
 | `Subscribe Thread` / `Unsubscribe Thread` | Change the selected inbox thread subscription |
 | `Subscribe Item` / `Unsubscribe Item` | Change the selected issue or pull request conversation subscription |
 | `Info` | Show terminal, version, config/db/log paths, cache counts, runtime state, and ghr system diagnostics in a scrollable popup |
-| `Log` | Show recent `gh` requests with timestamps, status, output sizes, and rate-limit events; use `j`/`k` to select and `Enter` to open details |
+| `Log` | Show recent direct API and `gh api` requests with timestamps, status, response sizes, errors, and rate-limit events; use `j`/`k` to select and `Enter` to open details |
 
 Diff review ranges:
 
@@ -342,7 +342,7 @@ Set `command_palette_key` to change the command palette shortcut. Printable keys
 
 Set `theme` to `"auto"`, `"dark"`, or `"light"` to switch the base TUI palette. Set `theme_name` for a fixed named theme such as `"catppuccin_mocha"`, `"gruvbox_light"`, or `"github_dark"`. `auto` follows the macOS system appearance and falls back to dark when the system theme cannot be detected; fixed themes do not auto-switch.
 
-Set `log_level` to `trace`, `debug`, `info`, `warn`, or `error`. In `debug` mode, `gh` / `gh api` requests plus UI focus/view changes and mouse clicks are written to `~/.ghr/ghr.log`. Failed `gh` executions and non-zero `gh` results are logged at `error` level, so they are visible with the default `info` log level. The `Log` command also keeps an in-memory list of recent `gh` calls for the current session, including GitHub rate-limit failures. `RUST_LOG` still overrides this config value when it is set.
+Set `log_level` to `trace`, `debug`, `info`, `warn`, or `error`. In `debug` mode, direct GitHub API and `gh` / `gh api` requests plus UI focus/view changes and mouse clicks are written to `~/.ghr/ghr.log`. Failed API requests, failed `gh` executions, and non-zero `gh` results are logged at `error` level, so they are visible with the default `info` log level. The `Log` command also keeps an in-memory list of recent direct API and `gh` calls for the current session, including response errors and GitHub rate-limit failures. `RUST_LOG` still overrides this config value when it is set.
 
 `pr_per_page` and `issue_per_page` control the page size used for PR and issue search sections. Use `[` and `]` in the list to load adjacent GitHub result pages.
 

--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ Open the command palette with `:` to fuzzy search and run commands. Recently run
 | `Set Color Theme` | Choose `auto` or a fixed color theme and save it to `config.toml` |
 | `Copy GitHub Link` | Copy the selected comment link, or the current PR/issue link, to the clipboard |
 | `Copy Content` | Copy the selected comment content, or the current PR/issue description, to the clipboard |
+| `Open Linked PR` | Open the first pull request linked from the current issue |
 | `Clear Cache` | Choose a local cache layer to clear: current section, current view, all list snapshots, suggestions, loaded details/diffs, or all cache |
 | `Mark Done` | Move the selected GitHub inbox notification out of inbox lists; future activity can still notify unless the thread is muted |
 | `Mark All Read` | Mark every GitHub inbox notification as read |

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Open the command palette with `:` to fuzzy search and run commands. Recently run
 | `Set Color Theme` | Choose `auto` or a fixed color theme and save it to `config.toml` |
 | `Copy GitHub Link` | Copy the selected comment link, or the current PR/issue link, to the clipboard |
 | `Copy Content` | Copy the selected comment content, or the current PR/issue description, to the clipboard |
-| `Open Linked PR` | Open the first pull request linked from the current issue |
+| `Open Linked PR/Issue` | Open the first linked pull request or issue from the current item |
 | `Clear Cache` | Choose a local cache layer to clear: current section, current view, all list snapshots, suggestions, loaded details/diffs, or all cache |
 | `Mark Done` | Move the selected GitHub inbox notification out of inbox lists; future activity can still notify unless the thread is muted |
 | `Mark All Read` | Mark every GitHub inbox notification as read |

--- a/docs/script.js
+++ b/docs/script.js
@@ -101,6 +101,7 @@ const commands = [
   ["Inbox", "Unsubscribe Thread", "Unsubscribe from the selected inbox thread"],
   ["Details", "Subscribe Item", "Subscribe to the selected issue or pull request conversation"],
   ["Details", "Unsubscribe Item", "Unsubscribe from the selected issue or pull request conversation"],
+  ["Details", "Open Linked PR", "Open the first pull request linked from the current issue"],
   ["Clipboard", "Copy GitHub Link", "Copy selected comment link or issue/PR URL"],
   ["Clipboard", "Copy Content", "Copy selected comment body or issue/PR description"],
   ["Info", "Info", "Show version, paths, ghr process memory, UI state, and ignored/recent counts"],

--- a/docs/script.js
+++ b/docs/script.js
@@ -101,7 +101,7 @@ const commands = [
   ["Inbox", "Unsubscribe Thread", "Unsubscribe from the selected inbox thread"],
   ["Details", "Subscribe Item", "Subscribe to the selected issue or pull request conversation"],
   ["Details", "Unsubscribe Item", "Unsubscribe from the selected issue or pull request conversation"],
-  ["Details", "Open Linked PR", "Open the first pull request linked from the current issue"],
+  ["Details", "Open Linked PR/Issue", "Open the first linked pull request or issue from the current item"],
   ["Clipboard", "Copy GitHub Link", "Copy selected comment link or issue/PR URL"],
   ["Clipboard", "Copy Content", "Copy selected comment body or issue/PR description"],
   ["Info", "Info", "Show version, paths, ghr process memory, UI state, and ignored/recent counts"],

--- a/src/app.rs
+++ b/src/app.rs
@@ -66,11 +66,12 @@ use crate::github::{
 };
 use crate::model::{
     ActionHints, CheckRunSummary, CheckSummary, CommentPreview, CommentPreviewKind, EditorDraft,
-    FailedCheckRunSummary, ItemKind, Milestone, PullRequestBranch, PullRequestReviewActor,
-    ReactionSummary, SectionKind, SectionSnapshot, WorkItem, builtin_view_key, configured_sections,
-    global_search_view_key, mark_all_notifications_read_in_section,
-    mark_notification_done_in_section, mark_notification_read_in_section, merge_cached_sections,
-    merge_refreshed_sections, repo_view_key, section_view_key,
+    FailedCheckRunSummary, ItemKind, LinkedPullRequest, Milestone, PullRequestBranch,
+    PullRequestReviewActor, ReactionSummary, SectionKind, SectionSnapshot, WorkItem,
+    builtin_view_key, configured_sections, global_search_view_key,
+    mark_all_notifications_read_in_section, mark_notification_done_in_section,
+    mark_notification_read_in_section, merge_cached_sections, merge_refreshed_sections,
+    repo_view_key, section_view_key,
 };
 use crate::snapshot::{RepoCandidateCache, SnapshotStore};
 use crate::state::{
@@ -5498,6 +5499,10 @@ impl AppState {
                 self.open_selected();
                 false
             }
+            PaletteAction::OpenLinkedPullRequest => {
+                self.open_linked_pull_request();
+                false
+            }
             PaletteAction::ShowDiff => {
                 self.show_diff();
                 false
@@ -5701,6 +5706,9 @@ impl AppState {
                 }
                 if let Some(assignees) = &metadata.assignees {
                     item.assignees = assignees.clone();
+                }
+                if let Some(linked_pull_requests) = &metadata.linked_pull_requests {
+                    item.linked_pull_requests = linked_pull_requests.clone();
                 }
                 if metadata.comments.is_some() {
                     item.comments = metadata.comments;
@@ -11771,6 +11779,15 @@ impl AppState {
         self.open_url(&url);
     }
 
+    fn open_linked_pull_request(&mut self) {
+        let Some(url) = self.linked_pull_request_open_url() else {
+            self.status = "no linked pull request".to_string();
+            return;
+        };
+
+        self.open_url(&url);
+    }
+
     fn copy_github_link(&mut self) {
         let Some((url, label)) = self.selected_github_link() else {
             self.status = "no GitHub link selected".to_string();
@@ -11886,6 +11903,17 @@ impl AppState {
             return Some(pull_request_changes_url(item));
         }
         Some(item.url.clone())
+    }
+
+    fn linked_pull_request_open_url(&self) -> Option<String> {
+        let item = self.current_item()?;
+        if !matches!(item.kind, ItemKind::Issue) {
+            return None;
+        }
+        item.linked_pull_requests.iter().find_map(|pull_request| {
+            let url = pull_request.url.trim();
+            (!url.is_empty()).then(|| url.to_string())
+        })
     }
 
     fn open_url(&mut self, url: &str) {

--- a/src/app.rs
+++ b/src/app.rs
@@ -139,12 +139,12 @@ use render::*;
 use runtime::*;
 use search::{QuickFilter, filtered_indices, fuzzy_score, quick_filter_query};
 use status::{
-    comment_pending_dialog, compact_error_label, message_dialog, operation_error_body,
-    persistent_success_message_dialog, pr_action_error_body, pr_action_error_status,
-    pr_action_error_title, pr_action_success_body, pr_action_success_title, refresh_error_status,
-    retryable_message_dialog, reviewer_action_error_status, reviewer_action_error_title,
-    reviewer_action_success_body, reviewer_action_success_title, setup_dialog_from_error,
-    success_message_dialog,
+    comment_pending_dialog, compact_error_label, info_message_dialog, message_dialog,
+    operation_error_body, persistent_success_message_dialog, pr_action_error_body,
+    pr_action_error_status, pr_action_error_title, pr_action_success_body, pr_action_success_title,
+    refresh_error_status, retryable_message_dialog, reviewer_action_error_status,
+    reviewer_action_error_title, reviewer_action_success_body, reviewer_action_success_title,
+    setup_dialog_from_error, success_message_dialog,
 };
 use switchers::*;
 use tasks::*;
@@ -1271,6 +1271,14 @@ fn inbox_thread_action_success_status(action: InboxThreadAction) -> &'static str
     }
 }
 
+fn inbox_thread_action_error_title(action: InboxThreadAction) -> &'static str {
+    match action {
+        InboxThreadAction::Mute => "Mute Thread Failed",
+        InboxThreadAction::Subscribe => "Subscribe to Thread Failed",
+        InboxThreadAction::Unsubscribe => "Unsubscribe from Thread Failed",
+    }
+}
+
 fn item_subscription_action_label(action: ItemSubscriptionAction) -> &'static str {
     match action {
         ItemSubscriptionAction::Subscribe => "subscribe item",
@@ -1301,6 +1309,21 @@ fn item_subscription_action_success_status(
         ItemSubscriptionAction::Unsubscribe => {
             format!("unsubscribed from {label} conversation")
         }
+    }
+}
+
+fn item_subscription_action_error_title(
+    action: ItemSubscriptionAction,
+    item_kind: ItemKind,
+) -> String {
+    let label = match item_kind {
+        ItemKind::PullRequest => "Pull Request",
+        ItemKind::Issue => "Issue",
+        ItemKind::Notification => "Item",
+    };
+    match action {
+        ItemSubscriptionAction::Subscribe => format!("Subscribe to {label} Failed"),
+        ItemSubscriptionAction::Unsubscribe => format!("Unsubscribe from {label} Failed"),
     }
 }
 
@@ -4455,18 +4478,7 @@ impl AppState {
                         ));
                     }
                     Err(error) => {
-                        let setup_dialog = setup_dialog_from_error(&error);
-                        if self.setup_dialog.is_none() {
-                            self.setup_dialog = setup_dialog;
-                        }
-                        if setup_dialog.is_none() {
-                            self.message_dialog = Some(message_dialog(
-                                "Review Failed",
-                                operation_error_body(&error),
-                            ));
-                        } else {
-                            self.message_dialog = None;
-                        }
+                        self.show_operation_error_dialog("Review Failed", &error);
                         self.status = "review submit failed".to_string();
                     }
                 }
@@ -4569,18 +4581,10 @@ impl AppState {
                         ));
                     }
                     Err(error) => {
-                        let setup_dialog = setup_dialog_from_error(&error);
-                        if self.setup_dialog.is_none() {
-                            self.setup_dialog = setup_dialog;
-                        }
-                        if setup_dialog.is_none() {
-                            self.message_dialog = Some(message_dialog(
-                                pr_action_error_title(action, item_kind),
-                                pr_action_error_body(&error),
-                            ));
-                        } else {
-                            self.message_dialog = None;
-                        }
+                        self.show_operation_error_dialog(
+                            pr_action_error_title(action, item_kind),
+                            &error,
+                        );
                         self.status = if action == PrAction::Merge {
                             format!(
                                 "pull request {} merge failed",
@@ -4808,19 +4812,22 @@ impl AppState {
                 match result {
                     Ok(save_error) => {
                         let changed = self.apply_notification_read_local(&thread_id);
-                        self.status = match (changed, save_error) {
+                        self.status = match (changed, save_error.as_deref()) {
                             (_, Some(error)) => {
                                 format!("notification marked read; snapshot save failed: {error}")
                             }
                             (true, None) => "notification marked read".to_string(),
                             (false, None) => "notification read synced".to_string(),
                         };
+                        if let Some(error) = save_error {
+                            self.show_operation_error_dialog(
+                                "Notification Snapshot Save Failed",
+                                &error,
+                            );
+                        }
                     }
                     Err(error) => {
-                        let setup_dialog = setup_dialog_from_error(&error);
-                        if self.setup_dialog.is_none() {
-                            self.setup_dialog = setup_dialog;
-                        }
+                        self.show_operation_error_dialog("Mark Notification Read Failed", &error);
                         self.status = format!(
                             "notification read sync failed: {}",
                             operation_error_body(&error)
@@ -4833,19 +4840,22 @@ impl AppState {
                 match result {
                     Ok(save_error) => {
                         let changed = self.apply_notification_done_local(&thread_id);
-                        self.status = match (changed, save_error) {
+                        self.status = match (changed, save_error.as_deref()) {
                             (_, Some(error)) => {
                                 format!("notification marked done; snapshot save failed: {error}")
                             }
                             (true, None) => "notification marked done".to_string(),
                             (false, None) => "notification done synced".to_string(),
                         };
+                        if let Some(error) = save_error {
+                            self.show_operation_error_dialog(
+                                "Notification Snapshot Save Failed",
+                                &error,
+                            );
+                        }
                     }
                     Err(error) => {
-                        let setup_dialog = setup_dialog_from_error(&error);
-                        if self.setup_dialog.is_none() {
-                            self.setup_dialog = setup_dialog;
-                        }
+                        self.show_operation_error_dialog("Mark Notification Done Failed", &error);
                         self.status = format!(
                             "notification done sync failed: {}",
                             operation_error_body(&error)
@@ -4856,7 +4866,7 @@ impl AppState {
             AppMsg::InboxMarkAllReadFinished { result } => match result {
                 Ok(save_error) => {
                     let changed = self.apply_all_notifications_read_local();
-                    self.status = match (changed, save_error) {
+                    self.status = match (changed, save_error.as_deref()) {
                         (_, Some(error)) => {
                             format!(
                                 "all inbox notifications marked read; snapshot save failed: {error}"
@@ -4865,12 +4875,12 @@ impl AppState {
                         (true, None) => "all inbox notifications marked read".to_string(),
                         (false, None) => "all inbox notifications already read".to_string(),
                     };
+                    if let Some(error) = save_error {
+                        self.show_operation_error_dialog("Inbox Snapshot Save Failed", &error);
+                    }
                 }
                 Err(error) => {
-                    let setup_dialog = setup_dialog_from_error(&error);
-                    if self.setup_dialog.is_none() {
-                        self.setup_dialog = setup_dialog;
-                    }
+                    self.show_operation_error_dialog("Mark All Notifications Read Failed", &error);
                     self.status = format!(
                         "mark all inbox read failed: {}",
                         operation_error_body(&error)
@@ -4882,10 +4892,10 @@ impl AppState {
                     self.status = inbox_thread_action_success_status(action).to_string();
                 }
                 Err(error) => {
-                    let setup_dialog = setup_dialog_from_error(&error);
-                    if self.setup_dialog.is_none() {
-                        self.setup_dialog = setup_dialog;
-                    }
+                    self.show_operation_error_dialog(
+                        inbox_thread_action_error_title(action),
+                        &error,
+                    );
                     self.status = format!(
                         "{} failed: {}",
                         inbox_thread_action_label(action),
@@ -4906,10 +4916,10 @@ impl AppState {
                     self.status = item_subscription_action_success_status(action, item_kind);
                 }
                 Err(error) => {
-                    let setup_dialog = setup_dialog_from_error(&error);
-                    if self.setup_dialog.is_none() {
-                        self.setup_dialog = setup_dialog;
-                    }
+                    self.show_operation_error_dialog(
+                        item_subscription_action_error_title(action, item_kind),
+                        &error,
+                    );
                     self.status = format!(
                         "{} failed: {}",
                         item_subscription_action_label(action),
@@ -5037,6 +5047,16 @@ impl AppState {
     fn dismiss_message_dialog(&mut self) {
         self.message_dialog = None;
         self.status = "message dismissed".to_string();
+    }
+
+    fn show_operation_error_dialog(&mut self, title: impl Into<String>, error: &str) {
+        let setup_dialog = setup_dialog_from_error(error);
+        if self.setup_dialog.is_none() {
+            self.setup_dialog = setup_dialog;
+        }
+        self.message_dialog = setup_dialog
+            .is_none()
+            .then(|| message_dialog(title, operation_error_body(error)));
     }
 
     fn dismiss_retryable_message_dialog(&mut self, cancel: bool) {
@@ -9434,7 +9454,7 @@ impl AppState {
             return;
         }
         self.review_submit_running = true;
-        self.message_dialog = Some(message_dialog(
+        self.message_dialog = Some(info_message_dialog(
             "Creating Pending Review",
             "Waiting for GitHub to create the pending review...",
         ));
@@ -9461,7 +9481,7 @@ impl AppState {
         let mode = dialog.mode;
         let item = dialog.item;
         self.review_submit_running = true;
-        self.message_dialog = Some(message_dialog(
+        self.message_dialog = Some(info_message_dialog(
             "Submitting Review",
             format!("Waiting for GitHub to {}...", event.label()),
         ));
@@ -9509,7 +9529,7 @@ impl AppState {
         self.comment_dialog = None;
         self.pr_action_dialog = None;
         self.review_submit_running = true;
-        self.message_dialog = Some(message_dialog(
+        self.message_dialog = Some(info_message_dialog(
             "Discarding Pending Review",
             "Waiting for GitHub to discard the pending review...",
         ));

--- a/src/app.rs
+++ b/src/app.rs
@@ -66,7 +66,7 @@ use crate::github::{
 };
 use crate::model::{
     ActionHints, CheckRunSummary, CheckSummary, CommentPreview, CommentPreviewKind, EditorDraft,
-    FailedCheckRunSummary, ItemKind, LinkedPullRequest, Milestone, PullRequestBranch,
+    FailedCheckRunSummary, ItemKind, LinkedIssue, LinkedPullRequest, Milestone, PullRequestBranch,
     PullRequestReviewActor, ReactionSummary, SectionKind, SectionSnapshot, WorkItem,
     builtin_view_key, configured_sections, global_search_view_key,
     mark_all_notifications_read_in_section, mark_notification_done_in_section,
@@ -5499,8 +5499,8 @@ impl AppState {
                 self.open_selected();
                 false
             }
-            PaletteAction::OpenLinkedPullRequest => {
-                self.open_linked_pull_request();
+            PaletteAction::OpenLinkedItem => {
+                self.open_linked_item();
                 false
             }
             PaletteAction::ShowDiff => {
@@ -5709,6 +5709,9 @@ impl AppState {
                 }
                 if let Some(linked_pull_requests) = &metadata.linked_pull_requests {
                     item.linked_pull_requests = linked_pull_requests.clone();
+                }
+                if let Some(linked_issues) = &metadata.linked_issues {
+                    item.linked_issues = linked_issues.clone();
                 }
                 if metadata.comments.is_some() {
                     item.comments = metadata.comments;
@@ -11779,9 +11782,9 @@ impl AppState {
         self.open_url(&url);
     }
 
-    fn open_linked_pull_request(&mut self) {
-        let Some(url) = self.linked_pull_request_open_url() else {
-            self.status = "no linked pull request".to_string();
+    fn open_linked_item(&mut self) {
+        let Some(url) = self.linked_item_open_url() else {
+            self.status = self.missing_linked_item_status();
             return;
         };
 
@@ -11905,15 +11908,27 @@ impl AppState {
         Some(item.url.clone())
     }
 
-    fn linked_pull_request_open_url(&self) -> Option<String> {
+    fn linked_item_open_url(&self) -> Option<String> {
         let item = self.current_item()?;
-        if !matches!(item.kind, ItemKind::Issue) {
-            return None;
+        match item.kind {
+            ItemKind::Issue => item.linked_pull_requests.iter().find_map(|pull_request| {
+                let url = pull_request.url.trim();
+                (!url.is_empty()).then(|| url.to_string())
+            }),
+            ItemKind::PullRequest => item.linked_issues.iter().find_map(|issue| {
+                let url = issue.url.trim();
+                (!url.is_empty()).then(|| url.to_string())
+            }),
+            ItemKind::Notification => None,
         }
-        item.linked_pull_requests.iter().find_map(|pull_request| {
-            let url = pull_request.url.trim();
-            (!url.is_empty()).then(|| url.to_string())
-        })
+    }
+
+    fn missing_linked_item_status(&self) -> String {
+        match self.current_item().map(|item| item.kind) {
+            Some(ItemKind::Issue) => "no linked pull request".to_string(),
+            Some(ItemKind::PullRequest) => "no linked issue".to_string(),
+            _ => "no linked pull request or issue".to_string(),
+        }
     }
 
     fn open_url(&mut self, url: &str) {

--- a/src/app.rs
+++ b/src/app.rs
@@ -5487,6 +5487,10 @@ impl AppState {
                 self.copy_github_link();
                 false
             }
+            PaletteAction::CopyPrIssueLink => {
+                self.copy_pr_issue_link();
+                false
+            }
             PaletteAction::CopyContent => {
                 self.copy_content();
                 false
@@ -11807,6 +11811,22 @@ impl AppState {
         }
     }
 
+    fn copy_pr_issue_link(&mut self) {
+        let Some((url, label)) = self.selected_pr_issue_link() else {
+            self.status = "no pull request or issue selected".to_string();
+            return;
+        };
+
+        match copy_text_to_clipboard(&url) {
+            Ok(()) => {
+                self.status = format!("copied {label} link");
+            }
+            Err(error) => {
+                self.status = format!("copy failed: {error}");
+            }
+        }
+    }
+
     fn copy_content(&mut self) {
         let Some((content, label)) = self.selected_copy_content() else {
             self.status = "no content selected".to_string();
@@ -11865,6 +11885,20 @@ impl AppState {
             ItemKind::Issue => "issue",
             ItemKind::Notification => "GitHub",
         };
+        Some((url.to_string(), label))
+    }
+
+    fn selected_pr_issue_link(&self) -> Option<(String, &'static str)> {
+        let item = self.current_item()?;
+        let label = match item.kind {
+            ItemKind::PullRequest => "pull request",
+            ItemKind::Issue => "issue",
+            ItemKind::Notification => return None,
+        };
+        let url = item.url.trim();
+        if url.is_empty() {
+            return None;
+        }
         Some((url.to_string(), label))
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1573,7 +1573,7 @@ struct AppState {
     diff_inline_comments_visible: bool,
     revealed_diff_inline_comments: HashMap<String, HashSet<usize>>,
     conversation_details_state: HashMap<String, ConversationDetailsState>,
-    viewed_item_at: HashMap<String, DateTime<Utc>>,
+    seen_item_updated_at: HashMap<String, DateTime<Utc>>,
     action_hints: HashMap<String, ActionHintState>,
     action_hints_stale: HashSet<String>,
     action_hints_refreshing: HashSet<String>,
@@ -2991,7 +2991,7 @@ impl AppState {
             diff_inline_comments_visible: true,
             revealed_diff_inline_comments: HashMap::new(),
             conversation_details_state,
-            viewed_item_at: ui_state.viewed_item_at.clone(),
+            seen_item_updated_at: ui_state.seen_item_updated_at.clone(),
             action_hints: HashMap::new(),
             action_hints_stale: HashSet::new(),
             action_hints_refreshing: HashSet::new(),
@@ -3248,7 +3248,7 @@ impl AppState {
                 .iter()
                 .map(|(item_id, state)| (item_id.clone(), state.selected_comment_index))
                 .collect(),
-            viewed_item_at: self.viewed_item_at.clone(),
+            seen_item_updated_at: self.seen_item_updated_at.clone(),
             selected_diff_file: self.selected_diff_file.clone(),
             selected_diff_line: self.selected_diff_line.clone(),
             diff_file_details_scroll,
@@ -12048,9 +12048,9 @@ impl AppState {
         let Some(updated_at) = item.updated_at else {
             return false;
         };
-        self.viewed_item_at
+        self.seen_item_updated_at
             .get(&key)
-            .is_some_and(|viewed_at| updated_at > *viewed_at)
+            .is_some_and(|seen_updated_at| updated_at > *seen_updated_at)
     }
 
     fn mark_current_details_stale_if_unseen(&mut self) {
@@ -12072,8 +12072,11 @@ impl AppState {
         {
             return;
         }
+        let Some(updated_at) = item.updated_at else {
+            return;
+        };
         if let Some(key) = work_item_details_memory_key(&item) {
-            self.viewed_item_at.insert(key, Utc::now());
+            self.seen_item_updated_at.insert(key, updated_at);
         }
     }
 

--- a/src/app/command_palette.rs
+++ b/src/app/command_palette.rs
@@ -44,6 +44,7 @@ pub(super) enum PaletteAction {
     CopyContent,
     ToggleMouseCapture,
     OpenSelected,
+    OpenLinkedPullRequest,
     ShowDiff,
     ClearIgnoredItems,
     ClearCache,
@@ -313,6 +314,13 @@ pub(super) fn command_palette_commands(
             "General",
             "Open the selected item or PR changes page",
             PaletteAction::OpenSelected,
+        ),
+        palette_command(
+            "Open Linked PR",
+            "",
+            "Details",
+            "Open the first pull request linked from the current issue",
+            PaletteAction::OpenLinkedPullRequest,
         ),
         palette_command(
             "Show Pull Request Diff",
@@ -1141,6 +1149,17 @@ mod tests {
             commands
                 .iter()
                 .any(|command| command.title == "Copy Content")
+        );
+        assert!(
+            commands
+                .iter()
+                .any(|command| command.title == "Open Linked PR")
+        );
+        let linked_pr_matches = command_palette_filtered_indices(&commands, "linked pr");
+        assert!(
+            linked_pr_matches
+                .iter()
+                .any(|index| commands[*index].title == "Open Linked PR")
         );
     }
 

--- a/src/app/command_palette.rs
+++ b/src/app/command_palette.rs
@@ -152,7 +152,7 @@ pub(super) fn command_palette_commands(
             "Log",
             "",
             "General",
-            "Show recent gh requests, timestamps, status, and rate-limit events",
+            "Show recent GitHub API requests, status, errors, and rate-limit events",
             PaletteAction::ShowGhLog,
         ),
         palette_command(

--- a/src/app/command_palette.rs
+++ b/src/app/command_palette.rs
@@ -44,7 +44,7 @@ pub(super) enum PaletteAction {
     CopyContent,
     ToggleMouseCapture,
     OpenSelected,
-    OpenLinkedPullRequest,
+    OpenLinkedItem,
     ShowDiff,
     ClearIgnoredItems,
     ClearCache,
@@ -316,11 +316,11 @@ pub(super) fn command_palette_commands(
             PaletteAction::OpenSelected,
         ),
         palette_command(
-            "Open Linked PR",
+            "Open Linked PR/Issue",
             "",
             "Details",
-            "Open the first pull request linked from the current issue",
-            PaletteAction::OpenLinkedPullRequest,
+            "Open the first linked pull request or issue from the current item",
+            PaletteAction::OpenLinkedItem,
         ),
         palette_command(
             "Show Pull Request Diff",
@@ -1153,13 +1153,19 @@ mod tests {
         assert!(
             commands
                 .iter()
-                .any(|command| command.title == "Open Linked PR")
+                .any(|command| command.title == "Open Linked PR/Issue")
         );
         let linked_pr_matches = command_palette_filtered_indices(&commands, "linked pr");
         assert!(
             linked_pr_matches
                 .iter()
-                .any(|index| commands[*index].title == "Open Linked PR")
+                .any(|index| commands[*index].title == "Open Linked PR/Issue")
+        );
+        let linked_issue_matches = command_palette_filtered_indices(&commands, "linked issue");
+        assert!(
+            linked_issue_matches
+                .iter()
+                .any(|index| commands[*index].title == "Open Linked PR/Issue")
         );
     }
 

--- a/src/app/command_palette.rs
+++ b/src/app/command_palette.rs
@@ -41,6 +41,7 @@ pub(super) enum PaletteAction {
     ProjectAdd,
     ProjectRemove,
     CopyGithubLink,
+    CopyPrIssueLink,
     CopyContent,
     ToggleMouseCapture,
     OpenSelected,
@@ -293,6 +294,13 @@ pub(super) fn command_palette_commands(
             "General",
             "Copy the selected comment or issue/PR link to the clipboard",
             PaletteAction::CopyGithubLink,
+        ),
+        palette_command(
+            "Copy PR/Issue Link",
+            "",
+            "General",
+            "Copy the current pull request or issue link to the clipboard",
+            PaletteAction::CopyPrIssueLink,
         ),
         palette_command(
             "Copy Content",
@@ -1144,6 +1152,17 @@ mod tests {
             commands
                 .iter()
                 .any(|command| command.title == "Copy GitHub Link")
+        );
+        assert!(
+            commands
+                .iter()
+                .any(|command| command.title == "Copy PR/Issue Link")
+        );
+        let pr_issue_link_matches = command_palette_filtered_indices(&commands, "copy pr issue");
+        assert!(
+            pr_issue_link_matches
+                .iter()
+                .any(|index| commands[*index].title == "Copy PR/Issue Link")
         );
         assert!(
             commands

--- a/src/app/details.rs
+++ b/src/app/details.rs
@@ -1451,6 +1451,13 @@ pub(super) fn build_conversation_document(app: &AppState, width: u16) -> Details
             3,
         );
     }
+    if matches!(item.kind, ItemKind::PullRequest) && !item.linked_issues.is_empty() {
+        builder.push_styled_key_value_limited(
+            "linked issues",
+            linked_issue_segments(&item.linked_issues, &item.repo),
+            3,
+        );
+    }
 
     if matches!(item.kind, ItemKind::Issue | ItemKind::PullRequest) {
         builder.push_blank();
@@ -1772,13 +1779,13 @@ pub(super) fn assignee_detail_segments(item: &WorkItem) -> Vec<DetailSegment> {
     }
     segments.push(DetailSegment::raw("  "));
     segments.push(DetailSegment::action(
-        "@ assign",
+        "@assign",
         DetailAction::AssignAssignee,
     ));
     if !item.assignees.is_empty() {
         segments.push(DetailSegment::raw("  "));
         segments.push(DetailSegment::action(
-            "- unassign",
+            "-unassign",
             DetailAction::UnassignAssignee,
         ));
     }
@@ -1803,45 +1810,108 @@ pub(super) fn linked_pull_request_segments(
     pull_requests: &[LinkedPullRequest],
     current_repo: &str,
 ) -> Vec<DetailSegment> {
+    linked_item_segments(pull_requests, current_repo)
+}
+
+pub(super) fn linked_issue_segments(
+    issues: &[LinkedIssue],
+    current_repo: &str,
+) -> Vec<DetailSegment> {
+    linked_item_segments(issues, current_repo)
+}
+
+trait LinkedDetailItem {
+    fn repository(&self) -> &str;
+    fn number(&self) -> u64;
+    fn title(&self) -> &str;
+    fn state(&self) -> Option<&str>;
+    fn url(&self) -> &str;
+}
+
+impl LinkedDetailItem for LinkedPullRequest {
+    fn repository(&self) -> &str {
+        &self.repository
+    }
+
+    fn number(&self) -> u64 {
+        self.number
+    }
+
+    fn title(&self) -> &str {
+        &self.title
+    }
+
+    fn state(&self) -> Option<&str> {
+        self.state.as_deref()
+    }
+
+    fn url(&self) -> &str {
+        &self.url
+    }
+}
+
+impl LinkedDetailItem for LinkedIssue {
+    fn repository(&self) -> &str {
+        &self.repository
+    }
+
+    fn number(&self) -> u64 {
+        self.number
+    }
+
+    fn title(&self) -> &str {
+        &self.title
+    }
+
+    fn state(&self) -> Option<&str> {
+        self.state.as_deref()
+    }
+
+    fn url(&self) -> &str {
+        &self.url
+    }
+}
+
+fn linked_item_segments<T: LinkedDetailItem>(
+    items: &[T],
+    current_repo: &str,
+) -> Vec<DetailSegment> {
     let mut segments = Vec::new();
-    for pull_request in pull_requests {
+    for item in items {
         if !segments.is_empty() {
             segments.push(DetailSegment::raw("; "));
         }
         segments.push(DetailSegment::link(
-            linked_pull_request_label(pull_request, current_repo),
-            pull_request.url.clone(),
+            linked_item_label(item, current_repo),
+            item.url().to_string(),
         ));
-        if !pull_request.title.trim().is_empty() {
-            segments.push(DetailSegment::raw(format!(
-                " {}",
-                pull_request.title.trim()
-            )));
+        if !item.title().trim().is_empty() {
+            segments.push(DetailSegment::raw(format!(" {}", item.title().trim())));
         }
-        if let Some(state) = useful_meta_value(pull_request.state.as_deref()) {
+        if let Some(state) = useful_meta_value(item.state()) {
             segments.push(DetailSegment::raw(" "));
             segments.push(DetailSegment::styled(
-                linked_pull_request_state_label(state),
-                linked_pull_request_state_style(state),
+                linked_item_state_label(state),
+                linked_item_state_style(state),
             ));
         }
     }
     segments
 }
 
-fn linked_pull_request_label(pull_request: &LinkedPullRequest, current_repo: &str) -> String {
-    if pull_request.repository.is_empty() || pull_request.repository == current_repo {
-        format!("#{}", pull_request.number)
+fn linked_item_label<T: LinkedDetailItem>(item: &T, current_repo: &str) -> String {
+    if item.repository().is_empty() || item.repository() == current_repo {
+        format!("#{}", item.number())
     } else {
-        format!("{}#{}", pull_request.repository, pull_request.number)
+        format!("{}#{}", item.repository(), item.number())
     }
 }
 
-fn linked_pull_request_state_label(state: &str) -> String {
+fn linked_item_state_label(state: &str) -> String {
     state.to_ascii_lowercase()
 }
 
-fn linked_pull_request_state_style(state: &str) -> Style {
+fn linked_item_state_style(state: &str) -> Style {
     match state.to_ascii_lowercase().as_str() {
         "open" => active_theme()
             .panel()
@@ -2246,7 +2316,7 @@ pub(super) fn push_diff_inline_comment(
     if comment.can_react() {
         header.push(DetailSegment::raw("  "));
         header.push(DetailSegment::action(
-            "+ react",
+            "+react",
             DetailAction::ReactComment(index),
         ));
     }
@@ -2902,7 +2972,7 @@ pub(super) fn push_reactions_line(
         } else {
             "  "
         }));
-        segments.push(DetailSegment::action("+ react", DetailAction::ReactItem));
+        segments.push(DetailSegment::action("+react", DetailAction::ReactItem));
     }
     if can_reply {
         segments.push(DetailSegment::raw(if reactions.is_empty() && !can_react {
@@ -3035,7 +3105,7 @@ pub(super) fn push_comment(
     if comment.can_react() {
         header.push(DetailSegment::raw("  "));
         header.push(DetailSegment::action(
-            "+ react",
+            "+react",
             DetailAction::ReactComment(index),
         ));
     }

--- a/src/app/details.rs
+++ b/src/app/details.rs
@@ -249,6 +249,37 @@ pub(super) struct DiffInlineCommentSummary {
     pub(super) has_outdated: bool,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct DiffGutterWidths {
+    old: usize,
+    new: usize,
+}
+
+impl Default for DiffGutterWidths {
+    fn default() -> Self {
+        Self { old: 4, new: 4 }
+    }
+}
+
+impl DiffGutterWidths {
+    fn for_file(file: &DiffFile) -> Self {
+        Self::for_lines(file.hunks.iter().flat_map(|hunk| hunk.lines.iter()))
+    }
+
+    fn for_lines<'a>(lines: impl IntoIterator<Item = &'a DiffLine>) -> Self {
+        let mut widths = Self::default();
+        for line in lines {
+            if let Some(old_line) = line.old_line {
+                widths.old = widths.old.max(diff_line_number_width(old_line));
+            }
+            if let Some(new_line) = line.new_line {
+                widths.new = widths.new.max(diff_line_number_width(new_line));
+            }
+        }
+        widths
+    }
+}
+
 impl From<&DiffReviewTarget> for DiffInlineCommentKey {
     fn from(target: &DiffReviewTarget) -> Self {
         Self {
@@ -1413,6 +1444,13 @@ pub(super) fn build_conversation_document(app: &AppState, width: u16) -> Details
         builder.push_styled_key_value_limited("reviewers", reviewer_segments, 2);
     }
     builder.push_link_value("url", &item.url);
+    if matches!(item.kind, ItemKind::Issue) && !item.linked_pull_requests.is_empty() {
+        builder.push_styled_key_value_limited(
+            "linked PRs",
+            linked_pull_request_segments(&item.linked_pull_requests, &item.repo),
+            3,
+        );
+    }
 
     if matches!(item.kind, ItemKind::Issue | ItemKind::PullRequest) {
         builder.push_blank();
@@ -1761,6 +1799,70 @@ pub(super) fn subscription_detail_segments(item: &WorkItem) -> Vec<DetailSegment
     }
 }
 
+pub(super) fn linked_pull_request_segments(
+    pull_requests: &[LinkedPullRequest],
+    current_repo: &str,
+) -> Vec<DetailSegment> {
+    let mut segments = Vec::new();
+    for pull_request in pull_requests {
+        if !segments.is_empty() {
+            segments.push(DetailSegment::raw("; "));
+        }
+        segments.push(DetailSegment::link(
+            linked_pull_request_label(pull_request, current_repo),
+            pull_request.url.clone(),
+        ));
+        if !pull_request.title.trim().is_empty() {
+            segments.push(DetailSegment::raw(format!(
+                " {}",
+                pull_request.title.trim()
+            )));
+        }
+        if let Some(state) = useful_meta_value(pull_request.state.as_deref()) {
+            segments.push(DetailSegment::raw(" "));
+            segments.push(DetailSegment::styled(
+                linked_pull_request_state_label(state),
+                linked_pull_request_state_style(state),
+            ));
+        }
+    }
+    segments
+}
+
+fn linked_pull_request_label(pull_request: &LinkedPullRequest, current_repo: &str) -> String {
+    if pull_request.repository.is_empty() || pull_request.repository == current_repo {
+        format!("#{}", pull_request.number)
+    } else {
+        format!("{}#{}", pull_request.repository, pull_request.number)
+    }
+}
+
+fn linked_pull_request_state_label(state: &str) -> String {
+    state.to_ascii_lowercase()
+}
+
+fn linked_pull_request_state_style(state: &str) -> Style {
+    match state.to_ascii_lowercase().as_str() {
+        "open" => active_theme()
+            .panel()
+            .fg(active_theme().success)
+            .add_modifier(Modifier::BOLD),
+        "draft" => active_theme()
+            .panel()
+            .fg(active_theme().warning)
+            .add_modifier(Modifier::BOLD),
+        "merged" => active_theme()
+            .panel()
+            .fg(active_theme().link)
+            .add_modifier(Modifier::BOLD),
+        "closed" => active_theme()
+            .panel()
+            .fg(active_theme().error)
+            .add_modifier(Modifier::BOLD),
+        _ => active_theme().muted(),
+    }
+}
+
 pub(super) fn push_diff(
     builder: &mut DetailsBuilder,
     diff: &PullRequestDiff,
@@ -1803,6 +1905,7 @@ pub(super) fn push_diff(
         context.file_link_base.as_ref(),
         context.selected_line,
     );
+    let gutter_widths = DiffGutterWidths::for_file(file);
     for metadata in &file.metadata {
         builder.push_line(vec![DetailSegment::styled(
             truncate_inline(metadata, builder.width),
@@ -1843,6 +1946,7 @@ pub(super) fn push_diff(
                     index == context.selected_line || index_in_range(index, context.selected_range)
                 }),
                 inline_summary,
+                gutter_widths,
             );
             if context.comments.is_some() {
                 if context.diff_inline_comments_visible {
@@ -2026,11 +2130,12 @@ pub(super) fn push_diff_line(
     review_index: Option<usize>,
     selected: bool,
     inline_comment_summary: DiffInlineCommentSummary,
+    gutter_widths: DiffGutterWidths,
 ) {
     if let Some(review_index) = review_index {
         builder.mark_diff_line(review_index, selected);
     }
-    let gutter = diff_gutter(line.old_line, line.new_line);
+    let gutter = diff_gutter(line.old_line, line.new_line, gutter_widths);
     let (marker, mut style) = match line.kind {
         DiffLineKind::Context => (" ", diff_context_style()),
         DiffLineKind::Added => ("+", diff_added_style()),
@@ -2680,13 +2785,21 @@ pub(super) fn diff_review_side_from_label(label: &str) -> Option<DiffReviewSide>
     }
 }
 
-pub(super) fn diff_gutter(old_line: Option<usize>, new_line: Option<usize>) -> String {
+fn diff_line_number_width(line: usize) -> usize {
+    line.to_string().len().max(4)
+}
+
+pub(super) fn diff_gutter(
+    old_line: Option<usize>,
+    new_line: Option<usize>,
+    widths: DiffGutterWidths,
+) -> String {
     let old = old_line
-        .map(|line| format!("{line:>4}"))
-        .unwrap_or_else(|| "    ".to_string());
+        .map(|line| format!("{line:>width$}", width = widths.old))
+        .unwrap_or_else(|| " ".repeat(widths.old));
     let new = new_line
-        .map(|line| format!("{line:>4}"))
-        .unwrap_or_else(|| "    ".to_string());
+        .map(|line| format!("{line:>width$}", width = widths.new))
+        .unwrap_or_else(|| " ".repeat(widths.new));
     format!("{old} {new} │ ")
 }
 
@@ -3233,6 +3346,7 @@ pub(super) fn push_inline_review_context(
 
     let focus_span = inline_diff_focus_span(&hunk.lines, review);
     let (start, end) = inline_diff_context_range(hunk.lines.len(), focus_span);
+    let gutter_widths = DiffGutterWidths::for_lines(hunk.lines.iter());
     let prefix = comment_line_prefix(selected, depth);
     let right_padding = comment_right_padding(selected);
     let original_width = builder.width;
@@ -3256,7 +3370,7 @@ pub(super) fn push_inline_review_context(
     for (offset, line) in hunk.lines[start..end].iter().enumerate() {
         let index = start + offset;
         let focused = focus_span.is_some_and(|(start, end)| (start..=end).contains(&index));
-        push_inline_diff_line(builder, line, prefix.as_slice(), focused);
+        push_inline_diff_line(builder, line, prefix.as_slice(), focused, gutter_widths);
     }
     if end < hunk.lines.len() {
         push_inline_diff_ellipsis(builder, prefix.as_slice());
@@ -3477,6 +3591,7 @@ pub(super) fn push_inline_diff_line(
     line: &DiffLine,
     prefix: &[DetailSegment],
     focused: bool,
+    gutter_widths: DiffGutterWidths,
 ) {
     let marker = match line.kind {
         DiffLineKind::Context => " ",
@@ -3506,7 +3621,7 @@ pub(super) fn push_inline_diff_line(
     let focus_marker = if focused { ">" } else { " " };
     let gutter = format!(
         "{focus_marker}{}",
-        compact_diff_gutter(line.old_line, line.new_line)
+        compact_diff_gutter(line.old_line, line.new_line, gutter_widths)
     );
     let prefix_width = prefix
         .iter()
@@ -3527,14 +3642,12 @@ pub(super) fn push_inline_diff_line(
     builder.push_line(segments);
 }
 
-pub(super) fn compact_diff_gutter(old_line: Option<usize>, new_line: Option<usize>) -> String {
-    let old = old_line
-        .map(|line| format!("{line:>4}"))
-        .unwrap_or_else(|| "    ".to_string());
-    let new = new_line
-        .map(|line| format!("{line:>4}"))
-        .unwrap_or_else(|| "    ".to_string());
-    format!("{old} {new} │ ")
+pub(super) fn compact_diff_gutter(
+    old_line: Option<usize>,
+    new_line: Option<usize>,
+    widths: DiffGutterWidths,
+) -> String {
+    diff_gutter(old_line, new_line, widths)
 }
 
 pub(super) fn details_comment_count(app: &AppState, item: &WorkItem) -> Option<usize> {

--- a/src/app/dialogs.rs
+++ b/src/app/dialogs.rs
@@ -3717,13 +3717,13 @@ pub(super) fn reset_milestone_dialog_selection(dialog: &mut MilestoneDialog) {
 }
 
 pub(super) fn draw_message_dialog(frame: &mut Frame<'_>, dialog: &MessageDialog, area: Rect) {
-    let dialog_area = centered_rect(78, message_dialog_height(dialog, area), area);
+    let dialog_area = message_dialog_area(dialog, area);
     let footer = if dialog.kind == MessageDialogKind::RetryableError {
         "Enter: cancel  Esc: edit and retry"
     } else if dialog.auto_close_at.is_some() {
-        "Auto closes shortly | Enter/Esc: close"
+        "Auto closes shortly | Esc: close  Enter: OK"
     } else {
-        "Enter/Esc: close"
+        "Esc: close  Enter: OK"
     };
     let accent = message_dialog_accent(dialog);
     let block = Block::default()
@@ -3744,7 +3744,28 @@ pub(super) fn draw_message_dialog(frame: &mut Frame<'_>, dialog: &MessageDialog,
 
     frame.render_widget(Clear, dialog_area);
     frame.render_widget(paragraph, dialog_area);
+    if dialog.kind != MessageDialogKind::RetryableError {
+        let ok = Paragraph::new("[ OK ]").alignment(Alignment::Center).style(
+            active_theme()
+                .panel()
+                .fg(active_theme().highlight_fg)
+                .bg(accent)
+                .add_modifier(Modifier::BOLD),
+        );
+        frame.render_widget(ok, message_dialog_ok_area(dialog_area));
+    }
     draw_modal_footer(frame, area, dialog_area, modal_footer_line(footer));
+}
+
+pub(super) fn message_dialog_area(dialog: &MessageDialog, area: Rect) -> Rect {
+    centered_rect(78, message_dialog_height(dialog, area), area)
+}
+
+pub(super) fn message_dialog_ok_area(dialog_area: Rect) -> Rect {
+    let width = 8.min(dialog_area.width.saturating_sub(4)).max(1);
+    let x = dialog_area.x + dialog_area.width.saturating_sub(width) / 2;
+    let y = dialog_area.y + dialog_area.height.saturating_sub(2);
+    Rect::new(x, y, width, 1)
 }
 
 pub(super) fn message_dialog_height(dialog: &MessageDialog, area: Rect) -> u16 {

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -983,7 +983,18 @@ pub(super) fn handle_mouse_with_sync(
     if app.help_dialog {
         return false;
     }
-    if app.message_dialog.is_some() {
+    if let Some(dialog) = app.message_dialog.as_ref() {
+        if dialog.kind != MessageDialogKind::RetryableError
+            && matches!(mouse.kind, MouseEventKind::Down(MouseButton::Left))
+            && rect_contains(
+                message_dialog_ok_area(message_dialog_area(dialog, area)),
+                mouse.column,
+                mouse.row,
+            )
+        {
+            app.dismiss_message_dialog();
+            return true;
+        }
         return false;
     }
     if app.command_palette.is_some()

--- a/src/app/runtime.rs
+++ b/src/app/runtime.rs
@@ -102,14 +102,17 @@ pub(super) fn info_lines(app: &AppState, config: &Config, paths: &Paths) -> Vec<
         format!("ignored items: {}", app.ignored_items.len()),
         format!("recent items: {}", app.recent_items.len()),
         format!("recent commands: {}", app.recent_commands.len()),
-        format!("gh log entries: {}", gh_log_entries.len()),
+        format!("GitHub request log entries: {}", gh_log_entries.len()),
     ]
 }
 
 pub(super) fn gh_log_lines_with_details() -> (Vec<String>, Vec<Vec<String>>) {
     let entries = recent_gh_log_entries();
     if entries.is_empty() {
-        return (vec!["No gh requests logged yet".to_string()], Vec::new());
+        return (
+            vec!["No GitHub requests logged yet".to_string()],
+            Vec::new(),
+        );
     }
 
     let lines = entries.iter().map(gh_log_entry_line).collect();
@@ -118,18 +121,21 @@ pub(super) fn gh_log_lines_with_details() -> (Vec<String>, Vec<Vec<String>>) {
 }
 
 fn gh_log_detail_lines(entry: &GhLogEntry) -> Vec<String> {
+    let direct_api = entry.kind == "api";
     let mut lines = vec![
         "Result".to_string(),
         format!("  {}", gh_log_result_label(entry)),
         format!("  Status      {}", entry.status),
         format!("  Duration    {} ms", entry.duration_ms),
-        format!("  Kind        {}", entry.kind),
+        format!("  Backend     {}", gh_log_backend_label(entry)),
         String::new(),
-        "Command".to_string(),
+        if direct_api { "Request" } else { "Command" }.to_string(),
     ];
     push_wrapped_detail_block(&mut lines, &entry.command);
-    lines.extend([String::new(), "Working Directory".to_string()]);
-    push_wrapped_detail_block(&mut lines, entry.cwd.as_deref().unwrap_or("(none)"));
+    if !direct_api {
+        lines.extend([String::new(), "Working Directory".to_string()]);
+        push_wrapped_detail_block(&mut lines, entry.cwd.as_deref().unwrap_or("(none)"));
+    }
     lines.extend([
         String::new(),
         "Timing".to_string(),
@@ -147,11 +153,21 @@ fn gh_log_detail_lines(entry: &GhLogEntry) -> Vec<String> {
                 .with_timezone(&Local)
                 .format("%Y-%m-%d %H:%M:%S")
         ),
-        String::new(),
-        "Output".to_string(),
-        format!("  stdout      {}", format_log_bytes(entry.stdout_bytes)),
-        format!("  stderr      {}", format_log_bytes(entry.stderr_bytes)),
     ]);
+    if entry.kind == "api" {
+        lines.extend([
+            String::new(),
+            "Response".to_string(),
+            format!("  body        {}", format_log_bytes(entry.stdout_bytes)),
+        ]);
+    } else {
+        lines.extend([
+            String::new(),
+            "Output".to_string(),
+            format!("  stdout      {}", format_log_bytes(entry.stdout_bytes)),
+            format!("  stderr      {}", format_log_bytes(entry.stderr_bytes)),
+        ]);
+    }
     if let Some(message) = &entry.message {
         lines.extend([String::new(), "Message".to_string()]);
         push_wrapped_detail_block(&mut lines, message);
@@ -207,6 +223,14 @@ fn gh_log_result_label(entry: &GhLogEntry) -> &'static str {
         "Success"
     } else {
         "Failed"
+    }
+}
+
+fn gh_log_backend_label(entry: &GhLogEntry) -> &str {
+    match entry.kind.as_str() {
+        "api" => "Direct API",
+        "gh" | "gh api" => "GitHub CLI",
+        _ => entry.kind.as_str(),
     }
 }
 
@@ -379,5 +403,38 @@ fn github_auth_summary() -> String {
             }
         }
         Err(error) => format!("unavailable ({error})"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::Utc;
+
+    use super::*;
+
+    #[test]
+    fn direct_api_log_detail_uses_compact_request_layout() {
+        let now = Utc::now();
+        let entry = GhLogEntry {
+            started_at: now,
+            finished_at: now,
+            duration_ms: 1022,
+            kind: "api".to_string(),
+            command: "POST /graphql  document=<1200 chars>  owner=rust-lang".to_string(),
+            cwd: None,
+            status: "HTTP 200".to_string(),
+            success: true,
+            stdout_bytes: 42,
+            stderr_bytes: 0,
+            message: None,
+            rate_limited: false,
+        };
+
+        let lines = gh_log_detail_lines(&entry);
+        assert!(lines.iter().any(|line| line == "  Backend     Direct API"));
+        assert!(lines.iter().any(|line| line == "Request"));
+        assert!(lines.iter().any(|line| line.contains("POST /graphql")));
+        assert!(!lines.iter().any(|line| line == "Working Directory"));
+        assert!(lines.iter().any(|line| line == "Response"));
     }
 }

--- a/src/app/tasks.rs
+++ b/src/app/tasks.rs
@@ -233,7 +233,7 @@ pub(super) fn start_notification_read_sync(
                 Ok(_) => Ok(None),
                 Err(error) => Ok(Some(error.to_string())),
             },
-            Err(error) => Err(error.to_string()),
+            Err(error) => Err(error_chain_message(error)),
         };
         let _ = tx.send(AppMsg::NotificationReadFinished { thread_id, result });
     });
@@ -250,7 +250,7 @@ pub(super) fn start_notification_done_sync(
                 Ok(_) => Ok(None),
                 Err(error) => Ok(Some(error.to_string())),
             },
-            Err(error) => Err(error.to_string()),
+            Err(error) => Err(error_chain_message(error)),
         };
         let _ = tx.send(AppMsg::NotificationDoneFinished { thread_id, result });
     });
@@ -263,7 +263,7 @@ pub(super) fn start_inbox_mark_all_read_sync(store: SnapshotStore, tx: Unbounded
                 Ok(_) => Ok(None),
                 Err(error) => Ok(Some(error.to_string())),
             },
-            Err(error) => Err(error.to_string()),
+            Err(error) => Err(error_chain_message(error)),
         };
         let _ = tx.send(AppMsg::InboxMarkAllReadFinished { result });
     });
@@ -280,7 +280,7 @@ pub(super) fn start_inbox_thread_action_sync(
             InboxThreadAction::Subscribe => subscribe_notification_thread(&thread_id).await,
             InboxThreadAction::Unsubscribe => unsubscribe_notification_thread(&thread_id).await,
         }
-        .map_err(|error| error.to_string());
+        .map_err(error_chain_message);
         let _ = tx.send(AppMsg::InboxThreadActionFinished { action, result });
     });
 }
@@ -320,7 +320,7 @@ pub(super) fn start_comments_load(item: WorkItem, tx: UnboundedSender<AppMsg>) {
         let comments = match item.number {
             Some(number) => fetch_comments(&item.repo, number, item.kind)
                 .await
-                .map_err(|error| error.to_string()),
+                .map_err(error_chain_message),
             None => Ok(CommentFetchResult {
                 item_metadata: None,
                 item_reactions: None,
@@ -338,7 +338,7 @@ pub(super) fn start_action_hints_load(item: WorkItem, tx: UnboundedSender<AppMsg
         let actions = match item.number {
             Some(number) => fetch_pull_request_action_hints(&item.repo, number)
                 .await
-                .map_err(|error| error.to_string()),
+                .map_err(error_chain_message),
             None => Err("selected item has no pull request number".to_string()),
         };
         let _ = tx.send(AppMsg::ActionHintsLoaded { item_id, actions });
@@ -351,7 +351,7 @@ pub(super) fn start_diff_load(item: WorkItem, tx: UnboundedSender<AppMsg>) {
         let diff = match item.number {
             Some(number) => match fetch_pull_request_diff(&item.repo, number).await {
                 Ok(diff) => parse_pull_request_diff(&diff),
-                Err(error) => Err(error.to_string()),
+                Err(error) => Err(error_chain_message(error)),
             },
             None => Err("selected item has no pull request number".to_string()),
         };
@@ -634,7 +634,7 @@ pub(super) fn start_review_draft_create(item: WorkItem, body: String, tx: Unboun
             Some(number) => create_pending_pull_request_review(&item.repo, number, &body)
                 .await
                 .map(|review_id| PendingReviewState { review_id, body })
-                .map_err(|error| error.to_string()),
+                .map_err(error_chain_message),
             None => Err("selected item has no pull request number".to_string()),
         };
         let _ = tx.send(AppMsg::ReviewDraftCreated { item_id, result });
@@ -652,7 +652,7 @@ pub(super) fn start_review_submit(
         let result = match item.number {
             Some(number) => submit_pull_request_review(&item.repo, number, event, &body)
                 .await
-                .map_err(|error| error.to_string()),
+                .map_err(error_chain_message),
             None => Err("selected item has no pull request number".to_string()),
         };
         let _ = tx.send(AppMsg::ReviewSubmitted {
@@ -676,7 +676,7 @@ pub(super) fn start_pending_review_submit(
             Some(number) => {
                 submit_pending_pull_request_review(&item.repo, number, review_id, event, &body)
                     .await
-                    .map_err(|error| error.to_string())
+                    .map_err(error_chain_message)
             }
             None => Err("selected item has no pull request number".to_string()),
         };
@@ -699,7 +699,7 @@ pub(super) fn start_pending_review_discard(
         let result = match item.number {
             Some(number) => discard_pending_pull_request_review(&item.repo, number, review_id)
                 .await
-                .map_err(|error| error.to_string()),
+                .map_err(error_chain_message),
             None => Err("selected item has no pull request number".to_string()),
         };
         let _ = tx.send(AppMsg::PendingReviewDiscarded {
@@ -740,8 +740,8 @@ pub(super) fn start_reaction_submit(
                 match add_result {
                     Ok(()) => fetch_comments(&item.repo, number, item.kind)
                         .await
-                        .map_err(|error| error.to_string()),
-                    Err(error) => Err(error.to_string()),
+                        .map_err(error_chain_message),
+                    Err(error) => Err(error_chain_message(error)),
                 }
             }
             None => Err("selected item has no issue or pull request number".to_string()),
@@ -764,8 +764,8 @@ pub(super) fn start_review_thread_resolution_update(
                 match set_pull_request_review_thread_resolved(&thread_id, resolved).await {
                     Ok(()) => fetch_comments(&item.repo, number, item.kind)
                         .await
-                        .map_err(|error| error.to_string()),
-                    Err(error) => Err(error.to_string()),
+                        .map_err(error_chain_message),
+                    Err(error) => Err(error_chain_message(error)),
                 }
             }
             Some(_) => Err("review threads are available for pull requests".to_string()),
@@ -786,11 +786,11 @@ pub(super) fn start_label_update(item: WorkItem, action: LabelAction, tx: Unboun
         let result = match (item.number, &action) {
             (Some(number), LabelAction::Add(label)) => add_issue_label(&item.repo, number, label)
                 .await
-                .map_err(|error| error.to_string()),
+                .map_err(error_chain_message),
             (Some(number), LabelAction::Remove(label)) => {
                 remove_issue_label(&item.repo, number, label)
                     .await
-                    .map_err(|error| error.to_string())
+                    .map_err(error_chain_message)
             }
             (None, _) => Err("selected item has no issue or pull request number".to_string()),
         };
@@ -813,7 +813,7 @@ pub(super) fn start_label_suggestions_load(
     handle.spawn(async move {
         let result = fetch_repository_labels(&repo)
             .await
-            .map_err(|error| error.to_string());
+            .map_err(error_chain_message);
         if let Ok(labels) = &result
             && let Some(store) = &store
             && let Err(error) = store.save_label_candidates(&repo, labels)
@@ -836,7 +836,7 @@ pub(super) fn start_assignee_suggestions_load(
     handle.spawn(async move {
         let result = fetch_repository_assignees(&repo)
             .await
-            .map_err(|error| error.to_string());
+            .map_err(error_chain_message);
         if let Ok(assignees) = &result
             && let Some(store) = &store
             && let Err(error) = store.save_assignee_candidates(&repo, assignees)
@@ -859,7 +859,7 @@ pub(super) fn start_reviewer_suggestions_load(
     handle.spawn(async move {
         let result = fetch_repository_assignees(&repo)
             .await
-            .map_err(|error| error.to_string());
+            .map_err(error_chain_message);
         if let Ok(reviewers) = &result
             && let Some(store) = &store
             && let Err(error) = store.save_reviewer_candidates(&repo, reviewers)
@@ -878,7 +878,7 @@ pub(super) fn start_mention_user_search_load(query: String, tx: UnboundedSender<
     handle.spawn(async move {
         let result = search_github_users(&query)
             .await
-            .map_err(|error| error.to_string());
+            .map_err(error_chain_message);
         let _ = tx.send(AppMsg::MentionUserSearchLoaded { query, result });
     });
     true
@@ -956,61 +956,61 @@ pub(super) fn start_pr_action(
                 PrAction::Merge if item.kind == ItemKind::PullRequest => {
                     merge_pull_request(&item.repo, number, merge_method.unwrap_or_default())
                         .await
-                        .map_err(|error| error.to_string())
+                        .map_err(error_chain_message)
                 }
                 PrAction::Close if item.kind == ItemKind::PullRequest => {
                     close_pull_request(&item.repo, number)
                         .await
-                        .map_err(|error| error.to_string())
+                        .map_err(error_chain_message)
                 }
                 PrAction::Close if item.kind == ItemKind::Issue => close_issue(&item.repo, number)
                     .await
-                    .map_err(|error| error.to_string()),
+                    .map_err(error_chain_message),
                 PrAction::Reopen if item.kind == ItemKind::PullRequest => {
                     reopen_pull_request(&item.repo, number)
                         .await
-                        .map_err(|error| error.to_string())
+                        .map_err(error_chain_message)
                 }
                 PrAction::Reopen if item.kind == ItemKind::Issue => {
                     reopen_issue(&item.repo, number)
                         .await
-                        .map_err(|error| error.to_string())
+                        .map_err(error_chain_message)
                 }
                 PrAction::Approve if item.kind == ItemKind::PullRequest => {
                     approve_pull_request(&item.repo, number)
                         .await
-                        .map_err(|error| error.to_string())
+                        .map_err(error_chain_message)
                 }
                 PrAction::EnableAutoMerge if item.kind == ItemKind::PullRequest => {
                     enable_pull_request_auto_merge(&item.repo, number)
                         .await
-                        .map_err(|error| error.to_string())
+                        .map_err(error_chain_message)
                 }
                 PrAction::DisableAutoMerge if item.kind == ItemKind::PullRequest => {
                     disable_pull_request_auto_merge(&item.repo, number)
                         .await
-                        .map_err(|error| error.to_string())
+                        .map_err(error_chain_message)
                 }
                 PrAction::Checkout => unreachable!("checkout is handled before remote PR actions"),
                 PrAction::RerunFailedChecks if item.kind == ItemKind::PullRequest => {
                     rerun_failed_pull_request_checks(&item.repo, number)
                         .await
-                        .map_err(|error| error.to_string())
+                        .map_err(error_chain_message)
                 }
                 PrAction::UpdateBranch if item.kind == ItemKind::PullRequest => {
                     update_pull_request_branch(&item.repo, number)
                         .await
-                        .map_err(|error| error.to_string())
+                        .map_err(error_chain_message)
                 }
                 PrAction::ConvertToDraft if item.kind == ItemKind::PullRequest => {
                     convert_pull_request_to_draft(&item.repo, number)
                         .await
-                        .map_err(|error| error.to_string())
+                        .map_err(error_chain_message)
                 }
                 PrAction::MarkReadyForReview if item.kind == ItemKind::PullRequest => {
                     mark_pull_request_ready_for_review(&item.repo, number)
                         .await
-                        .map_err(|error| error.to_string())
+                        .map_err(error_chain_message)
                 }
                 PrAction::Merge
                 | PrAction::Approve
@@ -1042,7 +1042,7 @@ pub(super) fn start_pr_action(
                 let item_id = item.id.clone();
                 let actions = fetch_pull_request_action_hints(&item.repo, number)
                     .await
-                    .map_err(|error| error.to_string());
+                    .map_err(error_chain_message);
                 let _ = tx.send(AppMsg::ActionHintsLoaded { item_id, actions });
             }
             let _ = tx.send(AppMsg::RefreshStarted {
@@ -1074,7 +1074,7 @@ pub(super) fn start_milestones_load(item: WorkItem, tx: UnboundedSender<AppMsg>)
         let item_id = item.id.clone();
         let result = fetch_open_milestones(&item.repo)
             .await
-            .map_err(|error| error.to_string());
+            .map_err(error_chain_message);
         let _ = tx.send(AppMsg::MilestonesLoaded { item_id, result });
     });
 }
@@ -1095,7 +1095,7 @@ pub(super) fn start_milestone_change(
                     changed_milestone = milestone.clone();
                     change_issue_milestone(&item.repo, number, milestone.as_ref().map(|m| m.number))
                         .await
-                        .map_err(|error| error.to_string())
+                        .map_err(error_chain_message)
                 }
                 Err(error) => Err(error),
             },
@@ -1143,7 +1143,7 @@ pub(super) async fn resolve_milestone_choice(
         MilestoneChoice::Create(title) => create_milestone(repository, &title)
             .await
             .map(Some)
-            .map_err(|error| error.to_string()),
+            .map_err(error_chain_message),
     }
 }
 
@@ -1162,12 +1162,12 @@ pub(super) fn start_reviewer_action(
                 ReviewerAction::Request => {
                     request_pull_request_reviewers(&item.repo, number, &reviewers)
                         .await
-                        .map_err(|error| error.to_string())
+                        .map_err(error_chain_message)
                 }
                 ReviewerAction::Remove => {
                     remove_pull_request_reviewers(&item.repo, number, &reviewers)
                         .await
-                        .map_err(|error| error.to_string())
+                        .map_err(error_chain_message)
                 }
             },
             None => Err("selected item has no pull request number".to_string()),
@@ -1217,7 +1217,7 @@ pub(super) fn start_assignee_update(
             Some(number) => {
                 update_issue_assignees(&item.repo, number, item.kind, action, &assignees)
                     .await
-                    .map_err(|error| error.to_string())
+                    .map_err(error_chain_message)
             }
             None => Err("selected item has no issue or pull request number".to_string()),
         };

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -13315,6 +13315,64 @@ fn copy_github_link_uses_item_link_without_selected_comment() {
 }
 
 #[test]
+fn copy_pr_issue_link_ignores_selected_comment_when_details_focused() {
+    let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
+    app.details.insert(
+        "1".to_string(),
+        DetailState::Loaded(vec![comment(
+            "alice",
+            "looks good",
+            Some("https://github.com/rust-lang/rust/pull/1#issuecomment-1"),
+        )]),
+    );
+    app.focus_details();
+
+    assert_eq!(
+        app.selected_pr_issue_link(),
+        Some((
+            "https://github.com/rust-lang/rust/pull/1".to_string(),
+            "pull request"
+        ))
+    );
+
+    app.copy_pr_issue_link();
+
+    assert_eq!(app.status, "copied pull request link");
+}
+
+#[test]
+fn copy_pr_issue_link_uses_selected_issue_link() {
+    let mut item = work_item("issue-159537", "rust-lang/rust", 159537, "Borrowck", None);
+    item.kind = ItemKind::Issue;
+    item.url = "https://github.com/rust-lang/rust/issues/159537".to_string();
+    let section = SectionSnapshot {
+        key: "issues:test".to_string(),
+        kind: SectionKind::Issues,
+        title: "Issues".to_string(),
+        filters: String::new(),
+        items: vec![item],
+        total_count: None,
+        page: 1,
+        page_size: 0,
+        refreshed_at: None,
+        error: None,
+    };
+    let mut app = AppState::new(SectionKind::Issues, vec![section]);
+
+    assert_eq!(
+        app.selected_pr_issue_link(),
+        Some((
+            "https://github.com/rust-lang/rust/issues/159537".to_string(),
+            "issue"
+        ))
+    );
+
+    app.copy_pr_issue_link();
+
+    assert_eq!(app.status, "copied issue link");
+}
+
+#[test]
 fn copy_content_prefers_selected_comment_when_details_focused() {
     let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
     app.details.insert(
@@ -13433,6 +13491,29 @@ fn command_palette_copy_github_link_copies_current_item_link() {
     let store = SnapshotStore::new(std::path::PathBuf::from("/tmp/ghr-test-unused.db"));
     app.command_palette = Some(CommandPalette {
         query: "copy github".to_string(),
+        selected: 0,
+    });
+
+    assert!(!handle_key(
+        &mut app,
+        key(KeyCode::Enter),
+        &config,
+        &store,
+        &tx
+    ));
+
+    assert_eq!(app.status, "copied pull request link");
+    assert!(app.command_palette.is_none());
+}
+
+#[test]
+fn command_palette_copy_pr_issue_link_copies_current_item_link() {
+    let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
+    let (tx, _rx) = mpsc::unbounded_channel();
+    let config = Config::default();
+    let store = SnapshotStore::new(std::path::PathBuf::from("/tmp/ghr-test-unused.db"));
+    app.command_palette = Some(CommandPalette {
+        query: "copy pr issue".to_string(),
         selected: 0,
     });
 

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -16870,6 +16870,113 @@ fn milestone_change_failure_opens_message_dialog() {
 }
 
 #[test]
+fn approve_review_failure_opens_blocking_error_dialog() {
+    let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
+    app.review_submit_running = true;
+    app.message_dialog = Some(info_message_dialog(
+        "Submitting Review",
+        "Waiting for GitHub to approve...",
+    ));
+    let error = anyhow::anyhow!(
+        "GitHub API request failed: HTTP 422: Unprocessable Entity; errors: Review Can not approve your own pull request"
+    )
+    .context("failed to submit review for chenyukang/ghr#81");
+
+    app.handle_msg(AppMsg::ReviewSubmitted {
+        item_id: "1".to_string(),
+        event: PullRequestReviewEvent::Approve,
+        result: Err(error_chain_message(error)),
+    });
+
+    assert!(!app.review_submit_running);
+    assert_eq!(app.status, "review submit failed");
+    let dialog = app.message_dialog.as_ref().expect("failure dialog");
+    assert_eq!(dialog.title, "Review Failed");
+    assert_eq!(dialog.kind, MessageDialogKind::Error);
+    assert!(dialog.body.contains("HTTP 422"));
+    assert!(
+        dialog
+            .body
+            .contains("Can not approve your own pull request")
+    );
+    assert!(dialog.auto_close_at.is_none());
+}
+
+#[test]
+fn user_triggered_write_failures_open_error_dialogs() {
+    let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
+
+    app.handle_msg(AppMsg::NotificationReadFinished {
+        thread_id: "thread-1".to_string(),
+        result: Err("HTTP 403".to_string()),
+    });
+    assert_eq!(
+        app.message_dialog
+            .as_ref()
+            .map(|dialog| dialog.title.as_str()),
+        Some("Mark Notification Read Failed")
+    );
+
+    app.handle_msg(AppMsg::NotificationDoneFinished {
+        thread_id: "thread-1".to_string(),
+        result: Err("HTTP 403".to_string()),
+    });
+    assert_eq!(
+        app.message_dialog
+            .as_ref()
+            .map(|dialog| dialog.title.as_str()),
+        Some("Mark Notification Done Failed")
+    );
+
+    app.handle_msg(AppMsg::InboxMarkAllReadFinished {
+        result: Err("HTTP 403".to_string()),
+    });
+    assert_eq!(
+        app.message_dialog
+            .as_ref()
+            .map(|dialog| dialog.title.as_str()),
+        Some("Mark All Notifications Read Failed")
+    );
+
+    app.handle_msg(AppMsg::InboxThreadActionFinished {
+        action: InboxThreadAction::Mute,
+        result: Err("HTTP 403".to_string()),
+    });
+    assert_eq!(
+        app.message_dialog
+            .as_ref()
+            .map(|dialog| dialog.title.as_str()),
+        Some("Mute Thread Failed")
+    );
+
+    app.handle_msg(AppMsg::ItemSubscriptionUpdated {
+        item_id: "1".to_string(),
+        item_kind: ItemKind::PullRequest,
+        action: ItemSubscriptionAction::Subscribe,
+        result: Err("HTTP 403".to_string()),
+    });
+    let dialog = app.message_dialog.as_ref().expect("failure dialog");
+    assert_eq!(dialog.title, "Subscribe to Pull Request Failed");
+    assert_eq!(dialog.body, "HTTP 403");
+    assert_eq!(dialog.kind, MessageDialogKind::Error);
+}
+
+#[test]
+fn notification_snapshot_save_failure_opens_error_dialog() {
+    let mut app = AppState::new(SectionKind::Notifications, vec![test_section()]);
+
+    app.handle_msg(AppMsg::NotificationReadFinished {
+        thread_id: "thread-1".to_string(),
+        result: Ok(Some("database is locked".to_string())),
+    });
+
+    let dialog = app.message_dialog.as_ref().expect("failure dialog");
+    assert_eq!(dialog.title, "Notification Snapshot Save Failed");
+    assert_eq!(dialog.body, "database is locked");
+    assert!(app.status.contains("snapshot save failed"));
+}
+
+#[test]
 fn message_dialog_enter_dismisses() {
     let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
     let (tx, _rx) = mpsc::unbounded_channel();
@@ -16887,6 +16994,57 @@ fn message_dialog_enter_dismisses() {
 
     assert!(app.message_dialog.is_none());
     assert_eq!(app.status, "message dismissed");
+}
+
+#[test]
+fn message_dialog_esc_and_ok_click_dismiss() {
+    let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
+    let (tx, _rx) = mpsc::unbounded_channel();
+    let config = Config::default();
+    let store = SnapshotStore::new(std::path::PathBuf::from("/tmp/ghr-test-unused.db"));
+
+    app.message_dialog = Some(message_dialog("Approve Failed", "HTTP 422"));
+    assert!(!handle_key(
+        &mut app,
+        key(KeyCode::Esc),
+        &config,
+        &store,
+        &tx
+    ));
+    assert!(app.message_dialog.is_none());
+
+    let area = Rect::new(0, 0, 120, 40);
+    app.message_dialog = Some(message_dialog("Approve Failed", "HTTP 422"));
+    let dialog = app.message_dialog.as_ref().expect("message dialog");
+    let ok_area = message_dialog_ok_area(message_dialog_area(dialog, area));
+    assert!(handle_mouse(
+        &mut app,
+        MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: ok_area.x,
+            row: ok_area.y,
+            modifiers: KeyModifiers::NONE,
+        },
+        area,
+    ));
+    assert!(app.message_dialog.is_none());
+}
+
+#[test]
+fn message_dialog_renders_ok_button() {
+    let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
+    app.message_dialog = Some(message_dialog("Approve Failed", "HTTP 422"));
+    let backend = ratatui::backend::TestBackend::new(100, 30);
+    let mut terminal = Terminal::new(backend).expect("test terminal");
+    let paths = test_paths();
+
+    terminal
+        .draw(|frame| draw(frame, &app, &paths))
+        .expect("draw");
+
+    let rendered = buffer_lines(terminal.backend().buffer()).join("\n");
+    assert!(rendered.contains("[ OK ]"));
+    assert!(rendered.contains("Esc: close  Enter: OK"));
 }
 
 #[test]

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -3636,6 +3636,7 @@ fn comments_loaded_records_item_updated_at_for_cache_freshness() {
                 comments: Some(1),
                 viewer_subscription: None,
                 linked_pull_requests: None,
+                linked_issues: None,
             }),
             item_reactions: Some(ReactionSummary::default()),
             item_milestone: Some(None),
@@ -3689,6 +3690,7 @@ fn comments_loaded_uses_notification_updated_at_when_it_is_newer_than_linked_ite
                 comments: Some(3),
                 viewer_subscription: None,
                 linked_pull_requests: None,
+                linked_issues: None,
             }),
             item_reactions: Some(ReactionSummary::default()),
             item_milestone: Some(None),
@@ -3733,6 +3735,7 @@ fn comment_metadata_updated_at_marks_unseen_when_not_focused() {
                 comments: Some(3),
                 viewer_subscription: None,
                 linked_pull_requests: None,
+                linked_issues: None,
             }),
             item_reactions: Some(ReactionSummary::default()),
             item_milestone: Some(None),
@@ -5052,7 +5055,7 @@ fn command_palette_recent_items_opens_recent_picker() {
 }
 
 #[test]
-fn command_palette_open_linked_pr_opens_current_issue_linked_pull_request() {
+fn command_palette_open_linked_item_opens_current_issue_linked_pull_request() {
     let mut item = work_item("issue-1", "chenyukang/ghr", 1, "Bug report", Some("alice"));
     item.kind = ItemKind::Issue;
     item.url = "https://github.com/chenyukang/ghr/issues/1".to_string();
@@ -5103,7 +5106,7 @@ fn command_palette_open_linked_pr_opens_current_issue_linked_pull_request() {
 }
 
 #[test]
-fn command_palette_open_linked_pr_reports_missing_linked_pull_request() {
+fn command_palette_open_linked_item_reports_missing_linked_pull_request() {
     let mut item = work_item("issue-1", "chenyukang/ghr", 1, "Bug report", Some("alice"));
     item.kind = ItemKind::Issue;
     item.url = "https://github.com/chenyukang/ghr/issues/1".to_string();
@@ -5140,6 +5143,105 @@ fn command_palette_open_linked_pr_reports_missing_linked_pull_request() {
     ));
 
     assert_eq!(app.status, "no linked pull request");
+    assert!(app.command_palette.is_none());
+}
+
+#[test]
+fn command_palette_open_linked_item_opens_current_pull_request_linked_issue() {
+    let mut item = work_item(
+        "pr-78",
+        "chenyukang/ghr",
+        78,
+        "Fix notification handling",
+        Some("alice"),
+    );
+    item.linked_issues = vec![LinkedIssue {
+        repository: "chenyukang/ghr".to_string(),
+        number: 77,
+        title: "Notifications reappear in inbox".to_string(),
+        state: Some("open".to_string()),
+        url: "https://github.com/chenyukang/ghr/issues/77".to_string(),
+    }];
+    let section = SectionSnapshot {
+        key: "pull_requests:test".to_string(),
+        kind: SectionKind::PullRequests,
+        title: "Pull Requests".to_string(),
+        filters: String::new(),
+        items: vec![item],
+        total_count: None,
+        page: 1,
+        page_size: 0,
+        refreshed_at: None,
+        error: None,
+    };
+    let mut app = AppState::new(SectionKind::PullRequests, vec![section]);
+    let (tx, _rx) = mpsc::unbounded_channel();
+    let mut config = Config::default();
+    let paths = unique_test_paths("command-palette-open-linked-issue");
+    let store = SnapshotStore::new(paths.db_path.clone());
+    app.command_palette = Some(CommandPalette {
+        query: "linked issue".to_string(),
+        selected: 0,
+    });
+
+    assert!(!handle_key_in_area_mut(
+        &mut app,
+        key(KeyCode::Enter),
+        &mut config,
+        &paths,
+        &store,
+        &tx,
+        None,
+    ));
+
+    assert_eq!(
+        app.status,
+        "opened https://github.com/chenyukang/ghr/issues/77"
+    );
+    assert!(app.command_palette.is_none());
+}
+
+#[test]
+fn command_palette_open_linked_item_reports_missing_linked_issue() {
+    let section = SectionSnapshot {
+        key: "pull_requests:test".to_string(),
+        kind: SectionKind::PullRequests,
+        title: "Pull Requests".to_string(),
+        filters: String::new(),
+        items: vec![work_item(
+            "pr-78",
+            "chenyukang/ghr",
+            78,
+            "Fix notification handling",
+            Some("alice"),
+        )],
+        total_count: None,
+        page: 1,
+        page_size: 0,
+        refreshed_at: None,
+        error: None,
+    };
+    let mut app = AppState::new(SectionKind::PullRequests, vec![section]);
+    let (tx, _rx) = mpsc::unbounded_channel();
+    let mut config = Config::default();
+    let paths = unique_test_paths("command-palette-open-linked-issue-missing");
+    let store = SnapshotStore::new(paths.db_path.clone());
+    app.command_palette = Some(CommandPalette {
+        query: "linked issue".to_string(),
+        selected: 0,
+    });
+
+    assert!(!handle_key_in_area_mut(
+        &mut app,
+        key(KeyCode::Enter),
+        &mut config,
+        &paths,
+        &store,
+        &tx,
+        None,
+    ));
+
+    assert_eq!(app.status, "no linked issue");
     assert!(app.command_palette.is_none());
 }
 
@@ -6707,7 +6809,7 @@ fn details_render_clears_stale_cells_when_scrolling_short_lines() {
         .iter()
         .position(|line| {
             let text = line.to_string();
-            text.contains("+ react") && text.contains("reply")
+            text.contains("+react") && text.contains("reply")
         })
         .expect("comment header");
     let paths = test_paths();
@@ -6726,7 +6828,7 @@ fn details_render_clears_stale_cells_when_scrolling_short_lines() {
 
     let top_details_line = &buffer_lines(terminal.backend().buffer())[inner.y as usize];
     assert!(
-        !top_details_line.contains("+ react") && !top_details_line.contains("reply"),
+        !top_details_line.contains("+react") && !top_details_line.contains("reply"),
         "stale comment header cells leaked after scroll: {top_details_line:?}"
     );
 }
@@ -9395,6 +9497,7 @@ fn comments_loaded_updates_issue_linked_pull_requests_metadata() {
                     state: Some("merged".to_string()),
                     url: "https://github.com/chenyukang/ghr/pull/78".to_string(),
                 }]),
+                linked_issues: None,
             }),
             item_reactions: Some(ReactionSummary::default()),
             item_milestone: Some(None),
@@ -9409,6 +9512,69 @@ fn comments_loaded_updates_issue_linked_pull_requests_metadata() {
         .collect::<Vec<_>>()
         .join("\n");
     assert!(rendered.contains("linked PRs: #78 Fix notification handling merged"));
+}
+
+#[test]
+fn comments_loaded_updates_pull_request_linked_issues_metadata() {
+    let mut item = work_item(
+        "pr-78",
+        "chenyukang/ghr",
+        78,
+        "Fix notification handling",
+        Some("alice"),
+    );
+    item.url = "https://github.com/chenyukang/ghr/pull/78".to_string();
+    let section = SectionSnapshot {
+        key: "pull_requests:test".to_string(),
+        kind: SectionKind::PullRequests,
+        title: "Pull Requests".to_string(),
+        filters: String::new(),
+        items: vec![item],
+        total_count: None,
+        page: 1,
+        page_size: 0,
+        refreshed_at: None,
+        error: None,
+    };
+    let mut app = AppState::new(SectionKind::PullRequests, vec![section]);
+
+    app.handle_msg(AppMsg::CommentsLoaded {
+        item_id: "pr-78".to_string(),
+        comments: Ok(CommentFetchResult {
+            item_metadata: Some(ItemDetailsMetadata {
+                title: Some("Fix notification handling".to_string()),
+                body: Some("Pull request body".to_string()),
+                author: Some("alice".to_string()),
+                state: Some("open".to_string()),
+                url: Some("https://github.com/chenyukang/ghr/pull/78".to_string()),
+                created_at: None,
+                updated_at: None,
+                labels: Some(Vec::new()),
+                assignees: Some(Vec::new()),
+                comments: Some(0),
+                viewer_subscription: None,
+                linked_pull_requests: None,
+                linked_issues: Some(vec![LinkedIssue {
+                    repository: "chenyukang/ghr".to_string(),
+                    number: 77,
+                    title: "Notifications reappear in inbox".to_string(),
+                    state: Some("open".to_string()),
+                    url: "https://github.com/chenyukang/ghr/issues/77".to_string(),
+                }]),
+            }),
+            item_reactions: Some(ReactionSummary::default()),
+            item_milestone: Some(None),
+            comments: Vec::new(),
+        }),
+    });
+
+    let rendered = build_details_document(&app, 120)
+        .lines
+        .iter()
+        .map(|line| line.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(rendered.contains("linked issues: #77 Notifications reappear in inbox open"));
 }
 
 #[test]
@@ -9474,6 +9640,7 @@ fn comments_loaded_updates_inbox_notification_description_from_lazy_metadata() {
                 comments: Some(3),
                 viewer_subscription: None,
                 linked_pull_requests: None,
+                linked_issues: None,
             }),
             item_reactions: Some(ReactionSummary::default()),
             item_milestone: Some(None),
@@ -9724,6 +9891,67 @@ fn issue_details_shows_linked_pull_requests() {
 }
 
 #[test]
+fn pull_request_details_shows_linked_issues() {
+    let mut item = work_item(
+        "pr-78",
+        "chenyukang/ghr",
+        78,
+        "Fix notification handling",
+        Some("alice"),
+    );
+    item.url = "https://github.com/chenyukang/ghr/pull/78".to_string();
+    item.linked_issues = vec![
+        LinkedIssue {
+            repository: "chenyukang/ghr".to_string(),
+            number: 77,
+            title: "Notifications reappear in inbox".to_string(),
+            state: Some("open".to_string()),
+            url: "https://github.com/chenyukang/ghr/issues/77".to_string(),
+        },
+        LinkedIssue {
+            repository: "rust-lang/rust".to_string(),
+            number: 159309,
+            title: "Move tests batch 18".to_string(),
+            state: Some("closed".to_string()),
+            url: "https://github.com/rust-lang/rust/issues/159309".to_string(),
+        },
+    ];
+    let section = SectionSnapshot {
+        key: "pull_requests:test".to_string(),
+        kind: SectionKind::PullRequests,
+        title: "Pull Requests".to_string(),
+        filters: String::new(),
+        items: vec![item],
+        total_count: None,
+        page: 1,
+        page_size: 0,
+        refreshed_at: None,
+        error: None,
+    };
+    let app = AppState::new(SectionKind::PullRequests, vec![section]);
+    let document = build_details_document(&app, 140);
+    let rendered = document
+        .lines
+        .iter()
+        .map(|line| line.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert!(rendered.contains("linked issues: #77 Notifications reappear in inbox open"));
+    assert!(rendered.contains("rust-lang/rust#159309 Move tests batch 18 closed"));
+    assert_document_link_for_text(
+        &document,
+        "#77",
+        "https://github.com/chenyukang/ghr/issues/77",
+    );
+    assert_document_link_for_text(
+        &document,
+        "rust-lang/rust#159309",
+        "https://github.com/rust-lang/rust/issues/159309",
+    );
+}
+
+#[test]
 fn issue_details_show_empty_labels_as_actionable() {
     let mut item = work_item("issue-1", "chenyukang/ghr", 1, "Bug report", Some("alice"));
     item.kind = ItemKind::Issue;
@@ -9753,7 +9981,7 @@ fn issue_details_show_empty_labels_as_actionable() {
     assert!(rendered.contains("labels:  +"));
     assert!(!rendered.contains("labels: none"));
     assert!(rendered.contains("subscription: subscribe"));
-    assert!(rendered.contains("  reactions:  + react"));
+    assert!(rendered.contains("  reactions:  +react"));
     assert!(!rendered.contains("reactions: none"));
     assert_document_action_for_text_on_line(&document, "labels:", "+", DetailAction::AddLabel);
     assert_document_action_for_text_on_line(
@@ -9771,7 +9999,7 @@ fn issue_details_show_empty_labels_as_actionable() {
     assert_document_action_for_text_on_line(
         &document,
         "reactions:",
-        "+ react",
+        "+react",
         DetailAction::ReactItem,
     );
 }
@@ -9894,7 +10122,7 @@ fn notification_details_hide_unavailable_item_reaction_action() {
         .collect::<Vec<_>>()
         .join("\n");
 
-    assert!(!rendered.contains("+ react"));
+    assert!(!rendered.contains("+react"));
     assert!(!rendered.contains("reactions:"));
     assert!(!rendered.contains("subscription:"));
     assert!(
@@ -9944,7 +10172,7 @@ fn notification_details_show_reaction_counts_without_unavailable_action() {
         .join("\n");
 
     assert!(rendered.contains("reactions: 👀 1"));
-    assert!(!rendered.contains("+ react"));
+    assert!(!rendered.contains("+react"));
     assert!(
         !document
             .actions
@@ -11392,7 +11620,7 @@ fn details_activity_hides_comment_actions() {
         .find(|line| line.contains("doitian"))
         .expect("activity header");
     assert!(activity_header.contains("activity:"));
-    assert!(!activity_header.contains("+ react"));
+    assert!(!activity_header.contains("+react"));
     assert!(!activity_header.contains("reply"));
     assert!(document.comments.is_empty());
 }
@@ -11585,7 +11813,7 @@ fn details_render_description_and_comment_reactions() {
         .collect::<Vec<_>>();
     let rendered = rendered_lines.join("\n");
 
-    assert!(rendered.contains("  reactions: ❤️ 1  👀 1  + react"));
+    assert!(rendered.contains("  reactions: ❤️ 1  👀 1  +react"));
     assert!(rendered.contains("alice - -  🚀 2  👀 1"));
     let header_index = rendered_lines
         .iter()
@@ -11619,7 +11847,7 @@ fn details_renderer_marks_terminal_wide_symbols_as_skip_cells() {
         Span::raw("Zhangcy0x3 - 16d open "),
         Span::raw("❤️"),
         Span::raw(" 1  "),
-        Span::styled("+ react", active_theme().action),
+        Span::styled("+react", active_theme().action),
     ]);
     let mut buffer = Buffer::empty(Rect::new(0, 0, 80, 3));
 
@@ -11911,7 +12139,7 @@ fn details_comments_show_inline_review_location() {
         .find(|line| line.contains("inline src/github.rs:876 right"))
         .expect("inline review metadata line");
     assert!(
-        !metadata_line.contains("+ react") && !metadata_line.contains("reply"),
+        !metadata_line.contains("+react") && !metadata_line.contains("reply"),
         "review metadata line should not carry comment actions: {rendered}"
     );
     assert!(rendered.contains("GH_NO_UPDATE_NOTIFIER"));
@@ -11954,7 +12182,7 @@ fn details_comments_keep_long_inline_review_metadata_on_own_line() {
         .collect::<Vec<_>>();
     let header_index = rendered
         .iter()
-        .position(|line| line.contains("mejrs") && line.contains("+ react"))
+        .position(|line| line.contains("mejrs") && line.contains("+react"))
         .expect("comment action header");
     let metadata_index = rendered
         .iter()
@@ -11977,8 +12205,7 @@ fn details_comments_keep_long_inline_review_metadata_on_own_line() {
         "long review metadata should not share the author/action header: {rendered:?}"
     );
     assert!(
-        !rendered[metadata_index].contains("+ react")
-            && !rendered[metadata_index].contains("reply"),
+        !rendered[metadata_index].contains("+react") && !rendered[metadata_index].contains("reply"),
         "comment actions should stay on the header: {rendered:?}"
     );
 }
@@ -12138,7 +12365,7 @@ fn comment_gap_lines_are_padded_to_clear_stale_header_cells() {
         .collect::<Vec<_>>();
     let header_index = rendered
         .iter()
-        .position(|line| line.contains("Zhangcy0x3") && line.contains("+ react"))
+        .position(|line| line.contains("Zhangcy0x3") && line.contains("+react"))
         .expect("comment header");
     let gap = rendered
         .get(header_index + 1)
@@ -12179,7 +12406,7 @@ fn selected_comment_right_border_stays_aligned_with_reactions() {
         .expect("selected comment top border");
     let header = rendered
         .iter()
-        .find(|line| line.contains("Zhangcy0x3") && line.contains("+ react"))
+        .find(|line| line.contains("Zhangcy0x3") && line.contains("+react"))
         .expect("selected comment header");
     let body = rendered
         .iter()
@@ -12475,7 +12702,7 @@ fn review_summary_details_show_reply_without_reaction_action() {
         .expect("review summary header");
 
     assert!(rendered[header_line].contains("reply"));
-    assert!(!rendered[header_line].contains("+ react"));
+    assert!(!rendered[header_line].contains("+react"));
     let reply_column = rendered[header_line].find("reply").expect("reply action") as u16;
     assert_eq!(
         document.action_at(header_line, reply_column),
@@ -12494,8 +12721,8 @@ fn assignee_actions_are_rendered_in_details() {
         .position(|line| line.to_string().contains("assignees: -"))
         .expect("empty assignee row");
     let empty_line = document.lines[assignee_line].to_string();
-    let assign_column = empty_line.find("@ assign").expect("assign action") as u16;
-    assert!(!empty_line.contains("- unassign"));
+    let assign_column = empty_line.find("@assign").expect("assign action") as u16;
+    assert!(!empty_line.contains("-unassign"));
     assert_eq!(
         document.action_at(assignee_line, assign_column),
         Some(DetailAction::AssignAssignee)
@@ -12511,11 +12738,11 @@ fn assignee_actions_are_rendered_in_details() {
         .expect("assignee row");
     let assign_column = document.lines[assignee_line]
         .to_string()
-        .find("@ assign")
+        .find("@assign")
         .expect("assign action") as u16;
     let unassign_column = document.lines[assignee_line]
         .to_string()
-        .find("- unassign")
+        .find("-unassign")
         .expect("unassign action") as u16;
 
     assert_eq!(
@@ -15946,6 +16173,7 @@ fn item_edit_rejects_non_issue_or_pull_request_items() {
             milestone: None,
             assignees: Vec::new(),
             linked_pull_requests: Vec::new(),
+            linked_issues: Vec::new(),
             comments: None,
             unread: Some(true),
             reason: Some("mention".to_string()),
@@ -21287,6 +21515,7 @@ fn work_item(id: &str, repo: &str, number: u64, title: &str, author: Option<&str
         milestone: None,
         assignees: Vec::new(),
         linked_pull_requests: Vec::new(),
+        linked_issues: Vec::new(),
         comments: Some(0),
         unread: None,
         reason: None,
@@ -21337,6 +21566,7 @@ fn notification_item(id: &str, unread: bool) -> WorkItem {
         milestone: None,
         assignees: Vec::new(),
         linked_pull_requests: Vec::new(),
+        linked_issues: Vec::new(),
         comments: None,
         unread: Some(unread),
         reason: Some("mention".to_string()),

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -240,6 +240,70 @@ fn diff_document_renders_lazygit_style_gutter() {
 }
 
 #[test]
+fn diff_document_aligns_gutter_for_wide_line_numbers() {
+    let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
+    app.show_diff();
+    app.diffs.insert(
+        "1".to_string(),
+        DiffState::Loaded(
+            parse_pull_request_diff(
+                r#"diff --git a/src/lib.rs b/src/lib.rs
+--- a/src/lib.rs
++++ b/src/lib.rs
+@@ -11099,4 +11423,5 @@
+ context before
+-old
++new
++extra
+ context after
+"#,
+            )
+            .expect("parse diff"),
+        ),
+    );
+
+    let rendered_lines = build_details_document(&app, 120)
+        .lines
+        .iter()
+        .map(Line::to_string)
+        .collect::<Vec<_>>();
+    let diff_lines = rendered_lines
+        .iter()
+        .filter(|line| {
+            line.contains("│")
+                && ["context before", "old", "new", "extra", "context after"]
+                    .iter()
+                    .any(|text| line.contains(text))
+        })
+        .collect::<Vec<_>>();
+    let separator_columns = diff_lines
+        .iter()
+        .map(|line| {
+            let separator = line.find('│').expect("diff gutter separator");
+            display_width(&line[..separator])
+        })
+        .collect::<std::collections::HashSet<_>>();
+
+    assert_eq!(
+        separator_columns.len(),
+        1,
+        "diff gutter separators should stay aligned: {diff_lines:?}"
+    );
+    assert!(
+        rendered_lines
+            .iter()
+            .any(|line| line.contains("11100       │ - old")),
+        "removed line should reserve the 5-wide new-line column: {rendered_lines:?}"
+    );
+    assert!(
+        rendered_lines
+            .iter()
+            .any(|line| line.contains("      11424 │ + new")),
+        "added line should reserve the 5-wide old-line column: {rendered_lines:?}"
+    );
+}
+
+#[test]
 fn diff_document_expands_tabs_in_source_lines() {
     let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
     app.show_diff();
@@ -2888,6 +2952,83 @@ fn progressive_refresh_does_not_force_current_details_reload() {
 }
 
 #[test]
+fn progressive_issue_refresh_keeps_linked_pull_requests_visible() {
+    let mut item = work_item(
+        "issue-1",
+        "chenyukang/ghr",
+        77,
+        "Notifications reappear",
+        Some("alice"),
+    );
+    item.kind = ItemKind::Issue;
+    item.url = "https://github.com/chenyukang/ghr/issues/77".to_string();
+    let linked_pull_requests = vec![LinkedPullRequest {
+        repository: "chenyukang/ghr".to_string(),
+        number: 78,
+        title: "Fix notification handling".to_string(),
+        state: Some("merged".to_string()),
+        url: "https://github.com/chenyukang/ghr/pull/78".to_string(),
+    }];
+    item.linked_pull_requests = linked_pull_requests.clone();
+    let section = SectionSnapshot {
+        key: "issues:test".to_string(),
+        kind: SectionKind::Issues,
+        title: "Issues".to_string(),
+        filters: String::new(),
+        items: vec![item],
+        total_count: None,
+        page: 1,
+        page_size: 0,
+        refreshed_at: None,
+        error: None,
+    };
+    let mut app = AppState::new(SectionKind::Issues, vec![section]);
+    app.refreshing = true;
+    app.focus_details();
+    app.details
+        .insert("issue-1".to_string(), DetailState::Loaded(Vec::new()));
+
+    let mut refreshed_item = work_item(
+        "issue-1",
+        "chenyukang/ghr",
+        77,
+        "Notifications reappear in inbox",
+        Some("alice"),
+    );
+    refreshed_item.kind = ItemKind::Issue;
+    refreshed_item.url = "https://github.com/chenyukang/ghr/issues/77".to_string();
+    refreshed_item.linked_pull_requests = Vec::new();
+    let refreshed_section = SectionSnapshot {
+        key: "issues:test".to_string(),
+        kind: SectionKind::Issues,
+        title: "Issues".to_string(),
+        filters: String::new(),
+        items: vec![refreshed_item],
+        total_count: None,
+        page: 1,
+        page_size: 0,
+        refreshed_at: None,
+        error: None,
+    };
+
+    app.handle_msg(AppMsg::RefreshSectionLoaded {
+        section: refreshed_section,
+        save_error: None,
+    });
+
+    let item = app.current_item().expect("current issue");
+    assert_eq!(item.title, "Notifications reappear in inbox");
+    assert_eq!(item.linked_pull_requests, linked_pull_requests);
+    let rendered = build_details_document(&app, 120)
+        .lines
+        .iter()
+        .map(|line| line.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(rendered.contains("linked PRs: #78 Fix notification handling merged"));
+}
+
+#[test]
 fn progressive_refresh_does_not_overwrite_active_user_page_load() {
     let mut current = many_items_section(1);
     current.total_count = Some(120);
@@ -3494,6 +3635,7 @@ fn comments_loaded_records_item_updated_at_for_cache_freshness() {
                 assignees: None,
                 comments: Some(1),
                 viewer_subscription: None,
+                linked_pull_requests: None,
             }),
             item_reactions: Some(ReactionSummary::default()),
             item_milestone: Some(None),
@@ -3546,6 +3688,7 @@ fn comments_loaded_uses_notification_updated_at_when_it_is_newer_than_linked_ite
                 assignees: None,
                 comments: Some(3),
                 viewer_subscription: None,
+                linked_pull_requests: None,
             }),
             item_reactions: Some(ReactionSummary::default()),
             item_milestone: Some(None),
@@ -3589,6 +3732,7 @@ fn comment_metadata_updated_at_marks_unseen_when_not_focused() {
                 assignees: None,
                 comments: Some(3),
                 viewer_subscription: None,
+                linked_pull_requests: None,
             }),
             item_reactions: Some(ReactionSummary::default()),
             item_milestone: Some(None),
@@ -4905,6 +5049,98 @@ fn command_palette_recent_items_opens_recent_picker() {
     assert!(app.command_palette.is_none());
     assert_eq!(app.recent_items_dialog, Some(RecentItemsDialog::default()));
     assert_eq!(app.status, "recent items");
+}
+
+#[test]
+fn command_palette_open_linked_pr_opens_current_issue_linked_pull_request() {
+    let mut item = work_item("issue-1", "chenyukang/ghr", 1, "Bug report", Some("alice"));
+    item.kind = ItemKind::Issue;
+    item.url = "https://github.com/chenyukang/ghr/issues/1".to_string();
+    item.linked_pull_requests = vec![LinkedPullRequest {
+        repository: "chenyukang/ghr".to_string(),
+        number: 78,
+        title: "Fix notification handling".to_string(),
+        state: Some("merged".to_string()),
+        url: "https://github.com/chenyukang/ghr/pull/78".to_string(),
+    }];
+    let section = SectionSnapshot {
+        key: "issues:test".to_string(),
+        kind: SectionKind::Issues,
+        title: "Issues".to_string(),
+        filters: String::new(),
+        items: vec![item],
+        total_count: None,
+        page: 1,
+        page_size: 0,
+        refreshed_at: None,
+        error: None,
+    };
+    let mut app = AppState::new(SectionKind::Issues, vec![section]);
+    let (tx, _rx) = mpsc::unbounded_channel();
+    let mut config = Config::default();
+    let paths = unique_test_paths("command-palette-open-linked-pr");
+    let store = SnapshotStore::new(paths.db_path.clone());
+    app.command_palette = Some(CommandPalette {
+        query: "linked pr".to_string(),
+        selected: 0,
+    });
+
+    assert!(!handle_key_in_area_mut(
+        &mut app,
+        key(KeyCode::Enter),
+        &mut config,
+        &paths,
+        &store,
+        &tx,
+        None,
+    ));
+
+    assert_eq!(
+        app.status,
+        "opened https://github.com/chenyukang/ghr/pull/78"
+    );
+    assert!(app.command_palette.is_none());
+}
+
+#[test]
+fn command_palette_open_linked_pr_reports_missing_linked_pull_request() {
+    let mut item = work_item("issue-1", "chenyukang/ghr", 1, "Bug report", Some("alice"));
+    item.kind = ItemKind::Issue;
+    item.url = "https://github.com/chenyukang/ghr/issues/1".to_string();
+    let section = SectionSnapshot {
+        key: "issues:test".to_string(),
+        kind: SectionKind::Issues,
+        title: "Issues".to_string(),
+        filters: String::new(),
+        items: vec![item],
+        total_count: None,
+        page: 1,
+        page_size: 0,
+        refreshed_at: None,
+        error: None,
+    };
+    let mut app = AppState::new(SectionKind::Issues, vec![section]);
+    let (tx, _rx) = mpsc::unbounded_channel();
+    let mut config = Config::default();
+    let paths = unique_test_paths("command-palette-open-linked-pr-missing");
+    let store = SnapshotStore::new(paths.db_path.clone());
+    app.command_palette = Some(CommandPalette {
+        query: "linked pr".to_string(),
+        selected: 0,
+    });
+
+    assert!(!handle_key_in_area_mut(
+        &mut app,
+        key(KeyCode::Enter),
+        &mut config,
+        &paths,
+        &store,
+        &tx,
+        None,
+    ));
+
+    assert_eq!(app.status, "no linked pull request");
+    assert!(app.command_palette.is_none());
 }
 
 #[test]
@@ -9119,6 +9355,63 @@ fn comments_loaded_updates_details_milestone_metadata() {
 }
 
 #[test]
+fn comments_loaded_updates_issue_linked_pull_requests_metadata() {
+    let mut item = work_item("issue-1", "chenyukang/ghr", 1, "Bug report", Some("alice"));
+    item.kind = ItemKind::Issue;
+    item.url = "https://github.com/chenyukang/ghr/issues/1".to_string();
+    let section = SectionSnapshot {
+        key: "issues:test".to_string(),
+        kind: SectionKind::Issues,
+        title: "Issues".to_string(),
+        filters: String::new(),
+        items: vec![item],
+        total_count: None,
+        page: 1,
+        page_size: 0,
+        refreshed_at: None,
+        error: None,
+    };
+    let mut app = AppState::new(SectionKind::Issues, vec![section]);
+
+    app.handle_msg(AppMsg::CommentsLoaded {
+        item_id: "issue-1".to_string(),
+        comments: Ok(CommentFetchResult {
+            item_metadata: Some(ItemDetailsMetadata {
+                title: Some("Bug report".to_string()),
+                body: Some("Issue body".to_string()),
+                author: Some("alice".to_string()),
+                state: Some("open".to_string()),
+                url: Some("https://github.com/chenyukang/ghr/issues/1".to_string()),
+                created_at: None,
+                updated_at: None,
+                labels: Some(Vec::new()),
+                assignees: Some(Vec::new()),
+                comments: Some(0),
+                viewer_subscription: None,
+                linked_pull_requests: Some(vec![LinkedPullRequest {
+                    repository: "chenyukang/ghr".to_string(),
+                    number: 78,
+                    title: "Fix notification handling".to_string(),
+                    state: Some("merged".to_string()),
+                    url: "https://github.com/chenyukang/ghr/pull/78".to_string(),
+                }]),
+            }),
+            item_reactions: Some(ReactionSummary::default()),
+            item_milestone: Some(None),
+            comments: Vec::new(),
+        }),
+    });
+
+    let rendered = build_details_document(&app, 120)
+        .lines
+        .iter()
+        .map(|line| line.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(rendered.contains("linked PRs: #78 Fix notification handling merged"));
+}
+
+#[test]
 fn comments_loaded_preserves_item_reactions_and_milestone_when_details_are_unknown() {
     let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
     let cached_reactions = ReactionSummary {
@@ -9180,6 +9473,7 @@ fn comments_loaded_updates_inbox_notification_description_from_lazy_metadata() {
                 assignees: Some(vec!["alice".to_string()]),
                 comments: Some(3),
                 viewer_subscription: None,
+                linked_pull_requests: None,
             }),
             item_reactions: Some(ReactionSummary::default()),
             item_milestone: Some(None),
@@ -9371,6 +9665,62 @@ fn issue_details_meta_links_author() {
 
     assert_document_link_for_text(&document, "alice", "https://github.com/alice");
     assert_document_action_for_text_on_line(&document, "labels:", "+", DetailAction::AddLabel);
+}
+
+#[test]
+fn issue_details_shows_linked_pull_requests() {
+    let mut item = work_item("issue-1", "chenyukang/ghr", 1, "Bug report", Some("alice"));
+    item.kind = ItemKind::Issue;
+    item.url = "https://github.com/chenyukang/ghr/issues/1".to_string();
+    item.linked_pull_requests = vec![
+        LinkedPullRequest {
+            repository: "chenyukang/ghr".to_string(),
+            number: 78,
+            title: "Fix notification handling".to_string(),
+            state: Some("merged".to_string()),
+            url: "https://github.com/chenyukang/ghr/pull/78".to_string(),
+        },
+        LinkedPullRequest {
+            repository: "rust-lang/rust".to_string(),
+            number: 159309,
+            title: "Move tests batch 18".to_string(),
+            state: Some("open".to_string()),
+            url: "https://github.com/rust-lang/rust/pull/159309".to_string(),
+        },
+    ];
+    let section = SectionSnapshot {
+        key: "issues:test".to_string(),
+        kind: SectionKind::Issues,
+        title: "Issues".to_string(),
+        filters: String::new(),
+        items: vec![item],
+        total_count: None,
+        page: 1,
+        page_size: 0,
+        refreshed_at: None,
+        error: None,
+    };
+    let app = AppState::new(SectionKind::Issues, vec![section]);
+    let document = build_details_document(&app, 140);
+    let rendered = document
+        .lines
+        .iter()
+        .map(|line| line.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert!(rendered.contains("linked PRs: #78 Fix notification handling merged"));
+    assert!(rendered.contains("rust-lang/rust#159309 Move tests batch 18 open"));
+    assert_document_link_for_text(
+        &document,
+        "#78",
+        "https://github.com/chenyukang/ghr/pull/78",
+    );
+    assert_document_link_for_text(
+        &document,
+        "rust-lang/rust#159309",
+        "https://github.com/rust-lang/rust/pull/159309",
+    );
 }
 
 #[test]
@@ -15595,6 +15945,7 @@ fn item_edit_rejects_non_issue_or_pull_request_items() {
             reactions: ReactionSummary::default(),
             milestone: None,
             assignees: Vec::new(),
+            linked_pull_requests: Vec::new(),
             comments: None,
             unread: Some(true),
             reason: Some("mention".to_string()),
@@ -20935,6 +21286,7 @@ fn work_item(id: &str, repo: &str, number: u64, title: &str, author: Option<&str
         reactions: ReactionSummary::default(),
         milestone: None,
         assignees: Vec::new(),
+        linked_pull_requests: Vec::new(),
         comments: Some(0),
         unread: None,
         reason: None,
@@ -20984,6 +21336,7 @@ fn notification_item(id: &str, unread: bool) -> WorkItem {
         reactions: ReactionSummary::default(),
         milestone: None,
         assignees: Vec::new(),
+        linked_pull_requests: Vec::new(),
         comments: None,
         unread: Some(unread),
         reason: Some("mention".to_string()),

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -3275,7 +3275,7 @@ fn ui_state_restores_view_selection_focus_and_scroll() {
         expanded_comments: Vec::new(),
         details_scroll_by_item: HashMap::new(),
         selected_comment_index_by_item: HashMap::new(),
-        viewed_item_at: HashMap::new(),
+        seen_item_updated_at: HashMap::new(),
         selected_diff_file: HashMap::new(),
         selected_diff_line: HashMap::new(),
         diff_file_details_scroll: HashMap::new(),
@@ -3556,52 +3556,53 @@ fn section_switch_restores_conversation_details_position_for_current_item() {
 }
 
 #[test]
-fn viewed_item_at_marks_items_updated_after_last_view_unseen() {
+fn seen_item_updated_at_marks_newer_item_updates_unseen() {
     let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
-    let viewed_at = DateTime::from_timestamp(1_700_000_000, 0).unwrap();
-    let updated_before_view = DateTime::from_timestamp(1_699_999_999, 0).unwrap();
-    let updated_after_view = DateTime::from_timestamp(1_700_000_001, 0).unwrap();
-    app.sections[0].items[0].updated_at = Some(updated_before_view);
+    let seen_updated_at = DateTime::from_timestamp(1_700_000_000, 0).unwrap();
+    let newer_updated_at = DateTime::from_timestamp(1_700_000_001, 0).unwrap();
+    app.sections[0].items[0].updated_at = Some(seen_updated_at);
     let key = work_item_details_memory_key(app.current_item().expect("item"))
         .expect("details memory key");
 
     assert!(!app.item_has_unseen_details(app.current_item().expect("item")));
 
-    app.viewed_item_at.insert(key, viewed_at);
+    app.seen_item_updated_at.insert(key, seen_updated_at);
     assert!(!app.item_has_unseen_details(app.current_item().expect("item")));
 
-    app.sections[0].items[0].updated_at = Some(updated_after_view);
+    app.sections[0].items[0].updated_at = Some(newer_updated_at);
     assert!(app.item_has_unseen_details(app.current_item().expect("item")));
 }
 
 #[test]
-fn focusing_details_marks_current_item_viewed_by_time() {
+fn focusing_details_marks_current_item_updated_at_seen() {
     let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
     let updated_at = DateTime::from_timestamp(1_700_000_001, 0).unwrap();
-    let viewed_at = DateTime::from_timestamp(1_700_000_000, 0).unwrap();
+    let seen_updated_at = DateTime::from_timestamp(1_700_000_000, 0).unwrap();
     app.sections[0].items[0].updated_at = Some(updated_at);
     let key = work_item_details_memory_key(app.current_item().expect("item"))
         .expect("details memory key");
-    app.viewed_item_at.insert(key, viewed_at);
+    app.seen_item_updated_at
+        .insert(key.clone(), seen_updated_at);
     assert!(app.item_has_unseen_details(app.current_item().expect("item")));
 
     app.focus_details();
     assert!(!app.item_has_unseen_details(app.current_item().expect("item")));
+    assert_eq!(app.seen_item_updated_at.get(&key), Some(&updated_at));
 }
 
 #[test]
-fn focusing_details_refreshes_cached_comments_when_item_updated_after_view() {
+fn focusing_details_refreshes_cached_comments_when_item_updated_after_seen_version() {
     let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
-    let viewed_at = DateTime::from_timestamp(1_700_000_000, 0).unwrap();
-    let updated_after_view = DateTime::from_timestamp(1_700_000_001, 0).unwrap();
-    app.sections[0].items[0].updated_at = Some(updated_after_view);
+    let seen_updated_at = DateTime::from_timestamp(1_700_000_000, 0).unwrap();
+    let newer_updated_at = DateTime::from_timestamp(1_700_000_001, 0).unwrap();
+    app.sections[0].items[0].updated_at = Some(newer_updated_at);
     app.details.insert(
         "1".to_string(),
         DetailState::Loaded(vec![comment("alice", "cached before update", None)]),
     );
     let key = work_item_details_memory_key(app.current_item().expect("item"))
         .expect("details memory key");
-    app.viewed_item_at.insert(key, viewed_at);
+    app.seen_item_updated_at.insert(key, seen_updated_at);
 
     app.focus_details();
 
@@ -3613,12 +3614,12 @@ fn focusing_details_refreshes_cached_comments_when_item_updated_after_view() {
 #[test]
 fn comments_loaded_records_item_updated_at_for_cache_freshness() {
     let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
-    let viewed_at = DateTime::from_timestamp(1_700_000_000, 0).unwrap();
-    let updated_after_view = DateTime::from_timestamp(1_700_000_001, 0).unwrap();
-    app.sections[0].items[0].updated_at = Some(updated_after_view);
+    let seen_updated_at = DateTime::from_timestamp(1_700_000_000, 0).unwrap();
+    let newer_updated_at = DateTime::from_timestamp(1_700_000_001, 0).unwrap();
+    app.sections[0].items[0].updated_at = Some(newer_updated_at);
     let key = work_item_details_memory_key(app.current_item().expect("item"))
         .expect("details memory key");
-    app.viewed_item_at.insert(key, viewed_at);
+    app.seen_item_updated_at.insert(key, seen_updated_at);
 
     app.handle_msg(AppMsg::CommentsLoaded {
         item_id: "1".to_string(),
@@ -3630,7 +3631,7 @@ fn comments_loaded_records_item_updated_at_for_cache_freshness() {
                 state: None,
                 url: None,
                 created_at: None,
-                updated_at: Some(updated_after_view),
+                updated_at: Some(newer_updated_at),
                 labels: None,
                 assignees: None,
                 comments: Some(1),
@@ -3710,13 +3711,12 @@ fn comments_loaded_uses_notification_updated_at_when_it_is_newer_than_linked_ite
 #[test]
 fn comment_metadata_updated_at_marks_unseen_when_not_focused() {
     let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
-    let updated_before_view = DateTime::from_timestamp(1_699_999_999, 0).unwrap();
-    let viewed_at = DateTime::from_timestamp(1_700_000_000, 0).unwrap();
-    let updated_after_view = DateTime::from_timestamp(1_700_000_001, 0).unwrap();
-    app.sections[0].items[0].updated_at = Some(updated_before_view);
+    let seen_updated_at = DateTime::from_timestamp(1_700_000_000, 0).unwrap();
+    let newer_updated_at = DateTime::from_timestamp(1_700_000_001, 0).unwrap();
+    app.sections[0].items[0].updated_at = Some(seen_updated_at);
     let key = work_item_details_memory_key(app.current_item().expect("item"))
         .expect("details memory key");
-    app.viewed_item_at.insert(key, viewed_at);
+    app.seen_item_updated_at.insert(key, seen_updated_at);
     assert!(!app.item_has_unseen_details(app.current_item().expect("item")));
 
     app.handle_msg(AppMsg::CommentsLoaded {
@@ -3729,7 +3729,7 @@ fn comment_metadata_updated_at_marks_unseen_when_not_focused() {
                 state: None,
                 url: None,
                 created_at: None,
-                updated_at: Some(updated_after_view),
+                updated_at: Some(newer_updated_at),
                 labels: None,
                 assignees: None,
                 comments: Some(3),

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,6 +14,15 @@ pub const DEFAULT_EDITOR_SUBMIT_KEY: &str = "Ctrl+O";
 pub const DEFAULT_LOG_LEVEL: &str = "info";
 pub const DEFAULT_REPO_REMOTE: &str = "origin";
 
+const DEFAULT_NEEDS_ATTENTION_QUERIES: [&str; 3] = [
+    "is:open review-requested:@me archived:false sort:created-desc",
+    "is:open assignee:@me archived:false sort:created-desc",
+    "is:open mentions:@me archived:false sort:created-desc",
+];
+const DEFAULT_MY_PULL_REQUESTS_FILTER: &str = "is:open author:@me archived:false sort:created-desc";
+const DEFAULT_REVIEWED_FILTER: &str =
+    "is:open reviewed-by:@me -author:@me archived:false sort:created-desc";
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct Config {
@@ -334,6 +343,10 @@ impl Config {
     }
 }
 
+fn strings(values: &[&str]) -> Vec<String> {
+    values.iter().map(|value| (*value).to_string()).collect()
+}
+
 fn current_github_repo_in(directory: &Path) -> Option<GitHubRemoteCandidate> {
     current_github_remote_candidates(directory)
         .into_iter()
@@ -495,23 +508,18 @@ impl Default for Config {
                 SearchSection {
                     title: "Needs Attention".to_string(),
                     filters: String::new(),
-                    queries: vec![
-                        "is:open review-requested:@me archived:false sort:updated-desc".to_string(),
-                        "is:open assignee:@me archived:false sort:updated-desc".to_string(),
-                        "is:open mentions:@me archived:false sort:updated-desc".to_string(),
-                    ],
+                    queries: strings(&DEFAULT_NEEDS_ATTENTION_QUERIES),
                     limit: None,
                 },
                 SearchSection {
                     title: "My Pull Requests".to_string(),
-                    filters: "is:open author:@me archived:false sort:updated-desc".to_string(),
+                    filters: DEFAULT_MY_PULL_REQUESTS_FILTER.to_string(),
                     queries: Vec::new(),
                     limit: None,
                 },
                 SearchSection {
                     title: "Reviewed".to_string(),
-                    filters: "is:open reviewed-by:@me -author:@me archived:false sort:updated-desc"
-                        .to_string(),
+                    filters: DEFAULT_REVIEWED_FILTER.to_string(),
                     queries: Vec::new(),
                     limit: None,
                 },
@@ -1038,7 +1046,7 @@ mod tests {
             config.pr_sections[0]
                 .queries
                 .iter()
-                .all(|query| query.contains("is:open") && query.contains("sort:updated-desc"))
+                .all(|query| query.contains("is:open") && query.contains("sort:created-desc"))
         );
         assert!(
             config.pr_sections[0]
@@ -1048,11 +1056,11 @@ mod tests {
         );
         assert_eq!(
             config.pr_sections[1].filters,
-            "is:open author:@me archived:false sort:updated-desc"
+            "is:open author:@me archived:false sort:created-desc"
         );
         assert_eq!(
             config.pr_sections[2].filters,
-            "is:open reviewed-by:@me -author:@me archived:false sort:updated-desc"
+            "is:open reviewed-by:@me -author:@me archived:false sort:created-desc"
         );
     }
 

--- a/src/github.rs
+++ b/src/github.rs
@@ -15,10 +15,11 @@ use tracing::{debug, error, info, warn};
 use crate::config::{Config, SearchSection, github_repo_from_remote_url};
 use crate::model::{
     ActionHints, CheckRunSummary, CheckSummary, CommentPreview, CommentPreviewKind,
-    FailedCheckRunSummary, ItemKind, MergeQueueInfo, Milestone, PullRequestBranch,
-    PullRequestReviewActor, PullRequestReviewActorState, PullRequestReviewSummary, ReactionSummary,
-    ReviewCommentPreview, SectionKind, SectionSnapshot, WorkItem, builtin_view_key,
-    global_search_view_key, repo_section_filters_with_labels, repo_view_key,
+    FailedCheckRunSummary, ItemKind, LinkedPullRequest, MergeQueueInfo, Milestone,
+    PullRequestBranch, PullRequestReviewActor, PullRequestReviewActorState,
+    PullRequestReviewSummary, ReactionSummary, ReviewCommentPreview, SectionKind, SectionSnapshot,
+    WorkItem, builtin_view_key, global_search_view_key, repo_section_filters_with_labels,
+    repo_view_key,
 };
 
 static VIEWER_LOGIN: OnceCell<String> = OnceCell::const_new();
@@ -80,6 +81,7 @@ pub struct ItemDetailsMetadata {
     pub assignees: Option<Vec<String>>,
     pub comments: Option<u64>,
     pub viewer_subscription: Option<String>,
+    pub linked_pull_requests: Option<Vec<LinkedPullRequest>>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -205,6 +207,54 @@ struct IssueDetails {
     item_metadata: Option<ItemDetailsMetadata>,
     reactions: ReactionSummary,
     milestone: Option<Milestone>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct IssueLinkedPullRequestsGraphQlRaw {
+    data: IssueLinkedPullRequestsDataRaw,
+}
+
+#[derive(Debug, Deserialize)]
+struct IssueLinkedPullRequestsDataRaw {
+    repository: Option<IssueLinkedPullRequestsRepositoryRaw>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct IssueLinkedPullRequestsRepositoryRaw {
+    issue: Option<IssueLinkedPullRequestsIssueRaw>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct IssueLinkedPullRequestsIssueRaw {
+    closed_by_pull_requests_references: IssueLinkedPullRequestConnectionRaw,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct IssueLinkedPullRequestConnectionRaw {
+    nodes: Option<Vec<IssueLinkedPullRequestRaw>>,
+    page_info: GraphQlPageInfoRaw,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct IssueLinkedPullRequestRaw {
+    repository: Option<IssueLinkedPullRequestRepositoryRaw>,
+    number: u64,
+    title: String,
+    state: Option<String>,
+    is_draft: Option<bool>,
+    merged: Option<bool>,
+    url: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct IssueLinkedPullRequestRepositoryRaw {
+    name_with_owner: String,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -1607,13 +1657,22 @@ pub async fn fetch_comments(
 
 pub async fn fetch_issue_comments(repository: &str, number: u64) -> Result<CommentFetchResult> {
     let issue_output = fetch_issue_details_output(repository, number);
+    let linked_pull_requests = fetch_issue_linked_pull_requests(repository, number);
     let comments_output = fetch_issue_comments_output(repository, number);
     let comment_permissions = fetch_issue_comment_permissions(repository, number, ItemKind::Issue);
     let viewer_login = comment_viewer_login("comment ownership");
     let viewer_subscription =
         fetch_item_subscription_state_optional(repository, number, ItemKind::Issue);
-    let (issue_output, comments_output, comment_permissions, viewer_login, viewer_subscription) = tokio::join!(
+    let (
         issue_output,
+        linked_pull_requests,
+        comments_output,
+        comment_permissions,
+        viewer_login,
+        viewer_subscription,
+    ) = tokio::join!(
+        issue_output,
+        linked_pull_requests,
         comments_output,
         comment_permissions,
         viewer_login,
@@ -1631,7 +1690,7 @@ pub async fn fetch_issue_comments(repository: &str, number: u64) -> Result<Comme
             HashMap::new()
         }
     };
-    let mut issue_details = match issue_output {
+    let issue_details = match issue_output {
         Ok(output) => Some(parse_issue_details_output(&output, repository, number)?),
         Err(error) => {
             warn!(
@@ -1643,13 +1702,19 @@ pub async fn fetch_issue_comments(repository: &str, number: u64) -> Result<Comme
             None
         }
     };
-    if let Some(metadata) = issue_details
-        .as_mut()
-        .and_then(|details| details.item_metadata.as_mut())
-    {
-        metadata.viewer_subscription = viewer_subscription;
-    }
-    let (item_metadata, item_reactions, item_milestone) = match issue_details {
+    let linked_pull_requests = match linked_pull_requests {
+        Ok(linked_pull_requests) => Some(linked_pull_requests),
+        Err(error) => {
+            warn!(
+                error = %error,
+                repository,
+                number,
+                "failed to load linked pull requests while loading issue comments"
+            );
+            None
+        }
+    };
+    let (mut item_metadata, item_reactions, item_milestone) = match issue_details {
         Some(details) => (
             details.item_metadata,
             Some(details.reactions),
@@ -1657,6 +1722,14 @@ pub async fn fetch_issue_comments(repository: &str, number: u64) -> Result<Comme
         ),
         None => (None, None, None),
     };
+    if let Some(linked_pull_requests) = linked_pull_requests
+        && let Some(metadata) = item_metadata.as_mut()
+    {
+        metadata.linked_pull_requests = Some(linked_pull_requests);
+    }
+    if let Some(metadata) = item_metadata.as_mut() {
+        metadata.viewer_subscription = viewer_subscription;
+    }
     Ok(CommentFetchResult {
         item_metadata,
         item_reactions,
@@ -1680,6 +1753,73 @@ async fn fetch_issue_details_output(repository: &str, number: u64) -> Result<Str
         path,
     ])
     .await
+}
+
+async fn fetch_issue_linked_pull_requests(
+    repository: &str,
+    number: u64,
+) -> Result<Vec<LinkedPullRequest>> {
+    let (owner, name) = split_repository(repository)?;
+    let query = r#"
+query($owner: String!, $name: String!, $number: Int!, $cursor: String) {
+  repository(owner: $owner, name: $name) {
+    issue(number: $number) {
+      closedByPullRequestsReferences(first: 100, after: $cursor) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        nodes {
+          repository {
+            nameWithOwner
+          }
+          number
+          title
+          state
+          isDraft
+          merged
+          url
+        }
+      }
+    }
+  }
+}
+"#;
+    let mut cursor = None;
+    let mut pull_requests = Vec::new();
+
+    loop {
+        let mut args = vec![
+            "api".to_string(),
+            "graphql".to_string(),
+            "-f".to_string(),
+            format!("query={query}"),
+            "-F".to_string(),
+            format!("owner={owner}"),
+            "-F".to_string(),
+            format!("name={name}"),
+            "-F".to_string(),
+            format!("number={number}"),
+        ];
+        if let Some(cursor) = &cursor {
+            args.push("-F".to_string());
+            args.push(format!("cursor={cursor}"));
+        }
+
+        let output = run_gh_json(&args).await?;
+        let (mut page, has_next_page, end_cursor) =
+            parse_issue_linked_pull_requests_page(&output, repository, number)?;
+        pull_requests.append(&mut page);
+        if !has_next_page {
+            break;
+        }
+        let Some(next_cursor) = end_cursor else {
+            break;
+        };
+        cursor = Some(next_cursor);
+    }
+
+    Ok(pull_requests)
 }
 
 async fn fetch_issue_comments_output(repository: &str, number: u64) -> Result<String> {
@@ -3679,6 +3819,60 @@ fn parse_issue_details_output(output: &str, repository: &str, number: u64) -> Re
     })
 }
 
+fn parse_issue_linked_pull_requests_page(
+    output: &str,
+    repository: &str,
+    number: u64,
+) -> Result<(Vec<LinkedPullRequest>, bool, Option<String>)> {
+    let raw =
+        serde_json::from_str::<IssueLinkedPullRequestsGraphQlRaw>(output).with_context(|| {
+            format!("failed to parse linked pull requests for {repository}#{number}")
+        })?;
+    let Some(issue) = raw.data.repository.and_then(|repository| repository.issue) else {
+        return Ok((Vec::new(), false, None));
+    };
+    let connection = issue.closed_by_pull_requests_references;
+    let pull_requests = connection
+        .nodes
+        .unwrap_or_default()
+        .into_iter()
+        .map(linked_pull_request_from_raw)
+        .collect::<Vec<_>>();
+
+    Ok((
+        pull_requests,
+        connection.page_info.has_next_page,
+        connection.page_info.end_cursor,
+    ))
+}
+
+fn linked_pull_request_from_raw(raw: IssueLinkedPullRequestRaw) -> LinkedPullRequest {
+    LinkedPullRequest {
+        repository: raw
+            .repository
+            .map(|repository| repository.name_with_owner)
+            .unwrap_or_default(),
+        number: raw.number,
+        title: raw.title,
+        state: linked_pull_request_state(raw.state, raw.is_draft, raw.merged),
+        url: raw.url,
+    }
+}
+
+fn linked_pull_request_state(
+    state: Option<String>,
+    is_draft: Option<bool>,
+    merged: Option<bool>,
+) -> Option<String> {
+    if is_draft == Some(true) {
+        return Some("draft".to_string());
+    }
+    if merged == Some(true) {
+        return Some("merged".to_string());
+    }
+    state.map(|state| state.to_ascii_lowercase())
+}
+
 impl IssueDetailsRaw {
     fn item_metadata(&mut self) -> Option<ItemDetailsMetadata> {
         let has_metadata = self.title.is_some()
@@ -3717,6 +3911,7 @@ impl IssueDetailsRaw {
             }),
             comments: self.comments,
             viewer_subscription: None,
+            linked_pull_requests: None,
         })
     }
 }
@@ -5137,6 +5332,7 @@ fn search_api_item_to_work_item(kind: SectionKind, item: SearchApiIssueRaw) -> W
             title: milestone.title,
         }),
         assignees,
+        linked_pull_requests: Vec::new(),
         comments: item.comments,
         unread: None,
         reason: None,
@@ -5255,6 +5451,7 @@ fn issue_api_item_to_work_item(kind: ItemKind, item: IssueItemRaw) -> WorkItem {
         reactions: ReactionSummary::default(),
         milestone: None,
         assignees,
+        linked_pull_requests: Vec::new(),
         comments: item.comments,
         unread: None,
         reason: None,
@@ -5370,6 +5567,7 @@ fn notification_to_work_item(notification: &NotificationRaw) -> WorkItem {
         reactions: ReactionSummary::default(),
         milestone: None,
         assignees: Vec::new(),
+        linked_pull_requests: Vec::new(),
         comments: None,
         unread: Some(notification.unread),
         reason: Some(normalize_reason_for_display(&notification.reason)),
@@ -6281,6 +6479,56 @@ mod tests {
             parse_issue_comments_output(output, "owner/repo", 1, None, &HashMap::new()).unwrap();
         assert_eq!(comments[0].reactions.plus_one, 2);
         assert_eq!(comments[0].reactions.rocket, 1);
+    }
+
+    #[test]
+    fn issue_linked_pull_requests_parse_graphql_page() {
+        let output = r#"{
+          "data": {
+            "repository": {
+              "issue": {
+                "closedByPullRequestsReferences": {
+                  "pageInfo": {
+                    "hasNextPage": true,
+                    "endCursor": "cursor-2"
+                  },
+                  "nodes": [
+                    {
+                      "repository": { "nameWithOwner": "owner/repo" },
+                      "number": 7,
+                      "title": "Fix linked issue",
+                      "state": "OPEN",
+                      "isDraft": false,
+                      "merged": false,
+                      "url": "https://github.com/owner/repo/pull/7"
+                    },
+                    {
+                      "repository": { "nameWithOwner": "owner/repo" },
+                      "number": 8,
+                      "title": "Close linked issue",
+                      "state": "CLOSED",
+                      "isDraft": false,
+                      "merged": true,
+                      "url": "https://github.com/owner/repo/pull/8"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }"#;
+
+        let (pull_requests, has_next_page, end_cursor) =
+            parse_issue_linked_pull_requests_page(output, "owner/repo", 1).unwrap();
+
+        assert!(has_next_page);
+        assert_eq!(end_cursor.as_deref(), Some("cursor-2"));
+        assert_eq!(pull_requests.len(), 2);
+        assert_eq!(pull_requests[0].repository, "owner/repo");
+        assert_eq!(pull_requests[0].number, 7);
+        assert_eq!(pull_requests[0].title, "Fix linked issue");
+        assert_eq!(pull_requests[0].state.as_deref(), Some("open"));
+        assert_eq!(pull_requests[1].state.as_deref(), Some("merged"));
     }
 
     #[test]

--- a/src/github.rs
+++ b/src/github.rs
@@ -15,7 +15,7 @@ use tracing::{debug, error, info, warn};
 use crate::config::{Config, SearchSection, github_repo_from_remote_url};
 use crate::model::{
     ActionHints, CheckRunSummary, CheckSummary, CommentPreview, CommentPreviewKind,
-    FailedCheckRunSummary, ItemKind, LinkedPullRequest, MergeQueueInfo, Milestone,
+    FailedCheckRunSummary, ItemKind, LinkedIssue, LinkedPullRequest, MergeQueueInfo, Milestone,
     PullRequestBranch, PullRequestReviewActor, PullRequestReviewActorState,
     PullRequestReviewSummary, ReactionSummary, ReviewCommentPreview, SectionKind, SectionSnapshot,
     WorkItem, builtin_view_key, global_search_view_key, repo_section_filters_with_labels,
@@ -82,6 +82,7 @@ pub struct ItemDetailsMetadata {
     pub comments: Option<u64>,
     pub viewer_subscription: Option<String>,
     pub linked_pull_requests: Option<Vec<LinkedPullRequest>>,
+    pub linked_issues: Option<Vec<LinkedIssue>>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -254,6 +255,52 @@ struct IssueLinkedPullRequestRaw {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct IssueLinkedPullRequestRepositoryRaw {
+    name_with_owner: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PullRequestLinkedIssuesGraphQlRaw {
+    data: PullRequestLinkedIssuesDataRaw,
+}
+
+#[derive(Debug, Deserialize)]
+struct PullRequestLinkedIssuesDataRaw {
+    repository: Option<PullRequestLinkedIssuesRepositoryRaw>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PullRequestLinkedIssuesRepositoryRaw {
+    pull_request: Option<PullRequestLinkedIssuesPullRequestRaw>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PullRequestLinkedIssuesPullRequestRaw {
+    closing_issues_references: PullRequestLinkedIssueConnectionRaw,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PullRequestLinkedIssueConnectionRaw {
+    nodes: Option<Vec<PullRequestLinkedIssueRaw>>,
+    page_info: GraphQlPageInfoRaw,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PullRequestLinkedIssueRaw {
+    repository: Option<PullRequestLinkedIssueRepositoryRaw>,
+    number: u64,
+    title: String,
+    state: Option<String>,
+    url: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PullRequestLinkedIssueRepositoryRaw {
     name_with_owner: String,
 }
 
@@ -1822,6 +1869,71 @@ query($owner: String!, $name: String!, $number: Int!, $cursor: String) {
     Ok(pull_requests)
 }
 
+async fn fetch_pull_request_linked_issues(
+    repository: &str,
+    number: u64,
+) -> Result<Vec<LinkedIssue>> {
+    let (owner, name) = split_repository(repository)?;
+    let query = r#"
+query($owner: String!, $name: String!, $number: Int!, $cursor: String) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      closingIssuesReferences(first: 100, after: $cursor) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        nodes {
+          repository {
+            nameWithOwner
+          }
+          number
+          title
+          state
+          url
+        }
+      }
+    }
+  }
+}
+"#;
+    let mut cursor = None;
+    let mut issues = Vec::new();
+
+    loop {
+        let mut args = vec![
+            "api".to_string(),
+            "graphql".to_string(),
+            "-f".to_string(),
+            format!("query={query}"),
+            "-F".to_string(),
+            format!("owner={owner}"),
+            "-F".to_string(),
+            format!("name={name}"),
+            "-F".to_string(),
+            format!("number={number}"),
+        ];
+        if let Some(cursor) = &cursor {
+            args.push("-F".to_string());
+            args.push(format!("cursor={cursor}"));
+        }
+
+        let output = run_gh_json(&args).await?;
+        let (mut page, has_next_page, end_cursor) =
+            parse_pull_request_linked_issues_page(&output, repository, number)?;
+        issues.append(&mut page);
+        if !has_next_page {
+            break;
+        }
+        let Some(next_cursor) = end_cursor else {
+            break;
+        };
+        cursor = Some(next_cursor);
+    }
+
+    Ok(issues)
+}
+
 async fn fetch_issue_comments_output(repository: &str, number: u64) -> Result<String> {
     let path = format!("repos/{repository}/issues/{number}/comments?per_page=100");
     fetch_paginated_api_array_output(
@@ -1904,6 +2016,7 @@ pub async fn fetch_pull_request_comments(
     number: u64,
 ) -> Result<CommentFetchResult> {
     let issue_details = fetch_issue_details_output(repository, number);
+    let linked_issues = fetch_pull_request_linked_issues(repository, number);
     let issue_comments = fetch_issue_comments_output(repository, number);
     let issue_comment_permissions =
         fetch_issue_comment_permissions(repository, number, ItemKind::PullRequest);
@@ -1915,6 +2028,7 @@ pub async fn fetch_pull_request_comments(
         fetch_item_subscription_state_optional(repository, number, ItemKind::PullRequest);
     let (
         issue_details,
+        linked_issues,
         issue_output,
         issue_comment_permissions,
         review_output,
@@ -1924,6 +2038,7 @@ pub async fn fetch_pull_request_comments(
         viewer_subscription,
     ) = tokio::join!(
         issue_details,
+        linked_issues,
         issue_comments,
         issue_comment_permissions,
         review_comments,
@@ -1965,6 +2080,18 @@ pub async fn fetch_pull_request_comments(
                 repository,
                 number,
                 "failed to load pull request details while loading comments"
+            );
+            None
+        }
+    };
+    let linked_issues = match linked_issues {
+        Ok(linked_issues) => Some(linked_issues),
+        Err(error) => {
+            warn!(
+                error = %error,
+                repository,
+                number,
+                "failed to load linked issues while loading pull request comments"
             );
             None
         }
@@ -2020,6 +2147,9 @@ pub async fn fetch_pull_request_comments(
         .and_then(|details| details.item_metadata.as_mut())
     {
         metadata.viewer_subscription = viewer_subscription;
+        if let Some(linked_issues) = linked_issues {
+            metadata.linked_issues = Some(linked_issues);
+        }
     }
     let (item_metadata, item_reactions, item_milestone) = match issue_details {
         Some(details) => (
@@ -3873,6 +4003,48 @@ fn linked_pull_request_state(
     state.map(|state| state.to_ascii_lowercase())
 }
 
+fn parse_pull_request_linked_issues_page(
+    output: &str,
+    repository: &str,
+    number: u64,
+) -> Result<(Vec<LinkedIssue>, bool, Option<String>)> {
+    let raw = serde_json::from_str::<PullRequestLinkedIssuesGraphQlRaw>(output)
+        .with_context(|| format!("failed to parse linked issues for {repository}#{number}"))?;
+    let Some(pull_request) = raw
+        .data
+        .repository
+        .and_then(|repository| repository.pull_request)
+    else {
+        return Ok((Vec::new(), false, None));
+    };
+    let connection = pull_request.closing_issues_references;
+    let issues = connection
+        .nodes
+        .unwrap_or_default()
+        .into_iter()
+        .map(linked_issue_from_raw)
+        .collect::<Vec<_>>();
+
+    Ok((
+        issues,
+        connection.page_info.has_next_page,
+        connection.page_info.end_cursor,
+    ))
+}
+
+fn linked_issue_from_raw(raw: PullRequestLinkedIssueRaw) -> LinkedIssue {
+    LinkedIssue {
+        repository: raw
+            .repository
+            .map(|repository| repository.name_with_owner)
+            .unwrap_or_default(),
+        number: raw.number,
+        title: raw.title,
+        state: raw.state.map(|state| state.to_ascii_lowercase()),
+        url: raw.url,
+    }
+}
+
 impl IssueDetailsRaw {
     fn item_metadata(&mut self) -> Option<ItemDetailsMetadata> {
         let has_metadata = self.title.is_some()
@@ -3912,6 +4084,7 @@ impl IssueDetailsRaw {
             comments: self.comments,
             viewer_subscription: None,
             linked_pull_requests: None,
+            linked_issues: None,
         })
     }
 }
@@ -5333,6 +5506,7 @@ fn search_api_item_to_work_item(kind: SectionKind, item: SearchApiIssueRaw) -> W
         }),
         assignees,
         linked_pull_requests: Vec::new(),
+        linked_issues: Vec::new(),
         comments: item.comments,
         unread: None,
         reason: None,
@@ -5452,6 +5626,7 @@ fn issue_api_item_to_work_item(kind: ItemKind, item: IssueItemRaw) -> WorkItem {
         milestone: None,
         assignees,
         linked_pull_requests: Vec::new(),
+        linked_issues: Vec::new(),
         comments: item.comments,
         unread: None,
         reason: None,
@@ -5568,6 +5743,7 @@ fn notification_to_work_item(notification: &NotificationRaw) -> WorkItem {
         milestone: None,
         assignees: Vec::new(),
         linked_pull_requests: Vec::new(),
+        linked_issues: Vec::new(),
         comments: None,
         unread: Some(notification.unread),
         reason: Some(normalize_reason_for_display(&notification.reason)),
@@ -6529,6 +6705,53 @@ mod tests {
         assert_eq!(pull_requests[0].title, "Fix linked issue");
         assert_eq!(pull_requests[0].state.as_deref(), Some("open"));
         assert_eq!(pull_requests[1].state.as_deref(), Some("merged"));
+    }
+
+    #[test]
+    fn pull_request_linked_issues_parse_graphql_page() {
+        let output = r#"{
+          "data": {
+            "repository": {
+              "pullRequest": {
+                "closingIssuesReferences": {
+                  "pageInfo": {
+                    "hasNextPage": true,
+                    "endCursor": "cursor-2"
+                  },
+                  "nodes": [
+                    {
+                      "repository": { "nameWithOwner": "owner/repo" },
+                      "number": 77,
+                      "title": "Notifications reappear in inbox",
+                      "state": "OPEN",
+                      "url": "https://github.com/owner/repo/issues/77"
+                    },
+                    {
+                      "repository": { "nameWithOwner": "other/repo" },
+                      "number": 91,
+                      "title": "Another linked issue",
+                      "state": "CLOSED",
+                      "url": "https://github.com/other/repo/issues/91"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }"#;
+
+        let (issues, has_next_page, end_cursor) =
+            parse_pull_request_linked_issues_page(output, "owner/repo", 78).unwrap();
+
+        assert!(has_next_page);
+        assert_eq!(end_cursor.as_deref(), Some("cursor-2"));
+        assert_eq!(issues.len(), 2);
+        assert_eq!(issues[0].repository, "owner/repo");
+        assert_eq!(issues[0].number, 77);
+        assert_eq!(issues[0].title, "Notifications reappear in inbox");
+        assert_eq!(issues[0].state.as_deref(), Some("open"));
+        assert_eq!(issues[1].repository, "other/repo");
+        assert_eq!(issues[1].state.as_deref(), Some("closed"));
     }
 
     #[test]

--- a/src/github.rs
+++ b/src/github.rs
@@ -4744,10 +4744,7 @@ async fn run_gh_json_raw_once(args: &[String]) -> Result<String> {
         bail!("GitHub backend expected a `gh api` request");
     }
     match crate::github_api::selected_backend() {
-        crate::github_api::GitHubBackend::DirectApi => {
-            let request = crate::github_api::parse_api_args(args)?;
-            crate::github_api::run_direct_request(&request).await
-        }
+        crate::github_api::GitHubBackend::DirectApi => crate::github_api::run_api(args).await,
         crate::github_api::GitHubBackend::GitHubCli => crate::github_gh::run_api(args).await,
     }
 }

--- a/src/github.rs
+++ b/src/github.rs
@@ -1365,6 +1365,7 @@ async fn fetch_search_items(
         return fetch_search_page(kind, query, page, limit, exclude_repos).await;
     }
 
+    let sort = merged_search_items_sort(&queries);
     let mut deduped = HashMap::<String, WorkItem>::new();
     for (index, query) in queries.into_iter().enumerate() {
         if index > 0 {
@@ -1381,13 +1382,7 @@ async fn fetch_search_items(
     }
 
     let mut items = deduped.into_values().collect::<Vec<_>>();
-    items.sort_by(|left, right| {
-        right
-            .updated_at
-            .cmp(&left.updated_at)
-            .then_with(|| left.repo.cmp(&right.repo))
-            .then_with(|| left.number.cmp(&right.number))
-    });
+    sort_merged_search_items(&mut items, sort);
     items.truncate(limit);
     Ok(SearchFetchResult {
         items,
@@ -1395,6 +1390,48 @@ async fn fetch_search_items(
         page: 1,
         page_size: search_command_limit(limit),
     })
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SearchItemsSort {
+    CreatedAsc,
+    CreatedDesc,
+    UpdatedAsc,
+    UpdatedDesc,
+}
+
+impl SearchItemsSort {
+    fn from_filters(filters: &str) -> Option<Self> {
+        let (field, order) = search_sort(filters)?;
+        match (field.as_str(), order.as_str()) {
+            ("created" | "created_at", "asc") => Some(Self::CreatedAsc),
+            ("created" | "created_at", "desc") => Some(Self::CreatedDesc),
+            ("updated" | "updated_at", "asc") => Some(Self::UpdatedAsc),
+            ("updated" | "updated_at", "desc") => Some(Self::UpdatedDesc),
+            _ => None,
+        }
+    }
+}
+
+fn merged_search_items_sort(queries: &[String]) -> SearchItemsSort {
+    queries
+        .iter()
+        .find_map(|query| SearchItemsSort::from_filters(query))
+        .unwrap_or(SearchItemsSort::UpdatedDesc)
+}
+
+fn sort_merged_search_items(items: &mut [WorkItem], sort: SearchItemsSort) {
+    items.sort_by(|left, right| {
+        let timestamp_order = match sort {
+            SearchItemsSort::CreatedAsc => left.created_at.cmp(&right.created_at),
+            SearchItemsSort::CreatedDesc => right.created_at.cmp(&left.created_at),
+            SearchItemsSort::UpdatedAsc => left.updated_at.cmp(&right.updated_at),
+            SearchItemsSort::UpdatedDesc => right.updated_at.cmp(&left.updated_at),
+        };
+        timestamp_order
+            .then_with(|| left.repo.cmp(&right.repo))
+            .then_with(|| left.number.cmp(&right.number))
+    });
 }
 
 async fn fetch_search_items_for_query(
@@ -6298,6 +6335,113 @@ mod tests {
             search_kind_filter("repo:rust-lang/rust type:issue"),
             SearchKindFilter::Issues
         );
+    }
+
+    #[test]
+    fn merged_search_items_sort_uses_configured_created_order() {
+        let mut items = vec![
+            search_sort_work_item(
+                "updated-newer",
+                1,
+                "2026-01-01T00:00:00Z",
+                "2026-01-05T00:00:00Z",
+            ),
+            search_sort_work_item(
+                "created-newer",
+                2,
+                "2026-01-03T00:00:00Z",
+                "2026-01-03T00:00:00Z",
+            ),
+            search_sort_work_item("middle", 3, "2026-01-02T00:00:00Z", "2026-01-04T00:00:00Z"),
+        ];
+        let queries = vec![
+            "is:open review-requested:@me archived:false sort:created-desc".to_string(),
+            "is:open assignee:@me archived:false sort:created-desc".to_string(),
+        ];
+
+        sort_merged_search_items(&mut items, merged_search_items_sort(&queries));
+
+        assert_eq!(
+            items
+                .iter()
+                .map(|item| item.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["created-newer", "middle", "updated-newer"]
+        );
+    }
+
+    #[test]
+    fn merged_search_items_sort_preserves_configured_updated_order() {
+        let mut items = vec![
+            search_sort_work_item(
+                "updated-newer",
+                1,
+                "2026-01-01T00:00:00Z",
+                "2026-01-05T00:00:00Z",
+            ),
+            search_sort_work_item(
+                "created-newer",
+                2,
+                "2026-01-03T00:00:00Z",
+                "2026-01-03T00:00:00Z",
+            ),
+            search_sort_work_item("middle", 3, "2026-01-02T00:00:00Z", "2026-01-04T00:00:00Z"),
+        ];
+        let queries = vec![
+            "is:open review-requested:@me archived:false sort:updated-desc".to_string(),
+            "is:open assignee:@me archived:false sort:updated-desc".to_string(),
+        ];
+
+        sort_merged_search_items(&mut items, merged_search_items_sort(&queries));
+
+        assert_eq!(
+            items
+                .iter()
+                .map(|item| item.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["updated-newer", "middle", "created-newer"]
+        );
+    }
+
+    fn search_sort_work_item(
+        id: &str,
+        number: u64,
+        created_at: &str,
+        updated_at: &str,
+    ) -> WorkItem {
+        WorkItem {
+            id: id.to_string(),
+            kind: ItemKind::PullRequest,
+            repo: "owner/repo".to_string(),
+            number: Some(number),
+            title: id.to_string(),
+            body: None,
+            author: None,
+            state: Some("open".to_string()),
+            url: format!("https://github.com/owner/repo/pull/{number}"),
+            created_at: Some(
+                DateTime::parse_from_rfc3339(created_at)
+                    .unwrap()
+                    .with_timezone(&Utc),
+            ),
+            updated_at: Some(
+                DateTime::parse_from_rfc3339(updated_at)
+                    .unwrap()
+                    .with_timezone(&Utc),
+            ),
+            last_read_at: None,
+            labels: Vec::new(),
+            reactions: ReactionSummary::default(),
+            milestone: None,
+            assignees: Vec::new(),
+            linked_pull_requests: Vec::new(),
+            linked_issues: Vec::new(),
+            comments: None,
+            unread: None,
+            reason: None,
+            extra: None,
+            viewer_subscription: None,
+        }
     }
 
     #[test]

--- a/src/github_api.rs
+++ b/src/github_api.rs
@@ -3,6 +3,9 @@ use std::{env, sync::OnceLock};
 use anyhow::{Context, Result, anyhow, bail};
 use octocrab::Octocrab;
 use serde_json::{Map, Value};
+use tracing::{debug, error};
+
+use crate::log::{GhLogRequest, fail_api_request, finish_api_request, start_gh_request};
 
 const TOKEN_ENV_VARS: [&str; 3] = ["GHR_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"];
 
@@ -48,46 +51,204 @@ pub fn parse_api_args(args: &[String]) -> Result<ApiRequest> {
     parse_api_args_impl(args)
 }
 
-pub async fn run_direct_request(request: &ApiRequest) -> Result<String> {
+pub async fn run_api(args: &[String]) -> Result<String> {
+    let request = match parse_api_args(args) {
+        Ok(request) => request,
+        Err(request_error) => {
+            let command = unparsed_request_display(args);
+            let log_request = start_gh_request("api", &command, None);
+            debug!(kind = "api", command, "GitHub API request started");
+            log_request_failed(log_request, &command, &request_error);
+            return Err(request_error);
+        }
+    };
+    let command = request_display(&request);
+    let log_request = start_gh_request("api", &command, None);
+    debug!(kind = "api", command, "GitHub API request started");
+
+    run_direct_request(&request, log_request, &command).await
+}
+
+async fn run_direct_request(
+    request: &ApiRequest,
+    log_request: GhLogRequest,
+    command: &str,
+) -> Result<String> {
     let graphql = request.graphql;
-    let client = client()?;
+    let client = match client() {
+        Ok(client) => client,
+        Err(request_error) => {
+            log_request_failed(log_request, command, &request_error);
+            return Err(request_error);
+        }
+    };
     let path = normalized_path(&request.path);
 
-    let response = if request.method == "GET" {
-        let path = append_query_fields(&path, &request.fields)?;
-        let headers = request_headers(&request.headers)?;
-        client._get_with_headers(path, Some(headers)).await?
-    } else {
-        let body = if request.graphql {
-            graphql_body(request.fields.clone())?
+    let response_result: Result<_> = async {
+        if request.method == "GET" {
+            let path = append_query_fields(&path, &request.fields)?;
+            let headers = request_headers(&request.headers)?;
+            Ok(client._get_with_headers(path, Some(headers)).await?)
         } else {
-            Value::Object(request.fields.clone())
-        };
-        match request.method.as_str() {
-            "POST" => client._post(path, Some(&body)).await?,
-            "PATCH" => client._patch(path, Some(&body)).await?,
-            "PUT" => client._put(path, Some(&body)).await?,
-            "DELETE" => client._delete(path, Some(&body)).await?,
-            method => bail!("direct GitHub API backend does not support method {method}"),
+            let body = if request.graphql {
+                graphql_body(request.fields.clone())?
+            } else {
+                Value::Object(request.fields.clone())
+            };
+            match request.method.as_str() {
+                "POST" => Ok(client._post(path, Some(&body)).await?),
+                "PATCH" => Ok(client._patch(path, Some(&body)).await?),
+                "PUT" => Ok(client._put(path, Some(&body)).await?),
+                "DELETE" => Ok(client._delete(path, Some(&body)).await?),
+                method => bail!("direct GitHub API backend does not support method {method}"),
+            }
+        }
+    }
+    .await;
+    let response = match response_result {
+        Ok(response) => response,
+        Err(request_error) => {
+            log_request_failed(log_request, command, &request_error);
+            return Err(request_error);
         }
     };
 
     let status = response.status();
-    let body = client
+    let body = match client
         .body_to_string(response)
         .await
-        .context("failed to read GitHub API response")?;
+        .context("failed to read GitHub API response")
+    {
+        Ok(body) => body,
+        Err(request_error) => {
+            log_request_finished(
+                log_request,
+                command,
+                status.as_u16(),
+                0,
+                Some(&request_error.to_string()),
+            );
+            return Err(request_error);
+        }
+    };
     if !status.is_success() {
         let message = github_error_message(&body);
-        bail!(
+        let request_error = anyhow!(
             "GitHub API request failed: HTTP {}: {message}",
             status.as_u16()
         );
+        log_request_finished(
+            log_request,
+            command,
+            status.as_u16(),
+            body.len(),
+            Some(&message),
+        );
+        return Err(request_error);
     }
     if graphql && let Some(message) = graphql_error_message(&body) {
-        bail!("GitHub GraphQL request failed: {message}");
+        let request_error = anyhow!("GitHub GraphQL request failed: {message}");
+        log_request_finished(
+            log_request,
+            command,
+            status.as_u16(),
+            body.len(),
+            Some(&message),
+        );
+        return Err(request_error);
     }
+    log_request_succeeded(log_request, command, status.as_u16(), body.len());
     Ok(body)
+}
+
+fn request_display(request: &ApiRequest) -> String {
+    let mut details = Vec::new();
+    if request.graphql
+        && let Some(query) = request.fields.get("query").and_then(Value::as_str)
+    {
+        details.push(format!("document=<{} chars>", query.chars().count()));
+    }
+    details.extend(
+        request
+            .fields
+            .iter()
+            .filter(|(name, _)| !request.graphql || name.as_str() != "query")
+            .map(|(name, value)| format!("{name}={}", request_value_display(value))),
+    );
+
+    let request_line = format!("{} {}", request.method, normalized_path(&request.path));
+    if details.is_empty() {
+        request_line
+    } else {
+        format!("{request_line}  {}", details.join("  "))
+    }
+}
+
+fn request_value_display(value: &Value) -> String {
+    let value = value
+        .as_str()
+        .map(str::to_string)
+        .unwrap_or_else(|| value.to_string());
+    let char_count = value.chars().count();
+    if char_count > 80 || value.contains(['\r', '\n']) {
+        format!("<{char_count} chars>")
+    } else if value.is_empty() || value.chars().any(char::is_whitespace) {
+        format!("{value:?}")
+    } else {
+        value
+    }
+}
+
+fn unparsed_request_display(args: &[String]) -> String {
+    let args = args
+        .iter()
+        .skip(1)
+        .map(|arg| {
+            if let Some(query) = arg.strip_prefix("query=") {
+                format!("query=<{} chars>", query.chars().count())
+            } else {
+                request_value_display(&Value::String(arg.clone()))
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ");
+    format!("api {args}").trim_end().to_string()
+}
+
+fn log_request_succeeded(request: GhLogRequest, command: &str, status: u16, response_bytes: usize) {
+    debug!(
+        kind = "api",
+        command, status, response_bytes, "GitHub API request finished"
+    );
+    finish_api_request(request, status, true, response_bytes, None);
+}
+
+fn log_request_finished(
+    request: GhLogRequest,
+    command: &str,
+    status: u16,
+    response_bytes: usize,
+    message: Option<&str>,
+) {
+    error!(
+        kind = "api",
+        command,
+        status,
+        response_bytes,
+        message = message.unwrap_or("unknown error"),
+        "GitHub API request returned failure"
+    );
+    finish_api_request(request, status, false, response_bytes, message);
+}
+
+fn log_request_failed(request: GhLogRequest, command: &str, request_error: &anyhow::Error) {
+    error!(
+        kind = "api",
+        command,
+        error = %request_error,
+        "GitHub API request failed"
+    );
+    fail_api_request(request, request_error);
 }
 
 fn client() -> Result<&'static Octocrab> {
@@ -299,22 +460,49 @@ fn graphql_body(mut fields: Map<String, Value>) -> Result<Value> {
 }
 
 fn github_error_message(body: &str) -> String {
-    serde_json::from_str::<Value>(body)
-        .ok()
-        .and_then(|value| {
-            value
-                .get("message")
-                .and_then(Value::as_str)
-                .map(str::to_string)
-        })
-        .unwrap_or_else(|| {
-            let body = body.trim();
-            if body.is_empty() {
-                "empty response".to_string()
-            } else {
-                body.to_string()
-            }
-        })
+    let Ok(value) = serde_json::from_str::<Value>(body) else {
+        return non_empty_error_body(body);
+    };
+
+    let mut parts = value
+        .get("message")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .into_iter()
+        .collect::<Vec<_>>();
+    if let Some(errors) = value.get("errors").and_then(Value::as_array) {
+        let details = errors
+            .iter()
+            .map(|error| {
+                error
+                    .as_str()
+                    .or_else(|| error.get("message").and_then(Value::as_str))
+                    .map(str::to_string)
+                    .unwrap_or_else(|| error.to_string())
+            })
+            .collect::<Vec<_>>();
+        if !details.is_empty() {
+            parts.push(format!("errors: {}", details.join("; ")));
+        }
+    }
+    if let Some(documentation_url) = value.get("documentation_url").and_then(Value::as_str) {
+        parts.push(format!("documentation: {documentation_url}"));
+    }
+
+    if parts.is_empty() {
+        non_empty_error_body(body)
+    } else {
+        parts.join("; ")
+    }
+}
+
+fn non_empty_error_body(body: &str) -> String {
+    let body = body.trim();
+    if body.is_empty() {
+        "empty response".to_string()
+    } else {
+        body.to_string()
+    }
 }
 
 fn graphql_error_message(body: &str) -> Option<String> {
@@ -354,6 +542,33 @@ mod tests {
         assert!(request.graphql);
         assert_eq!(request.fields["number"], 57);
         assert_eq!(request.fields["enabled"], true);
+    }
+
+    #[test]
+    fn api_request_display_uses_http_method_and_path() {
+        let request = parse_api_args(&strings(&["api", "user"])).unwrap();
+
+        assert_eq!(request_display(&request), "GET /user");
+    }
+
+    #[test]
+    fn graphql_request_display_summarizes_document_and_keeps_variables() {
+        let query = "query($owner: String!) {\n  repository(owner: $owner) { name }\n}";
+        let request = parse_api_args(&strings(&[
+            "api",
+            "graphql",
+            "-f",
+            &format!("query={query}"),
+            "-F",
+            "owner=rust-lang",
+        ]))
+        .unwrap();
+
+        let display = request_display(&request);
+        assert!(display.starts_with("POST /graphql  document=<"));
+        assert!(display.contains("owner=rust-lang"));
+        assert!(!display.contains("repository"));
+        assert!(!display.contains('\n'));
     }
 
     #[test]
@@ -403,6 +618,20 @@ mod tests {
             graphql_error_message(body).as_deref(),
             Some("Bad credentials; denied")
         );
+    }
+
+    #[test]
+    fn rest_error_message_keeps_validation_details() {
+        let body = r#"{
+            "message":"Validation Failed",
+            "errors":[{"resource":"Search","field":"q","code":"invalid"}],
+            "documentation_url":"https://docs.github.com/rest/search/search"
+        }"#;
+
+        let message = github_error_message(body);
+        assert!(message.contains("Validation Failed"));
+        assert!(message.contains(r#""field":"q""#));
+        assert!(message.contains("documentation: https://docs.github.com/rest/search/search"));
     }
 
     fn strings(values: &[&str]) -> Vec<String> {

--- a/src/log.rs
+++ b/src/log.rs
@@ -8,7 +8,7 @@ use chrono::{DateTime, Utc};
 
 const MAX_GH_LOG_ENTRIES: usize = 200;
 const MAX_GH_LOG_COMMAND_CHARS: usize = 1200;
-const MAX_GH_LOG_MESSAGE_CHARS: usize = 280;
+const MAX_GH_LOG_MESSAGE_CHARS: usize = 1200;
 
 static GH_LOG: OnceLock<Mutex<VecDeque<GhLogEntry>>> = OnceLock::new();
 
@@ -74,6 +74,50 @@ pub fn finish_gh_request(request: GhLogRequest, output: &Output) {
         stderr_bytes: output.stderr.len(),
         message,
         rate_limited,
+    });
+}
+
+pub fn finish_api_request(
+    request: GhLogRequest,
+    status: u16,
+    success: bool,
+    response_bytes: usize,
+    message: Option<&str>,
+) {
+    let message = message.map(|message| truncate_gh_log_text(message, MAX_GH_LOG_MESSAGE_CHARS));
+    let rate_limited =
+        status == 429 || message.as_deref().is_some_and(looks_like_github_rate_limit);
+    push_gh_log_entry(GhLogEntry {
+        started_at: request.started_at,
+        finished_at: Utc::now(),
+        duration_ms: request.started_instant.elapsed().as_millis(),
+        kind: request.kind,
+        command: request.command,
+        cwd: request.cwd,
+        status: format!("HTTP {status}"),
+        success,
+        stdout_bytes: response_bytes,
+        stderr_bytes: 0,
+        message,
+        rate_limited,
+    });
+}
+
+pub fn fail_api_request(request: GhLogRequest, error: impl std::fmt::Display) {
+    let message = error.to_string();
+    push_gh_log_entry(GhLogEntry {
+        started_at: request.started_at,
+        finished_at: Utc::now(),
+        duration_ms: request.started_instant.elapsed().as_millis(),
+        kind: request.kind,
+        command: request.command,
+        cwd: request.cwd,
+        status: "request failed".to_string(),
+        success: false,
+        stdout_bytes: 0,
+        stderr_bytes: 0,
+        rate_limited: looks_like_github_rate_limit(&message),
+        message: Some(truncate_gh_log_text(&message, MAX_GH_LOG_MESSAGE_CHARS)),
     });
 }
 
@@ -161,7 +205,7 @@ mod tests {
     use std::io::Error;
 
     #[test]
-    fn recent_entries_are_newest_first_and_flag_rate_limits() {
+    fn recent_entries_include_cli_and_api_request_details() {
         clear_gh_log_entries();
         let request = start_gh_request("gh api", "gh api /rate_limit", None);
         fail_gh_request_to_start(request, &Error::other("HTTP 403: API rate limit exceeded"));
@@ -176,6 +220,32 @@ mod tests {
                 .message
                 .as_deref()
                 .is_some_and(|message| message.contains("API rate limit exceeded"))
+        );
+
+        let request = start_gh_request(
+            "api",
+            "api search/issues -f q=repo:rust-lang/triagebot",
+            None,
+        );
+        finish_api_request(
+            request,
+            422,
+            false,
+            134,
+            Some(r#"{"message":"Validation Failed","errors":[{"field":"q","code":"invalid"}]}"#),
+        );
+
+        let entries = recent_gh_log_entries();
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].kind, "api");
+        assert_eq!(entries[0].status, "HTTP 422");
+        assert_eq!(entries[0].stdout_bytes, 134);
+        assert!(!entries[0].success);
+        assert!(
+            entries[0]
+                .message
+                .as_deref()
+                .is_some_and(|message| message.contains("Validation Failed"))
         );
     }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -52,6 +52,8 @@ pub struct WorkItem {
     pub assignees: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub linked_pull_requests: Vec<LinkedPullRequest>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub linked_issues: Vec<LinkedIssue>,
     pub comments: Option<u64>,
     pub unread: Option<bool>,
     pub reason: Option<String>,
@@ -62,6 +64,15 @@ pub struct WorkItem {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LinkedPullRequest {
+    pub repository: String,
+    pub number: u64,
+    pub title: String,
+    pub state: Option<String>,
+    pub url: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LinkedIssue {
     pub repository: String,
     pub number: u64,
     pub title: String,
@@ -615,11 +626,22 @@ fn preserve_lazy_item_details(current: &WorkItem, refreshed: &mut WorkItem) {
 }
 
 fn preserve_detail_only_fields(current: &WorkItem, refreshed: &mut WorkItem) {
-    if current.kind != refreshed.kind || !matches!(refreshed.kind, ItemKind::Issue) {
+    if current.kind != refreshed.kind {
         return;
     }
-    if refreshed.linked_pull_requests.is_empty() && !current.linked_pull_requests.is_empty() {
-        refreshed.linked_pull_requests = current.linked_pull_requests.clone();
+    match refreshed.kind {
+        ItemKind::Issue => {
+            if refreshed.linked_pull_requests.is_empty() && !current.linked_pull_requests.is_empty()
+            {
+                refreshed.linked_pull_requests = current.linked_pull_requests.clone();
+            }
+        }
+        ItemKind::PullRequest => {
+            if refreshed.linked_issues.is_empty() && !current.linked_issues.is_empty() {
+                refreshed.linked_issues = current.linked_issues.clone();
+            }
+        }
+        ItemKind::Notification => {}
     }
 }
 
@@ -848,6 +870,37 @@ mod tests {
     }
 
     #[test]
+    fn refreshed_pull_request_sections_preserve_loaded_linked_issues() {
+        let mut current_item = test_work_item("owner/repo#7", ItemKind::PullRequest);
+        current_item.body = Some("Old description".to_string());
+        current_item.labels = vec!["old-label".to_string()];
+        let linked_issues = vec![LinkedIssue {
+            repository: "owner/repo".to_string(),
+            number: 42,
+            title: "Bug example".to_string(),
+            state: Some("open".to_string()),
+            url: "https://github.com/owner/repo/issues/42".to_string(),
+        }];
+        current_item.linked_issues = linked_issues.clone();
+
+        let mut refreshed_item = test_work_item("owner/repo#7", ItemKind::PullRequest);
+        refreshed_item.title = "Updated PR title".to_string();
+        let merged = merge_refreshed_sections(
+            vec![test_section(SectionKind::PullRequests, vec![current_item])],
+            vec![test_section(
+                SectionKind::PullRequests,
+                vec![refreshed_item],
+            )],
+        );
+
+        let item = &merged[0].items[0];
+        assert_eq!(item.title, "Updated PR title");
+        assert!(item.body.is_none());
+        assert!(item.labels.is_empty());
+        assert_eq!(item.linked_issues, linked_issues);
+    }
+
+    #[test]
     fn configured_repo_sections_use_repo_view_and_generic_titles() {
         let mut config = Config::default();
         config.repos.push(crate::config::RepoConfig {
@@ -1001,6 +1054,7 @@ mod tests {
             milestone: None,
             assignees: Vec::new(),
             linked_pull_requests: Vec::new(),
+            linked_issues: Vec::new(),
             comments: None,
             unread: None,
             reason: None,

--- a/src/model.rs
+++ b/src/model.rs
@@ -50,12 +50,23 @@ pub struct WorkItem {
     pub milestone: Option<Milestone>,
     #[serde(default)]
     pub assignees: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub linked_pull_requests: Vec<LinkedPullRequest>,
     pub comments: Option<u64>,
     pub unread: Option<bool>,
     pub reason: Option<String>,
     pub extra: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub viewer_subscription: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LinkedPullRequest {
+    pub repository: String,
+    pub number: u64,
+    pub title: String,
+    pub state: Option<String>,
+    pub url: String,
 }
 
 impl WorkItem {
@@ -519,6 +530,7 @@ pub fn merge_refreshed_sections(
         .into_iter()
         .map(|mut section| match refreshed_by_key.remove(&section.key) {
             Some(mut refreshed) if refreshed.error.is_none() => {
+                preserve_detail_only_item_fields(&section, &mut refreshed);
                 preserve_lazy_notification_item_details(&section, &mut refreshed);
                 refreshed
             }
@@ -529,6 +541,20 @@ pub fn merge_refreshed_sections(
             None => section,
         })
         .collect()
+}
+
+fn preserve_detail_only_item_fields(current: &SectionSnapshot, refreshed: &mut SectionSnapshot) {
+    let current_by_id = current
+        .items
+        .iter()
+        .map(|item| (item.id.as_str(), item))
+        .collect::<HashMap<_, _>>();
+    for item in &mut refreshed.items {
+        let Some(current_item) = current_by_id.get(item.id.as_str()) else {
+            continue;
+        };
+        preserve_detail_only_fields(current_item, item);
+    }
 }
 
 fn preserve_lazy_notification_item_details(
@@ -582,8 +608,18 @@ fn preserve_lazy_item_details(current: &WorkItem, refreshed: &mut WorkItem) {
     if refreshed.assignees.is_empty() && !current.assignees.is_empty() {
         refreshed.assignees = current.assignees.clone();
     }
+    preserve_detail_only_fields(current, refreshed);
     if refreshed.comments.is_none() {
         refreshed.comments = current.comments;
+    }
+}
+
+fn preserve_detail_only_fields(current: &WorkItem, refreshed: &mut WorkItem) {
+    if current.kind != refreshed.kind || !matches!(refreshed.kind, ItemKind::Issue) {
+        return;
+    }
+    if refreshed.linked_pull_requests.is_empty() && !current.linked_pull_requests.is_empty() {
+        refreshed.linked_pull_requests = current.linked_pull_requests.clone();
     }
 }
 
@@ -690,6 +726,7 @@ mod tests {
         .expect("old cached work item should still parse");
 
         assert_eq!(item.body, None);
+        assert!(item.linked_pull_requests.is_empty());
     }
 
     #[test]
@@ -703,7 +740,7 @@ mod tests {
         let refreshed_updated_at = DateTime::parse_from_rfc3339("2026-05-03T00:00:00Z")
             .unwrap()
             .with_timezone(&Utc);
-        let mut current_item = test_work_item("thread-1", ItemKind::PullRequest);
+        let mut current_item = test_work_item("thread-1", ItemKind::Issue);
         current_item.body = Some("Lazy PR description".to_string());
         current_item.author = Some("alice".to_string());
         current_item.state = Some("open".to_string());
@@ -716,11 +753,19 @@ mod tests {
             title: "next".to_string(),
         });
         current_item.assignees = vec!["bob".to_string()];
+        let linked_pull_requests = vec![LinkedPullRequest {
+            repository: "owner/repo".to_string(),
+            number: 42,
+            title: "Fix example".to_string(),
+            state: Some("open".to_string()),
+            url: "https://github.com/owner/repo/pull/42".to_string(),
+        }];
+        current_item.linked_pull_requests = linked_pull_requests.clone();
         current_item.comments = Some(3);
         current_item.unread = Some(true);
         current_item.reason = Some("subscribed".to_string());
 
-        let mut refreshed_item = test_work_item("thread-1", ItemKind::PullRequest);
+        let mut refreshed_item = test_work_item("thread-1", ItemKind::Issue);
         refreshed_item.updated_at = Some(refreshed_updated_at);
         refreshed_item.unread = Some(false);
         refreshed_item.reason = Some("mention".to_string());
@@ -748,6 +793,7 @@ mod tests {
             })
         );
         assert_eq!(item.assignees, vec!["bob".to_string()]);
+        assert_eq!(item.linked_pull_requests, linked_pull_requests);
         assert_eq!(item.comments, Some(3));
         assert_eq!(item.unread, Some(false));
         assert_eq!(item.reason.as_deref(), Some("mention"));
@@ -771,6 +817,34 @@ mod tests {
         let item = &merged[0].items[0];
         assert!(item.body.is_none());
         assert!(item.labels.is_empty());
+    }
+
+    #[test]
+    fn refreshed_issue_sections_preserve_loaded_linked_pull_requests() {
+        let mut current_item = test_work_item("owner/repo#1", ItemKind::Issue);
+        current_item.body = Some("Old description".to_string());
+        current_item.labels = vec!["old-label".to_string()];
+        let linked_pull_requests = vec![LinkedPullRequest {
+            repository: "owner/repo".to_string(),
+            number: 42,
+            title: "Fix example".to_string(),
+            state: Some("open".to_string()),
+            url: "https://github.com/owner/repo/pull/42".to_string(),
+        }];
+        current_item.linked_pull_requests = linked_pull_requests.clone();
+
+        let mut refreshed_item = test_work_item("owner/repo#1", ItemKind::Issue);
+        refreshed_item.title = "Updated issue title".to_string();
+        let merged = merge_refreshed_sections(
+            vec![test_section(SectionKind::Issues, vec![current_item])],
+            vec![test_section(SectionKind::Issues, vec![refreshed_item])],
+        );
+
+        let item = &merged[0].items[0];
+        assert_eq!(item.title, "Updated issue title");
+        assert!(item.body.is_none());
+        assert!(item.labels.is_empty());
+        assert_eq!(item.linked_pull_requests, linked_pull_requests);
     }
 
     #[test]
@@ -926,6 +1000,7 @@ mod tests {
             reactions: ReactionSummary::default(),
             milestone: None,
             assignees: Vec::new(),
+            linked_pull_requests: Vec::new(),
             comments: None,
             unread: None,
             reason: None,

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -758,6 +758,7 @@ mod tests {
             reactions: Default::default(),
             milestone: None,
             assignees: Vec::new(),
+            linked_pull_requests: Vec::new(),
             comments: None,
             unread: Some(unread),
             reason: Some("mention".to_string()),

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -759,6 +759,7 @@ mod tests {
             milestone: None,
             assignees: Vec::new(),
             linked_pull_requests: Vec::new(),
+            linked_issues: Vec::new(),
             comments: None,
             unread: Some(unread),
             reason: Some("mention".to_string()),

--- a/src/state.rs
+++ b/src/state.rs
@@ -29,7 +29,8 @@ pub struct UiState {
     pub expanded_comments: Vec<String>,
     pub details_scroll_by_item: HashMap<String, u16>,
     pub selected_comment_index_by_item: HashMap<String, usize>,
-    pub viewed_item_at: HashMap<String, DateTime<Utc>>,
+    #[serde(default, alias = "viewed_item_at")]
+    pub seen_item_updated_at: HashMap<String, DateTime<Utc>>,
     pub selected_diff_file: HashMap<String, usize>,
     pub selected_diff_line: HashMap<String, usize>,
     pub diff_file_details_scroll: HashMap<String, u16>,
@@ -248,7 +249,8 @@ impl UiState {
             .retain(|key, _| !key.trim().is_empty());
         self.selected_comment_index_by_item =
             normalized_index_map(self.selected_comment_index_by_item);
-        self.viewed_item_at.retain(|key, _| !key.trim().is_empty());
+        self.seen_item_updated_at
+            .retain(|key, _| !key.trim().is_empty());
         self.selected_diff_file = normalized_index_map(self.selected_diff_file);
         self.selected_diff_line = normalized_index_map(self.selected_diff_line);
         self.diff_file_details_scroll
@@ -282,7 +284,7 @@ impl Default for UiState {
             expanded_comments: Vec::new(),
             details_scroll_by_item: HashMap::new(),
             selected_comment_index_by_item: HashMap::new(),
-            viewed_item_at: HashMap::new(),
+            seen_item_updated_at: HashMap::new(),
             selected_diff_file: HashMap::new(),
             selected_diff_line: HashMap::new(),
             diff_file_details_scroll: HashMap::new(),
@@ -484,7 +486,7 @@ mod tests {
             expanded_comments: vec!["1:comment:42".to_string()],
             details_scroll_by_item: HashMap::from([("issue-3".to_string(), 12)]),
             selected_comment_index_by_item: HashMap::from([("issue-3".to_string(), 4)]),
-            viewed_item_at: HashMap::from([(
+            seen_item_updated_at: HashMap::from([(
                 "issue:rust-lang/rust:3".to_string(),
                 DateTime::from_timestamp(1_700_000_030, 0).unwrap(),
             )]),
@@ -612,7 +614,7 @@ mod tests {
             Some(&4)
         );
         assert_eq!(
-            state.viewed_item_at.get("issue:rust-lang/rust:3"),
+            state.seen_item_updated_at.get("issue:rust-lang/rust:3"),
             Some(&DateTime::from_timestamp(1_700_000_030, 0).unwrap())
         );
         assert_eq!(state.selected_diff_file.get("issue-3"), Some(&4));
@@ -687,6 +689,24 @@ mod tests {
     #[test]
     fn default_split_ratio_is_even() {
         assert_eq!(UiState::default().list_width_percent, 50);
+    }
+
+    #[test]
+    fn legacy_viewed_item_at_loads_as_seen_item_updated_at() {
+        let content = r#"
+[viewed_item_at]
+"issue:rust-lang/rust:3" = "2026-01-01T00:00:30Z"
+"#;
+
+        let state = toml::from_str::<UiState>(content).expect("parse legacy state");
+
+        assert_eq!(
+            state
+                .seen_item_updated_at
+                .get("issue:rust-lang/rust:3")
+                .copied(),
+            Some(DateTime::from_timestamp(1_767_225_630, 0).unwrap())
+        );
     }
 
     #[test]


### PR DESCRIPTION

- Show linked pull requests in issue details and linked issues in pull request details.
- Fetch linked items through GitHub GraphQL:
  - `closedByPullRequestsReferences` for issue -> PR links
  - `closingIssuesReferences` for PR -> issue links
- Add a unified `Open Linked PR/Issue` command palette action:
  - opens the first linked PR from an issue
  - opens the first linked issue from a PR
- Preserve loaded linked item metadata across list/section refreshes to avoid flickering while details reload.
- Fix diff gutter alignment for large line numbers.
- Tighten detail action labels from `+ react`, `@ assign`, `- unassign` to `+react`, `@assign`, `-unassign`.
