### PR TITLE
feat: implement inbox idle refresh functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 
 - Inbox, pull request, and issue views.
 - Snapshot-first startup: cached data is shown immediately, the active view refreshes first, Inbox refreshes every 60 seconds while idle, and non-active PR/issue sections are kept warm by a quiet idle sweep.
+- Bounded read-request scheduling per GitHub backend, with limited foreground concurrency, serialized background work, foreground priority, resource-specific rate-limit cooldowns, and rate-limit-aware retries; write operations run immediately and are never retried automatically.
 - Configurable sections and repo tabs, including multi-query sections such as `Needs Attention`.
 - Automatic current-repo tab persistence when launched inside a Git checkout with a GitHub remote.
 - Paged PR and issue lists with configurable page size.
@@ -206,6 +207,7 @@ Open the command palette with `:` to fuzzy search and run commands. Recently run
 | `Subscribe Item` / `Unsubscribe Item` | Change the selected issue or pull request conversation subscription |
 | `Info` | Show terminal, version, config/db/log paths, cache counts, runtime state, and ghr system diagnostics in a scrollable popup |
 | `Log` | Show recent direct API and `gh api` requests with timestamps, status, response sizes, errors, and rate-limit events; use `j`/`k` to select and `Enter` to open details |
+| `Rate Limit` | Query and show current GitHub core, search, and GraphQL quotas together with local queue and cooldown state |
 
 Diff review ranges:
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 ## Features
 
 - Inbox, pull request, and issue views.
-- Snapshot-first startup: cached data is shown immediately, the active view refreshes first, and non-active PR/issue sections are kept warm by a quiet idle sweep.
+- Snapshot-first startup: cached data is shown immediately, the active view refreshes first, Inbox refreshes every 60 seconds while idle, and non-active PR/issue sections are kept warm by a quiet idle sweep.
 - Configurable sections and repo tabs, including multi-query sections such as `Needs Attention`.
 - Automatic current-repo tab persistence when launched inside a Git checkout with a GitHub remote.
 - Paged PR and issue lists with configurable page size.

--- a/src/app.rs
+++ b/src/app.rs
@@ -43,7 +43,7 @@ use crate::config::{
 };
 use crate::dirs::Paths;
 use crate::github::{
-    AssigneeAction, CommentFetchResult, ItemDetailsMetadata, MergeMethod,
+    AssigneeAction, CommentFetchResult, GitHubRateLimitSnapshot, ItemDetailsMetadata, MergeMethod,
     PullRequestReviewCommentTarget, PullRequestReviewEvent, RefreshScope,
     add_issue_comment_reaction, add_issue_label, add_issue_reaction,
     add_pull_request_review_comment_reaction, approve_pull_request, change_issue_milestone,
@@ -51,9 +51,9 @@ use crate::github::{
     create_pending_pull_request_review, create_pull_request, disable_pull_request_auto_merge,
     discard_pending_pull_request_review, edit_issue_comment, edit_item_metadata,
     edit_pull_request_review_comment, enable_pull_request_auto_merge, fetch_comments,
-    fetch_open_milestones, fetch_pull_request_action_hints, fetch_pull_request_diff,
-    fetch_repository_assignees, fetch_repository_labels, mark_all_notifications_read,
-    mark_notification_thread_done, mark_notification_thread_read,
+    fetch_github_rate_limits, fetch_open_milestones, fetch_pull_request_action_hints,
+    fetch_pull_request_diff, fetch_repository_assignees, fetch_repository_labels,
+    mark_all_notifications_read, mark_notification_thread_done, mark_notification_thread_read,
     mark_pull_request_ready_for_review, merge_pull_request, mute_notification_thread,
     post_issue_comment, post_pull_request_review_comment, post_pull_request_review_reply,
     refresh_dashboard, refresh_dashboard_with_progress, refresh_idle_search_sections,
@@ -160,6 +160,9 @@ const NO_SELECTED_COMMENT_INDEX: usize = usize::MAX;
 const NO_SELECTED_CHECK_RUN_INDEX: usize = usize::MAX;
 
 enum AppMsg {
+    RateLimitLoaded {
+        result: std::result::Result<GitHubRateLimitSnapshot, String>,
+    },
     RefreshStarted {
         scope: RefreshScope,
     },
@@ -952,6 +955,7 @@ enum DiagnosticsDialogKind {
     Info,
     GhLog,
     GhLogDetail,
+    RateLimit,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1588,6 +1592,7 @@ struct AppState {
     cache_clear_dialog: Option<CacheClearDialog>,
     command_palette_key: String,
     status: String,
+    rate_limit_loading: bool,
     refreshing: bool,
     current_refresh_scope: RefreshScope,
     pending_full_refresh_after_view: bool,
@@ -1628,6 +1633,7 @@ struct AppState {
     mention_selected: usize,
     details_stale: HashSet<String>,
     details_refreshing: HashSet<String>,
+    details_auto_retry_blocked: HashSet<String>,
     pending_details_load: Option<PendingDetailsLoad>,
     comments_refresh_requested_at: HashMap<String, Instant>,
     comments_refresh_after: HashMap<String, Instant>,
@@ -3021,6 +3027,7 @@ impl AppState {
             cache_clear_dialog: None,
             command_palette_key: DEFAULT_COMMAND_PALETTE_KEY.to_string(),
             status: "loading snapshot; background refresh started".to_string(),
+            rate_limit_loading: false,
             refreshing: false,
             current_refresh_scope: RefreshScope::Full,
             pending_full_refresh_after_view: false,
@@ -3061,6 +3068,7 @@ impl AppState {
             mention_selected: 0,
             details_stale: HashSet::new(),
             details_refreshing: HashSet::new(),
+            details_auto_retry_blocked: HashSet::new(),
             pending_details_load: None,
             comments_refresh_requested_at: HashMap::new(),
             comments_refresh_after: HashMap::new(),
@@ -3675,7 +3683,8 @@ impl AppState {
             return;
         }
 
-        self.invalidate_action_hints_for_sections(&sections);
+        let updated_item_ids = self.updated_item_ids_for_sections(&sections);
+        self.invalidate_action_hints_for_item_ids(&updated_item_ids);
         for section in &sections {
             self.remember_base_filters(section);
         }
@@ -3685,7 +3694,10 @@ impl AppState {
         if self.restore_refresh_anchor(&anchor) {
             self.details_scroll = previous_details_scroll;
             self.selected_comment_index = previous_comment_index;
-            if let Some(item_id) = anchor.item_id {
+            if let Some(item_id) = anchor
+                .item_id
+                .filter(|item_id| updated_item_ids.contains(item_id))
+            {
                 self.details_stale.insert(item_id);
             }
             self.clamp_selected_comment();
@@ -3728,6 +3740,8 @@ impl AppState {
             return;
         }
 
+        let updated_item_ids = self.updated_item_ids_for_sections(std::slice::from_ref(&section));
+        self.invalidate_action_hints_for_item_ids(&updated_item_ids);
         self.record_unseen_repo_items_for_sections(std::slice::from_ref(&section));
         let current = std::mem::take(&mut self.sections);
         self.sections = merge_refreshed_sections(current, vec![section]);
@@ -3736,6 +3750,12 @@ impl AppState {
         if restored_item {
             self.details_scroll = previous_details_scroll;
             self.selected_comment_index = previous_comment_index;
+            if let Some(item_id) = anchor
+                .item_id
+                .filter(|item_id| updated_item_ids.contains(item_id))
+            {
+                self.details_stale.insert(item_id);
+            }
             self.clamp_selected_comment();
         } else {
             self.reset_or_restore_current_conversation_details_state();
@@ -3773,6 +3793,19 @@ impl AppState {
 
     fn handle_msg(&mut self, message: AppMsg) {
         match message {
+            AppMsg::RateLimitLoaded { result } => {
+                self.rate_limit_loading = false;
+                match result {
+                    Ok(snapshot) => self.show_diagnostics_dialog(
+                        DiagnosticsDialogKind::RateLimit,
+                        "Rate Limit",
+                        rate_limit_lines(&snapshot),
+                        Vec::new(),
+                        "rate limits",
+                    ),
+                    Err(error) => self.show_operation_error_dialog("Rate Limit Failed", &error),
+                }
+            }
             AppMsg::RefreshStarted { scope } => {
                 self.refreshing = true;
                 self.current_refresh_scope = scope;
@@ -3828,7 +3861,6 @@ impl AppState {
                     .find_map(|section| section.error.as_deref())
                     .map(str::to_string);
                 let setup_dialog = first_error.as_deref().and_then(setup_dialog_from_error);
-                self.invalidate_action_hints_for_sections(&sections);
                 for section in &sections {
                     self.remember_base_filters(section);
                 }
@@ -3837,6 +3869,8 @@ impl AppState {
                     .filter(|section| !self.has_active_section_filter(&section.key))
                     .filter(|section| !self.should_preserve_user_section_page(section))
                     .collect::<Vec<_>>();
+                let updated_item_ids = self.updated_item_ids_for_sections(&sections);
+                self.invalidate_action_hints_for_item_ids(&updated_item_ids);
                 self.record_unseen_repo_items_for_sections(&sections);
                 let current = std::mem::take(&mut self.sections);
                 self.sections = merge_refreshed_sections(current, sections);
@@ -3844,7 +3878,10 @@ impl AppState {
                 if restored_item {
                     self.details_scroll = previous_details_scroll;
                     self.selected_comment_index = previous_comment_index;
-                    if let Some(item_id) = anchor.item_id {
+                    if let Some(item_id) = anchor
+                        .item_id
+                        .filter(|item_id| updated_item_ids.contains(item_id))
+                    {
                         self.details_stale.insert(item_id);
                     }
                     self.clamp_selected_comment();
@@ -3876,6 +3913,7 @@ impl AppState {
                 Ok(mut result) => {
                     self.details_stale.remove(&item_id);
                     self.details_refreshing.remove(&item_id);
+                    self.details_auto_retry_blocked.remove(&item_id);
                     self.remember_details_synced_at(&item_id, &result);
                     self.apply_comment_fetch_result_metadata(&item_id, &result);
                     self.merge_optimistic_comments(&item_id, &mut result.comments);
@@ -3887,6 +3925,7 @@ impl AppState {
                 Err(error) => {
                     self.details_stale.remove(&item_id);
                     self.details_refreshing.remove(&item_id);
+                    self.details_auto_retry_blocked.insert(item_id.clone());
                     if matches!(self.details.get(&item_id), Some(DetailState::Loaded(_))) {
                         self.status = format!(
                             "comments refresh failed; keeping cached comments: {}",
@@ -5336,6 +5375,16 @@ impl AppState {
         debug!("log dialog opened");
     }
 
+    fn start_rate_limit_load(&mut self, tx: &UnboundedSender<AppMsg>) {
+        if self.rate_limit_loading {
+            self.status = "rate limits already loading".to_string();
+            return;
+        }
+        self.rate_limit_loading = true;
+        self.status = "loading GitHub rate limits".to_string();
+        spawn_rate_limit_load(tx.clone());
+    }
+
     fn show_diagnostics_dialog(
         &mut self,
         kind: DiagnosticsDialogKind,
@@ -5545,6 +5594,10 @@ impl AppState {
             }
             PaletteAction::ShowGhLog => {
                 self.show_gh_log_dialog();
+                false
+            }
+            PaletteAction::ShowRateLimit => {
+                self.start_rate_limit_load(tx);
                 false
             }
             PaletteAction::ShowHelp => {
@@ -5848,16 +5901,31 @@ impl AppState {
         }
     }
 
+    fn updated_item_ids_for_sections(&self, sections: &[SectionSnapshot]) -> HashSet<String> {
+        sections
+            .iter()
+            .flat_map(|section| section.items.iter())
+            .filter_map(|item| {
+                let refreshed_at = item.updated_at?;
+                self.item_updated_at_by_id(&item.id)
+                    .is_some_and(|current_at| refreshed_at > current_at)
+                    .then(|| item.id.clone())
+            })
+            .collect()
+    }
+
+    fn invalidate_action_hints_for_item_ids(&mut self, item_ids: &HashSet<String>) {
+        for item_id in item_ids {
+            self.mark_action_hints_stale(item_id.clone());
+        }
+    }
+
     fn invalidate_action_hints_for_sections(&mut self, sections: &[SectionSnapshot]) {
         let item_ids = sections
             .iter()
-            .flat_map(|section| {
-                section
-                    .items
-                    .iter()
-                    .filter(|item| item.kind == ItemKind::PullRequest)
-                    .map(|item| item.id.clone())
-            })
+            .flat_map(|section| section.items.iter())
+            .filter(|item| item.kind == ItemKind::PullRequest)
+            .map(|item| item.id.clone())
             .collect::<Vec<_>>();
         for item_id in item_ids {
             self.mark_action_hints_stale(item_id);
@@ -6232,8 +6300,9 @@ impl AppState {
         self.sections
             .iter()
             .flat_map(|section| section.items.iter())
-            .find(|item| item.id == item_id)
-            .and_then(|item| item.updated_at)
+            .filter(|item| item.id == item_id)
+            .filter_map(|item| item.updated_at)
+            .max()
     }
 
     fn append_local_comment(&mut self, item_id: &str, comment: CommentPreview) -> usize {
@@ -6527,6 +6596,17 @@ impl AppState {
     }
 
     fn comments_load_needed(&self, item: &WorkItem) -> bool {
+        if self.details_refreshing.contains(&item.id)
+            || matches!(self.details.get(&item.id), Some(DetailState::Loading))
+        {
+            return false;
+        }
+        if (self.details_auto_retry_blocked.contains(&item.id)
+            || matches!(self.details.get(&item.id), Some(DetailState::Error(_))))
+            && !self.details_stale.contains(&item.id)
+        {
+            return false;
+        }
         !self.details.contains_key(&item.id)
             || self.details_stale.contains(&item.id)
             || self.details_cache_outdated(item)
@@ -6739,6 +6819,11 @@ impl AppState {
     }
 
     fn start_comments_load_if_needed_at(&mut self, item: &WorkItem, now: Instant) -> bool {
+        if self.details_refreshing.contains(&item.id)
+            || matches!(self.details.get(&item.id), Some(DetailState::Loading))
+        {
+            return false;
+        }
         let should_refresh =
             self.details_stale.remove(&item.id) || self.details_cache_outdated(item);
         if self.details.contains_key(&item.id) && !should_refresh {
@@ -6752,6 +6837,7 @@ impl AppState {
         }
         self.comments_refresh_requested_at
             .insert(item.id.clone(), now);
+        self.details_auto_retry_blocked.remove(&item.id);
         true
     }
 
@@ -6774,9 +6860,10 @@ impl AppState {
             return false;
         }
         if self.details_refreshing.contains(&item.id)
+            || self.details_auto_retry_blocked.contains(&item.id)
             || matches!(
                 self.details.get(&item.id),
-                Some(DetailState::Loading) | None
+                Some(DetailState::Loading | DetailState::Error(_)) | None
             )
         {
             return false;
@@ -12171,6 +12258,16 @@ impl AppState {
         if self.details_cache_outdated(&item) {
             self.details_stale.insert(item.id);
         }
+    }
+
+    fn mark_current_details_stale_for_user_refresh(&mut self) {
+        let Some(item) = self.current_item().cloned() else {
+            return;
+        };
+        if self.details.contains_key(&item.id) {
+            self.details_stale.insert(item.id.clone());
+        }
+        self.mark_action_hints_stale(item.id);
     }
 
     fn mark_current_details_viewed(&mut self) {

--- a/src/app.rs
+++ b/src/app.rs
@@ -57,12 +57,13 @@ use crate::github::{
     mark_pull_request_ready_for_review, merge_pull_request, mute_notification_thread,
     post_issue_comment, post_pull_request_review_comment, post_pull_request_review_reply,
     refresh_dashboard, refresh_dashboard_with_progress, refresh_idle_search_sections,
-    refresh_section_page, remove_issue_label, remove_pull_request_reviewers, reopen_issue,
-    reopen_pull_request, request_pull_request_reviewers, rerun_failed_pull_request_checks,
-    search_github_users, search_global, set_pull_request_review_thread_resolved,
-    submit_pending_pull_request_review, submit_pull_request_review, subscribe_notification_thread,
-    unsubscribe_notification_thread, update_issue_assignees, update_item_subscription,
-    update_pull_request_branch, with_background_github_priority,
+    refresh_notification_sections, refresh_section_page, remove_issue_label,
+    remove_pull_request_reviewers, reopen_issue, reopen_pull_request,
+    request_pull_request_reviewers, rerun_failed_pull_request_checks, search_github_users,
+    search_global, set_pull_request_review_thread_resolved, submit_pending_pull_request_review,
+    submit_pull_request_review, subscribe_notification_thread, unsubscribe_notification_thread,
+    update_issue_assignees, update_item_subscription, update_pull_request_branch,
+    with_background_github_priority,
 };
 #[cfg(test)]
 use crate::model::PullRequestCommitActivityPreview;
@@ -174,6 +175,10 @@ enum AppMsg {
     IdleSweepFinished {
         sections: Vec<SectionSnapshot>,
         next_cursor: usize,
+    },
+    InboxIdleRefreshStarted,
+    InboxIdleRefreshFinished {
+        sections: Vec<SectionSnapshot>,
     },
     CommentsLoaded {
         item_id: String,
@@ -1527,6 +1532,7 @@ const GLOBAL_SEARCH_SUGGESTION_LIMIT: usize = 6;
 const MENTION_SUGGESTION_LIMIT: usize = 6;
 const IDLE_SWEEP_SECTION_LIMIT: usize = 2;
 const INITIAL_IDLE_SWEEP_DELAY: Duration = Duration::from_secs(300);
+const INBOX_IDLE_REFRESH_INTERVAL: Duration = Duration::from_secs(60);
 
 struct AppState {
     theme_name: ThemeName,
@@ -1590,6 +1596,8 @@ struct AppState {
     idle_sweep_refreshing: bool,
     idle_sweep_cursor: usize,
     last_idle_sweep_request: Instant,
+    inbox_idle_refreshing: bool,
+    last_inbox_refresh_request: Instant,
     details: HashMap<String, DetailState>,
     details_synced_at: HashMap<String, DateTime<Utc>>,
     details_refreshed_at: HashMap<String, DateTime<Utc>>,
@@ -2053,6 +2061,8 @@ async fn run_loop(
 
         if !started_pending_full_refresh
             && !app.refreshing
+            && !app.idle_sweep_refreshing
+            && !app.inbox_idle_refreshing
             && config.defaults.refetch_interval_seconds > 0
             && app.last_refresh_request.elapsed().as_secs()
                 >= config.defaults.refetch_interval_seconds
@@ -2064,6 +2074,8 @@ async fn run_loop(
                 RefreshPriority::Background,
                 RefreshScope::View(app.active_view.clone()),
             );
+        } else if !started_pending_full_refresh && app.should_start_inbox_idle_refresh() {
+            start_inbox_idle_refresh(config.clone(), store.clone(), tx.clone());
         } else if !started_pending_full_refresh && app.should_start_idle_sweep(config) {
             start_idle_sweep(
                 config.clone(),
@@ -2900,6 +2912,15 @@ fn recent_item_matches_work_item(recent: &RecentItem, item: &WorkItem) -> bool {
     !recent.id.is_empty() && item.id == recent.id
 }
 
+fn refresh_scope_includes_inbox(scope: &RefreshScope) -> bool {
+    match scope {
+        RefreshScope::Full => true,
+        RefreshScope::View(view) => {
+            same_view_key(view, &builtin_view_key(SectionKind::Notifications))
+        }
+    }
+}
+
 impl AppState {
     fn with_ui_state(
         active_view: SectionKind,
@@ -3008,6 +3029,8 @@ impl AppState {
             idle_sweep_refreshing: false,
             idle_sweep_cursor: 0,
             last_idle_sweep_request: Instant::now() - INITIAL_IDLE_SWEEP_DELAY,
+            inbox_idle_refreshing: false,
+            last_inbox_refresh_request: Instant::now() - INBOX_IDLE_REFRESH_INTERVAL,
             details: HashMap::new(),
             details_synced_at: HashMap::new(),
             details_refreshed_at: HashMap::new(),
@@ -3494,12 +3517,25 @@ impl AppState {
     fn should_start_idle_sweep(&self, config: &Config) -> bool {
         !self.refreshing
             && !self.idle_sweep_refreshing
+            && !self.inbox_idle_refreshing
             && self.setup_dialog.is_none()
             && self.section_page_loading.is_none()
             && !self.global_search_running
             && config.defaults.refetch_interval_seconds > 0
             && self.last_idle_sweep_request.elapsed().as_secs()
                 >= config.defaults.refetch_interval_seconds
+    }
+
+    fn should_start_inbox_idle_refresh(&self) -> bool {
+        !self.refreshing
+            && !self.idle_sweep_refreshing
+            && !self.inbox_idle_refreshing
+            && self.setup_dialog.is_none()
+            && self.section_page_loading.is_none()
+            && !self.global_search_running
+            && self.notification_read_pending.is_empty()
+            && self.notification_done_pending.is_empty()
+            && self.last_inbox_refresh_request.elapsed() >= INBOX_IDLE_REFRESH_INTERVAL
     }
 
     fn record_unseen_repo_items_for_sections(&mut self, sections: &[SectionSnapshot]) {
@@ -3624,6 +3660,40 @@ impl AppState {
         self.sections = merge_refreshed_sections(current, sections);
     }
 
+    fn apply_inbox_idle_refreshed_sections(&mut self, sections: Vec<SectionSnapshot>) {
+        let anchor = self.current_refresh_anchor();
+        let previous_details_scroll = self.details_scroll;
+        let previous_comment_index = self.selected_comment_index;
+        let sections = sections
+            .into_iter()
+            .filter(|section| matches!(section.kind, SectionKind::Notifications))
+            .filter(|section| !self.has_active_section_filter(&section.key))
+            .filter(|section| !self.should_preserve_user_section_page(section))
+            .collect::<Vec<_>>();
+
+        if sections.is_empty() {
+            return;
+        }
+
+        self.invalidate_action_hints_for_sections(&sections);
+        for section in &sections {
+            self.remember_base_filters(section);
+        }
+
+        let current = std::mem::take(&mut self.sections);
+        self.sections = merge_refreshed_sections(current, sections);
+        if self.restore_refresh_anchor(&anchor) {
+            self.details_scroll = previous_details_scroll;
+            self.selected_comment_index = previous_comment_index;
+            if let Some(item_id) = anchor.item_id {
+                self.details_stale.insert(item_id);
+            }
+            self.clamp_selected_comment();
+        } else {
+            self.reset_or_restore_current_conversation_details_state();
+        }
+    }
+
     fn apply_refreshed_section(&mut self, section: SectionSnapshot, save_error: Option<String>) {
         let anchor = self.current_refresh_anchor();
         let previous_details_scroll = self.details_scroll;
@@ -3707,6 +3777,9 @@ impl AppState {
                 self.refreshing = true;
                 self.current_refresh_scope = scope;
                 self.last_refresh_request = Instant::now();
+                if refresh_scope_includes_inbox(&self.current_refresh_scope) {
+                    self.last_inbox_refresh_request = Instant::now();
+                }
                 if self.section_page_loading.is_none() {
                     self.status = refresh_started_status(&self.current_refresh_scope);
                 }
@@ -3729,6 +3802,15 @@ impl AppState {
                 self.idle_sweep_cursor = next_cursor;
                 self.last_idle_sweep_request = Instant::now();
                 self.apply_idle_refreshed_sections(sections);
+            }
+            AppMsg::InboxIdleRefreshStarted => {
+                self.inbox_idle_refreshing = true;
+                self.last_inbox_refresh_request = Instant::now();
+            }
+            AppMsg::InboxIdleRefreshFinished { sections } => {
+                self.inbox_idle_refreshing = false;
+                self.last_inbox_refresh_request = Instant::now();
+                self.apply_inbox_idle_refreshed_sections(sections);
             }
             AppMsg::RefreshFinished {
                 sections,

--- a/src/app/command_palette.rs
+++ b/src/app/command_palette.rs
@@ -28,6 +28,7 @@ pub(super) enum PaletteAction {
     Quit,
     ShowInfo,
     ShowGhLog,
+    ShowRateLimit,
     ShowHelp,
     ShowCommandPalette,
     SubmitEditor,
@@ -154,6 +155,13 @@ pub(super) fn command_palette_commands(
             "General",
             "Show recent GitHub API requests, status, errors, and rate-limit events",
             PaletteAction::ShowGhLog,
+        ),
+        palette_command(
+            "Rate Limit",
+            "",
+            "General",
+            "Show current GitHub core, search, and GraphQL quotas and local cooldowns",
+            PaletteAction::ShowRateLimit,
         ),
         palette_command(
             "Close or Cancel",
@@ -1041,6 +1049,9 @@ mod tests {
                 .any(|command| command.title == "Change Milestone")
         );
         assert!(commands.iter().any(|command| command.title == "Info"));
+        assert!(commands.iter().any(|command| {
+            command.title == "Rate Limit" && matches!(command.action, PaletteAction::ShowRateLimit)
+        }));
         assert!(
             commands
                 .iter()

--- a/src/app/dialogs.rs
+++ b/src/app/dialogs.rs
@@ -893,6 +893,9 @@ fn diagnostics_dialog_footer(kind: DiagnosticsDialogKind) -> &'static str {
         DiagnosticsDialogKind::Info => {
             "j/k/Up/Down: scroll    PageUp/PageDown: jump    Enter/Esc/q: close"
         }
+        DiagnosticsDialogKind::RateLimit => {
+            "j/k/Up/Down: scroll    PageUp/PageDown: jump    Enter/Esc/q: close"
+        }
         DiagnosticsDialogKind::GhLogDetail => {
             "j/k/Up/Down: scroll    PageUp/PageDown: jump    Esc: list    Enter/q: close"
         }

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -889,6 +889,7 @@ pub(super) fn trigger_refresh(
     tx: &UnboundedSender<AppMsg>,
 ) {
     if !app.refreshing {
+        app.mark_current_details_stale_for_user_refresh();
         app.queue_full_refresh_after_view();
     }
     trigger_refresh_scope(

--- a/src/app/runtime.rs
+++ b/src/app/runtime.rs
@@ -121,6 +121,80 @@ pub(super) fn gh_log_lines_with_details() -> (Vec<String>, Vec<Vec<String>>) {
     (lines, details)
 }
 
+pub(super) fn rate_limit_lines(snapshot: &GitHubRateLimitSnapshot) -> Vec<String> {
+    let mut lines = vec![
+        "GitHub quotas".to_string(),
+        format!("backend: {}", snapshot.scheduler.backend.label()),
+        format!(
+            "checked: {}",
+            snapshot
+                .fetched_at
+                .with_timezone(&Local)
+                .format("%Y-%m-%d %H:%M:%S %:z")
+        ),
+        String::new(),
+    ];
+
+    for resource in &snapshot.resources {
+        lines.push(format!(
+            "{}: {:>5} remaining / {:>5} limit | {:>5} used | reset {}",
+            resource.name,
+            resource.remaining,
+            resource.limit,
+            resource.used,
+            rate_limit_reset_summary(resource.reset, snapshot.fetched_at),
+        ));
+    }
+    if snapshot.resources.is_empty() {
+        lines.push("No core, search, or graphql quota returned".to_string());
+    }
+
+    lines.extend([
+        String::new(),
+        "Local scheduler".to_string(),
+        format!(
+            "active: {} / {} foreground slots",
+            snapshot.scheduler.active, snapshot.scheduler.max_active
+        ),
+    ]);
+    for resource in &snapshot.scheduler.resources {
+        let cooldown = resource
+            .cooldown_remaining
+            .map(|duration| format!("{} remaining", compact_duration(duration)))
+            .unwrap_or_else(|| "none".to_string());
+        lines.push(format!(
+            "{} queue: {} foreground, {} background waiting | cooldown {cooldown}",
+            resource.resource.label(),
+            resource.user_waiting,
+            resource.background_waiting,
+        ));
+    }
+    lines
+}
+
+fn rate_limit_reset_summary(reset_epoch: i64, checked_at: DateTime<Utc>) -> String {
+    let Some(reset) = DateTime::<Utc>::from_timestamp(reset_epoch, 0) else {
+        return "unknown".to_string();
+    };
+    let until_reset = reset.signed_duration_since(checked_at).num_seconds().max(0) as u64;
+    format!(
+        "{} (in {})",
+        reset.with_timezone(&Local).format("%Y-%m-%d %H:%M:%S"),
+        compact_duration(Duration::from_secs(until_reset))
+    )
+}
+
+fn compact_duration(duration: Duration) -> String {
+    let seconds = duration.as_secs();
+    if seconds < 60 {
+        format!("{seconds}s")
+    } else if seconds < 3_600 {
+        format!("{}m {}s", seconds / 60, seconds % 60)
+    } else {
+        format!("{}h {}m", seconds / 3_600, (seconds % 3_600) / 60)
+    }
+}
+
 fn gh_log_detail_lines(entry: &GhLogEntry) -> Vec<String> {
     let direct_api = entry.kind == "api";
     let mut lines = vec![

--- a/src/app/runtime.rs
+++ b/src/app/runtime.rs
@@ -83,6 +83,7 @@ pub(super) fn info_lines(app: &AppState, config: &Config, paths: &Paths) -> Vec<
         format!("refreshing: {}", app.refreshing),
         format!("refresh_scope: {:?}", app.current_refresh_scope),
         format!("idle_sweep_refreshing: {}", app.idle_sweep_refreshing),
+        format!("inbox_idle_refreshing: {}", app.inbox_idle_refreshing),
         format!(
             "mouse: {}",
             if app.mouse_capture_enabled {

--- a/src/app/switchers.rs
+++ b/src/app/switchers.rs
@@ -1070,6 +1070,7 @@ impl AppState {
         self.action_hints_refreshing.clear();
         self.details_stale.clear();
         self.details_refreshing.clear();
+        self.details_auto_retry_blocked.clear();
         self.pending_details_load = None;
         self.reset_or_restore_current_conversation_details_state();
         count

--- a/src/app/tasks.rs
+++ b/src/app/tasks.rs
@@ -1,5 +1,14 @@
 use super::*;
 
+pub(super) fn spawn_rate_limit_load(tx: UnboundedSender<AppMsg>) {
+    tokio::spawn(async move {
+        let result = fetch_github_rate_limits()
+            .await
+            .map_err(error_chain_message);
+        let _ = tx.send(AppMsg::RateLimitLoaded { result });
+    });
+}
+
 pub(super) fn start_refresh(
     config: Config,
     store: SnapshotStore,

--- a/src/app/tasks.rs
+++ b/src/app/tasks.rs
@@ -79,6 +79,37 @@ pub(super) fn start_idle_sweep(
     });
 }
 
+pub(super) fn start_inbox_idle_refresh(
+    config: Config,
+    store: SnapshotStore,
+    tx: UnboundedSender<AppMsg>,
+) {
+    let _ = tx.send(AppMsg::InboxIdleRefreshStarted);
+    tokio::spawn(async move {
+        let refresh = refresh_notification_sections(&config);
+        let refreshed = with_background_github_priority(refresh).await;
+        let mut sections = Vec::new();
+
+        for section in refreshed {
+            if let Some(error) = &section.error {
+                warn!(error = %error, "failed to refresh inbox in background");
+                continue;
+            }
+
+            if let Err(error) = store.save_section(&section) {
+                warn!(
+                    error = %error,
+                    section = %section.key,
+                    "failed to save background inbox snapshot"
+                );
+            }
+            sections.push(section);
+        }
+
+        let _ = tx.send(AppMsg::InboxIdleRefreshFinished { sections });
+    });
+}
+
 pub(super) fn start_section_page_load(
     app: &mut AppState,
     config: &Config,

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -2881,6 +2881,44 @@ fn inbox_idle_refresh_preserves_selected_notification_and_details_position() {
     );
     assert_eq!(app.focus, FocusTarget::Details);
     assert_eq!(app.details_scroll, 7);
+    assert!(!app.details_stale.contains("thread-2"));
+}
+
+#[test]
+fn inbox_idle_refresh_only_stales_selected_details_when_item_updated() {
+    let older = DateTime::from_timestamp(1_700_000_000, 0).unwrap();
+    let newer = DateTime::from_timestamp(1_700_000_001, 0).unwrap();
+    let mut old_item = notification_item("thread-1", true);
+    old_item.updated_at = Some(older);
+    let inbox = SectionSnapshot {
+        key: "notifications:All".to_string(),
+        kind: SectionKind::Notifications,
+        title: "All".to_string(),
+        filters: "is:all".to_string(),
+        items: vec![old_item],
+        total_count: None,
+        page: 1,
+        page_size: 50,
+        refreshed_at: None,
+        error: None,
+    };
+    let mut app = AppState::new(SectionKind::Notifications, vec![inbox.clone()]);
+    app.details.insert(
+        "thread-1".to_string(),
+        DetailState::Loaded(vec![comment("alice", "cached", None)]),
+    );
+
+    app.handle_msg(AppMsg::InboxIdleRefreshFinished {
+        sections: vec![inbox.clone()],
+    });
+    assert!(!app.details_stale.contains("thread-1"));
+
+    let mut refreshed = inbox;
+    refreshed.items[0].updated_at = Some(newer);
+    app.handle_msg(AppMsg::InboxIdleRefreshFinished {
+        sections: vec![refreshed],
+    });
+    assert!(app.details_stale.contains("thread-1"));
 }
 
 #[test]
@@ -2951,7 +2989,11 @@ fn refresh_finished_does_not_open_ready_dialog_without_startup_dialog() {
 
 #[test]
 fn refresh_finished_marks_pr_action_hints_stale_without_hiding_loaded_fields() {
-    let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
+    let older = DateTime::from_timestamp(1_700_000_000, 0).unwrap();
+    let newer = DateTime::from_timestamp(1_700_000_001, 0).unwrap();
+    let mut initial = test_section();
+    initial.items[0].updated_at = Some(older);
+    let mut app = AppState::new(SectionKind::PullRequests, vec![initial]);
     app.action_hints.insert(
         "1".to_string(),
         ActionHintState::loaded(ActionHints {
@@ -2965,8 +3007,10 @@ fn refresh_finished_marks_pr_action_hints_stale_without_hiding_loaded_fields() {
         }),
     );
 
+    let mut refreshed = test_section();
+    refreshed.items[0].updated_at = Some(newer);
     app.handle_msg(AppMsg::RefreshFinished {
-        sections: vec![test_section()],
+        sections: vec![refreshed],
         save_error: None,
     });
 
@@ -3071,6 +3115,33 @@ fn progressive_refresh_does_not_force_current_details_reload() {
     let item = app.current_item().expect("current item").clone();
     assert!(!app.start_comments_load_if_needed(&item));
     assert!(matches!(app.details.get("1"), Some(DetailState::Loaded(_))));
+}
+
+#[test]
+fn progressive_refresh_stales_details_when_updated_at_advances() {
+    let older = DateTime::from_timestamp(1_700_000_000, 0).unwrap();
+    let newer = DateTime::from_timestamp(1_700_000_001, 0).unwrap();
+    let mut initial = test_section();
+    initial.items[0].updated_at = Some(older);
+    let mut app = AppState::new(SectionKind::PullRequests, vec![initial]);
+    app.details.insert(
+        "1".to_string(),
+        DetailState::Loaded(vec![comment("alice", "cached", None)]),
+    );
+    app.action_hints.insert(
+        "1".to_string(),
+        ActionHintState::loaded(ActionHints::default()),
+    );
+    let mut refreshed = test_section();
+    refreshed.items[0].updated_at = Some(newer);
+
+    app.handle_msg(AppMsg::RefreshSectionLoaded {
+        section: refreshed,
+        save_error: None,
+    });
+
+    assert!(app.details_stale.contains("1"));
+    assert!(app.action_hints_stale.contains("1"));
 }
 
 #[test]
@@ -4027,7 +4098,7 @@ fn ui_state_saves_and_restores_project_view_snapshot() {
 }
 
 #[test]
-fn refresh_preserves_details_scroll_when_current_item_survives() {
+fn refresh_preserves_details_without_staling_unchanged_item() {
     let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
     app.set_selection(1);
     app.focus_details();
@@ -4065,7 +4136,29 @@ fn refresh_preserves_details_scroll_when_current_item_survives() {
     assert_eq!(app.current_selected_position(), 0);
     assert_eq!(app.details_scroll, 9);
     assert_eq!(app.selected_comment_index, 1);
-    assert!(app.details_stale.contains("2"));
+    assert!(!app.details_stale.contains("2"));
+}
+
+#[test]
+fn refresh_stales_selected_details_when_updated_at_advances() {
+    let older = DateTime::from_timestamp(1_700_000_000, 0).unwrap();
+    let newer = DateTime::from_timestamp(1_700_000_001, 0).unwrap();
+    let mut initial = test_section();
+    initial.items[0].updated_at = Some(older);
+    let mut app = AppState::new(SectionKind::PullRequests, vec![initial]);
+    app.details.insert(
+        "1".to_string(),
+        DetailState::Loaded(vec![comment("alice", "cached", None)]),
+    );
+    let mut refreshed = test_section();
+    refreshed.items[0].updated_at = Some(newer);
+
+    app.handle_msg(AppMsg::RefreshFinished {
+        sections: vec![refreshed],
+        save_error: None,
+    });
+
+    assert!(app.details_stale.contains("1"));
 }
 
 #[test]
@@ -4188,7 +4281,7 @@ fn refresh_preserves_repo_anchor_over_builtin_duplicate_item() {
     assert_eq!(app.current_selected_position(), 0);
     assert_eq!(app.details_scroll, 12);
     assert_eq!(app.selected_comment_index, 1);
-    assert!(app.details_stale.contains("fiber-1294"));
+    assert!(!app.details_stale.contains("fiber-1294"));
 }
 
 #[test]
@@ -4268,6 +4361,9 @@ fn stale_details_refresh_failure_preserves_loaded_comments() {
     );
     assert!(!app.details_stale.contains("1"));
     assert!(!app.details_refreshing.contains("1"));
+    assert!(app.details_auto_retry_blocked.contains("1"));
+    assert!(!app.comments_load_needed(&item));
+    assert!(!app.comments_auto_refresh_due(&item, Instant::now() + COMMENTS_AUTO_REFRESH_INTERVAL));
     assert!(app.setup_dialog.is_none());
     assert!(app.status.contains("keeping cached comments"));
 
@@ -4279,6 +4375,26 @@ fn stale_details_refresh_failure_preserves_loaded_comments() {
         .join("\n");
     assert!(rendered.contains("old cached comment"));
     assert!(!rendered.contains("Failed to load comments"));
+
+    app.mark_current_details_stale_for_user_refresh();
+    assert!(app.comments_load_needed(&item));
+}
+
+#[test]
+fn loading_and_error_details_do_not_start_duplicate_automatic_loads() {
+    let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
+    let item = app.current_item().cloned().expect("selected item");
+
+    app.details.insert("1".to_string(), DetailState::Loading);
+    app.details_stale.insert("1".to_string());
+    assert!(!app.comments_load_needed(&item));
+    assert!(!app.start_comments_load_if_needed(&item));
+
+    app.details
+        .insert("1".to_string(), DetailState::Error("failed".to_string()));
+    app.details_stale.remove("1");
+    assert!(!app.comments_load_needed(&item));
+    assert!(!app.start_comments_load_if_needed(&item));
 }
 
 #[test]
@@ -5000,6 +5116,76 @@ fn command_palette_log_opens_recent_gh_request_dialog() {
     );
     assert_eq!(app.status, "log");
     clear_gh_log_entries();
+}
+
+#[test]
+fn rate_limit_result_opens_quota_and_scheduler_dialog() {
+    let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
+    app.rate_limit_loading = true;
+    app.handle_msg(AppMsg::RateLimitLoaded {
+        result: Ok(GitHubRateLimitSnapshot {
+            fetched_at: DateTime::<Utc>::from_timestamp(1_800_000_000, 0).unwrap(),
+            resources: vec![crate::github::GitHubRateLimitResource {
+                name: "core".to_string(),
+                limit: 5_000,
+                used: 1_250,
+                remaining: 3_750,
+                reset: 1_800_000_600,
+            }],
+            scheduler: crate::github_queue::GitHubQueueSnapshot {
+                backend: crate::github_queue::GitHubQueueBackend::DirectApi,
+                active: 2,
+                max_active: 16,
+                resources: vec![crate::github_queue::GitHubQueueResourceSnapshot {
+                    resource: crate::github_queue::GitHubRateResource::Core,
+                    user_waiting: 1,
+                    background_waiting: 3,
+                    cooldown_remaining: Some(Duration::from_secs(42)),
+                }],
+            },
+        }),
+    });
+
+    assert!(!app.rate_limit_loading);
+    let dialog = app.diagnostics_dialog.as_ref().expect("rate limit dialog");
+    assert_eq!(dialog.kind, DiagnosticsDialogKind::RateLimit);
+    assert_eq!(dialog.title, "Rate Limit");
+    assert!(dialog.lines.iter().any(|line| line == "GitHub quotas"));
+    assert!(
+        dialog
+            .lines
+            .iter()
+            .any(|line| line.contains("core:") && line.contains("3750"))
+    );
+    assert!(
+        dialog
+            .lines
+            .iter()
+            .any(|line| line == "active: 2 / 16 foreground slots")
+    );
+    assert!(
+        dialog
+            .lines
+            .iter()
+            .any(|line| line.contains("1 foreground, 3 background")
+                && line.contains("42s remaining"))
+    );
+    assert_eq!(app.status, "rate limits");
+}
+
+#[test]
+fn rate_limit_error_uses_operation_error_dialog() {
+    let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
+    app.rate_limit_loading = true;
+    app.handle_msg(AppMsg::RateLimitLoaded {
+        result: Err("HTTP 403: secondary rate limit".to_string()),
+    });
+
+    assert!(!app.rate_limit_loading);
+    let dialog = app.message_dialog.as_ref().expect("error dialog");
+    assert_eq!(dialog.title, "Rate Limit Failed");
+    assert!(dialog.body.contains("secondary rate limit"));
+    assert_eq!(dialog.kind, MessageDialogKind::Error);
 }
 
 #[tokio::test]
@@ -9867,7 +10053,10 @@ fn issue_or_pr_description_renders_without_preview_truncation() {
 
 #[test]
 fn inbox_refresh_keeps_lazy_description_visible_while_details_reload() {
+    let older = DateTime::from_timestamp(1_700_000_000, 0).unwrap();
+    let newer = DateTime::from_timestamp(1_700_000_001, 0).unwrap();
     let mut item = notification_item("thread-1", true);
+    item.updated_at = Some(older);
     item.body = Some("Loaded from the linked pull request.".to_string());
     item.author = Some("rustbot".to_string());
     item.labels = vec!["T-compiler".to_string()];
@@ -9889,12 +10078,14 @@ fn inbox_refresh_keeps_lazy_description_visible_while_details_reload() {
         DetailState::Loaded(vec![comment("alice", "cached comment", None)]),
     );
 
+    let mut refreshed_item = notification_item("thread-1", false);
+    refreshed_item.updated_at = Some(newer);
     let refreshed_section = SectionSnapshot {
         key: "notifications:all".to_string(),
         kind: SectionKind::Notifications,
         title: "All".to_string(),
         filters: "is:all".to_string(),
-        items: vec![notification_item("thread-1", false)],
+        items: vec![refreshed_item],
         total_count: None,
         page: 1,
         page_size: 50,
@@ -13276,6 +13467,30 @@ fn capital_r_replies_in_details_while_lowercase_r_keeps_refreshing() {
     ));
     assert_eq!(app.status, "refresh already running");
     assert!(app.comment_dialog.is_none());
+}
+
+#[test]
+fn lowercase_r_retries_failed_details() {
+    let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
+    let (tx, _rx) = mpsc::unbounded_channel();
+    let config = Config::default();
+    let store = SnapshotStore::new(std::path::PathBuf::from("/tmp/ghr-test-unused.db"));
+    app.details
+        .insert("1".to_string(), DetailState::Error("failed".to_string()));
+    app.details_auto_retry_blocked.insert("1".to_string());
+    let item = app.current_item().cloned().expect("selected item");
+    assert!(!app.comments_load_needed(&item));
+
+    assert!(!handle_key(
+        &mut app,
+        key(KeyCode::Char('r')),
+        &config,
+        &store,
+        &tx
+    ));
+
+    assert!(app.details_stale.contains("1"));
+    assert!(app.comments_load_needed(&item));
 }
 
 #[test]

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -2777,6 +2777,128 @@ fn idle_sweep_does_not_merge_current_active_view() {
 }
 
 #[test]
+fn inbox_idle_refresh_runs_every_minute_only_between_other_refreshes() {
+    let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
+    app.last_inbox_refresh_request = Instant::now() - INBOX_IDLE_REFRESH_INTERVAL;
+
+    assert!(app.should_start_inbox_idle_refresh());
+
+    app.refreshing = true;
+    assert!(!app.should_start_inbox_idle_refresh());
+    app.refreshing = false;
+    app.idle_sweep_refreshing = true;
+    assert!(!app.should_start_inbox_idle_refresh());
+    app.idle_sweep_refreshing = false;
+    app.notification_read_pending.insert("thread-1".to_string());
+    assert!(!app.should_start_inbox_idle_refresh());
+    app.notification_read_pending.clear();
+
+    app.handle_msg(AppMsg::InboxIdleRefreshStarted);
+    assert!(app.inbox_idle_refreshing);
+    assert!(!app.should_start_inbox_idle_refresh());
+
+    app.handle_msg(AppMsg::InboxIdleRefreshFinished {
+        sections: Vec::new(),
+    });
+    assert!(!app.inbox_idle_refreshing);
+    assert!(!app.should_start_inbox_idle_refresh());
+}
+
+#[test]
+fn inbox_idle_refresh_updates_notifications_without_changing_active_view_or_status() {
+    let inbox = SectionSnapshot {
+        key: "notifications:All".to_string(),
+        kind: SectionKind::Notifications,
+        title: "All".to_string(),
+        filters: "is:all".to_string(),
+        items: vec![notification_item("thread-1", false)],
+        total_count: None,
+        page: 1,
+        page_size: 50,
+        refreshed_at: None,
+        error: None,
+    };
+    let mut app = AppState::new(
+        SectionKind::PullRequests,
+        vec![test_section(), inbox.clone()],
+    );
+    app.status = "steady".to_string();
+
+    let mut refreshed_inbox = inbox;
+    refreshed_inbox.items = vec![
+        notification_item("thread-1", true),
+        notification_item("thread-2", true),
+    ];
+    app.handle_msg(AppMsg::InboxIdleRefreshFinished {
+        sections: vec![refreshed_inbox],
+    });
+
+    assert_eq!(app.active_view, "pull_requests");
+    assert_eq!(app.status, "steady");
+    assert_eq!(app.unread_notification_count(), 2);
+    let inbox = app
+        .sections
+        .iter()
+        .find(|section| section.key == "notifications:All")
+        .expect("inbox section should remain loaded");
+    assert_eq!(inbox.items.len(), 2);
+    assert!(inbox.items.iter().all(|item| item.unread == Some(true)));
+}
+
+#[test]
+fn inbox_idle_refresh_preserves_selected_notification_and_details_position() {
+    let mut inbox = SectionSnapshot {
+        key: "notifications:All".to_string(),
+        kind: SectionKind::Notifications,
+        title: "All".to_string(),
+        filters: "is:all".to_string(),
+        items: vec![
+            notification_item("thread-1", true),
+            notification_item("thread-2", true),
+        ],
+        total_count: None,
+        page: 1,
+        page_size: 50,
+        refreshed_at: None,
+        error: None,
+    };
+    let mut app = AppState::new(SectionKind::Notifications, vec![inbox.clone()]);
+    app.set_current_selected_position(1);
+    app.focus = FocusTarget::Details;
+    app.details_scroll = 7;
+
+    inbox.items = vec![
+        notification_item("thread-2", true),
+        notification_item("thread-3", true),
+    ];
+    app.handle_msg(AppMsg::InboxIdleRefreshFinished {
+        sections: vec![inbox],
+    });
+
+    assert_eq!(
+        app.current_item().map(|item| item.id.as_str()),
+        Some("thread-2")
+    );
+    assert_eq!(app.focus, FocusTarget::Details);
+    assert_eq!(app.details_scroll, 7);
+}
+
+#[test]
+fn visible_inbox_refresh_resets_independent_idle_timer() {
+    let inbox = SectionSnapshot::empty(SectionKind::Notifications, "All", "is:all");
+    let mut app = AppState::new(SectionKind::Notifications, vec![inbox]);
+    app.last_inbox_refresh_request = Instant::now() - INBOX_IDLE_REFRESH_INTERVAL;
+
+    app.handle_msg(AppMsg::RefreshStarted {
+        scope: RefreshScope::View("notifications".to_string()),
+    });
+
+    assert!(app.refreshing);
+    assert!(app.last_inbox_refresh_request.elapsed() < Duration::from_secs(1));
+    assert!(!app.should_start_inbox_idle_refresh());
+}
+
+#[test]
 fn startup_refresh_finishes_with_ready_dialog() {
     let mut app = AppState::new(SectionKind::PullRequests, vec![test_section()]);
     let paths = test_paths();

--- a/src/github.rs
+++ b/src/github.rs
@@ -1,7 +1,6 @@
 use std::collections::{HashMap, HashSet};
 use std::future::Future;
 use std::path::Path;
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result, anyhow, bail};
@@ -13,6 +12,7 @@ use tokio::time::sleep;
 use tracing::{debug, error, info, warn};
 
 use crate::config::{Config, SearchSection, github_repo_from_remote_url};
+use crate::github_queue::{GitHubQueueBackend, GitHubRequestPriority};
 use crate::model::{
     ActionHints, CheckRunSummary, CheckSummary, CommentPreview, CommentPreviewKind,
     CommitCheckStatus, FailedCheckRunSummary, ItemKind, LinkedIssue, LinkedPullRequest,
@@ -24,12 +24,10 @@ use crate::model::{
 };
 
 static VIEWER_LOGIN: OnceCell<String> = OnceCell::const_new();
-static USER_GH_REQUESTS_IN_FLIGHT: AtomicUsize = AtomicUsize::new(0);
 
 const SEARCH_API_MAX_RESULTS: usize = 1000;
 const SEARCH_API_MAX_PAGE_SIZE: usize = 100;
 const SEARCH_REFRESH_SPACING: Duration = Duration::from_millis(350);
-const BACKGROUND_GH_YIELD_INTERVAL: Duration = Duration::from_millis(50);
 const MAX_PULL_REQUEST_COMMIT_ACTIVITIES: usize = 5;
 const MAX_PULL_REQUEST_ACTIVITY_COMMITS: usize = 20;
 const GITHUB_API_PAGE_SIZE: usize = 100;
@@ -86,14 +84,8 @@ pub struct ItemDetailsMetadata {
     pub linked_issues: Option<Vec<LinkedIssue>>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum GhRequestPriority {
-    User,
-    Background,
-}
-
 tokio::task_local! {
-    static GH_REQUEST_PRIORITY: GhRequestPriority;
+    static GH_REQUEST_PRIORITY: GitHubRequestPriority;
 }
 
 pub async fn with_background_github_priority<F>(future: F) -> F::Output
@@ -101,35 +93,14 @@ where
     F: Future,
 {
     GH_REQUEST_PRIORITY
-        .scope(GhRequestPriority::Background, future)
+        .scope(GitHubRequestPriority::Background, future)
         .await
 }
 
-fn current_gh_request_priority() -> GhRequestPriority {
+fn current_gh_request_priority() -> GitHubRequestPriority {
     GH_REQUEST_PRIORITY
         .try_with(|priority| *priority)
-        .unwrap_or(GhRequestPriority::User)
-}
-
-struct UserGhRequestGuard;
-
-impl UserGhRequestGuard {
-    fn new() -> Self {
-        USER_GH_REQUESTS_IN_FLIGHT.fetch_add(1, Ordering::AcqRel);
-        Self
-    }
-}
-
-impl Drop for UserGhRequestGuard {
-    fn drop(&mut self) {
-        USER_GH_REQUESTS_IN_FLIGHT.fetch_sub(1, Ordering::AcqRel);
-    }
-}
-
-async fn wait_for_user_gh_requests() {
-    while USER_GH_REQUESTS_IN_FLIGHT.load(Ordering::Acquire) > 0 {
-        sleep(BACKGROUND_GH_YIELD_INTERVAL).await;
-    }
+        .unwrap_or(GitHubRequestPriority::User)
 }
 
 #[derive(Debug, Deserialize)]
@@ -2314,18 +2285,7 @@ async fn fetch_paginated_api_array_output(
     path: &str,
     accept_header: Option<&str>,
 ) -> Result<String> {
-    if gh_api_slurp_supported().await {
-        return fetch_paginated_api_array_output_with_slurp(path, accept_header).await;
-    }
-
     fetch_paginated_api_array_output_without_slurp(path, accept_header).await
-}
-
-async fn fetch_paginated_api_array_output_with_slurp(
-    path: &str,
-    accept_header: Option<&str>,
-) -> Result<String> {
-    run_gh_json(&paginated_api_slurp_args(path, accept_header)).await
 }
 
 async fn fetch_paginated_api_array_output_without_slurp(
@@ -2352,25 +2312,6 @@ async fn fetch_paginated_api_array_output_without_slurp(
     }
 
     serde_json::to_string(&pages).context("failed to encode paginated gh api output")
-}
-
-async fn gh_api_slurp_supported() -> bool {
-    if !crate::github_api::selected_backend().supports_cli_commands() {
-        return false;
-    }
-    crate::github_gh::api_slurp_supported().await
-}
-
-fn paginated_api_slurp_args(path: &str, accept_header: Option<&str>) -> Vec<String> {
-    let mut args = vec!["api".to_string()];
-    if let Some(header) = accept_header {
-        args.push("-H".to_string());
-        args.push(header.to_string());
-    }
-    args.push("--paginate".to_string());
-    args.push("--slurp".to_string());
-    args.push(path.to_string());
-    args
 }
 
 fn paginated_api_array_args(page_path: &str, accept_header: Option<&str>) -> Vec<String> {
@@ -4553,7 +4494,7 @@ fn parse_issue_comment_permissions_page(
     ))
 }
 
-async fn refresh_notification_sections(config: &Config) -> Vec<SectionSnapshot> {
+pub async fn refresh_notification_sections(config: &Config) -> Vec<SectionSnapshot> {
     let limit = notification_fetch_limit(config);
     let include_all = should_fetch_all_notifications(config);
     let fetched = fetch_notifications(limit, include_all).await;
@@ -4744,16 +4685,7 @@ fn should_fetch_all_notifications(config: &Config) -> bool {
 }
 
 async fn run_gh_json(args: &[String]) -> Result<String> {
-    match current_gh_request_priority() {
-        GhRequestPriority::User => {
-            let _guard = UserGhRequestGuard::new();
-            run_gh_json_raw(args).await
-        }
-        GhRequestPriority::Background => {
-            wait_for_user_gh_requests().await;
-            run_gh_json_raw(args).await
-        }
-    }
+    run_gh_json_raw(args).await
 }
 
 async fn run_gh_json_raw(args: &[String]) -> Result<String> {
@@ -4784,7 +4716,13 @@ async fn run_gh_json_raw_once(args: &[String]) -> Result<String> {
     if args.first().map(String::as_str) != Some("api") {
         bail!("GitHub backend expected a `gh api` request");
     }
-    match crate::github_api::selected_backend() {
+    let backend = crate::github_api::selected_backend();
+    let queue_backend = match backend {
+        crate::github_api::GitHubBackend::DirectApi => GitHubQueueBackend::DirectApi,
+        crate::github_api::GitHubBackend::GitHubCli => GitHubQueueBackend::GitHubCli,
+    };
+    let _permit = crate::github_queue::acquire(queue_backend, current_gh_request_priority()).await;
+    match backend {
         crate::github_api::GitHubBackend::DirectApi => crate::github_api::run_api(args).await,
         crate::github_api::GitHubBackend::GitHubCli => crate::github_gh::run_api(args).await,
     }
@@ -4829,29 +4767,30 @@ fn gh_api_method(args: &[String]) -> Option<&str> {
 
 fn is_retryable_gh_json_error(error: &str) -> bool {
     let error = error.to_ascii_lowercase();
-    [
-        "tls handshake timeout",
-        "i/o timeout",
-        "timeout awaiting response headers",
-        "client.timeout",
-        "connection reset",
-        "connection refused",
-        "connection timed out",
-        "error connecting to api.github.com",
-        "check your internet connection",
-        "unexpected eof",
-        " eof",
-        ": eof",
-        "temporary failure",
-        "bad gateway",
-        "service unavailable",
-        "gateway timeout",
-        "http 502",
-        "http 503",
-        "http 504",
-    ]
-    .iter()
-    .any(|needle| error.contains(needle))
+    crate::github_queue::message_looks_rate_limited(&error)
+        || [
+            "tls handshake timeout",
+            "i/o timeout",
+            "timeout awaiting response headers",
+            "client.timeout",
+            "connection reset",
+            "connection refused",
+            "connection timed out",
+            "error connecting to api.github.com",
+            "check your internet connection",
+            "unexpected eof",
+            " eof",
+            ": eof",
+            "temporary failure",
+            "bad gateway",
+            "service unavailable",
+            "gateway timeout",
+            "http 502",
+            "http 503",
+            "http 504",
+        ]
+        .iter()
+        .any(|needle| error.contains(needle))
 }
 
 async fn run_git_text_in_dir(args: &[String], directory: &Path) -> Result<String> {
@@ -5638,11 +5577,6 @@ fn open_milestones_path(repository: &str) -> String {
     format!("repos/{repository}/milestones?state=open&per_page=100")
 }
 
-#[cfg(test)]
-fn open_milestones_args(repository: &str) -> Vec<String> {
-    paginated_api_slurp_args(&open_milestones_path(repository), None)
-}
-
 fn create_milestone_args(repository: &str, title: &str) -> Vec<String> {
     vec![
         "api".to_string(),
@@ -6004,7 +5938,10 @@ mod tests {
 
     #[test]
     fn gh_request_priority_defaults_to_user() {
-        assert_eq!(current_gh_request_priority(), GhRequestPriority::User);
+        assert_eq!(
+            current_gh_request_priority(),
+            GitHubRequestPriority::User
+        );
     }
 
     #[tokio::test]
@@ -6012,8 +5949,11 @@ mod tests {
         let priority =
             with_background_github_priority(async { current_gh_request_priority() }).await;
 
-        assert_eq!(priority, GhRequestPriority::Background);
-        assert_eq!(current_gh_request_priority(), GhRequestPriority::User);
+        assert_eq!(priority, GitHubRequestPriority::Background);
+        assert_eq!(
+            current_gh_request_priority(),
+            GitHubRequestPriority::User
+        );
     }
 
     #[test]
@@ -6029,6 +5969,9 @@ mod tests {
         ));
         assert!(is_retryable_gh_json_error(
             "gh api user failed: error connecting to api.github.com\ncheck your internet connection"
+        ));
+        assert!(is_retryable_gh_json_error(
+            "GitHub API request failed: HTTP 403: You have exceeded a secondary rate limit"
         ));
     }
 
@@ -6626,33 +6569,10 @@ mod tests {
     }
 
     #[test]
-    fn paginated_api_helpers_fall_back_when_gh_slurp_is_missing() {
+    fn paginated_api_helpers_build_individually_queued_pages() {
         assert_eq!(
             open_milestones_path("owner/repo"),
             "repos/owner/repo/milestones?state=open&per_page=100"
-        );
-        assert_eq!(
-            open_milestones_args("owner/repo"),
-            vec![
-                "api",
-                "--paginate",
-                "--slurp",
-                "repos/owner/repo/milestones?state=open&per_page=100"
-            ]
-        );
-        assert_eq!(
-            paginated_api_slurp_args(
-                "repos/owner/repo/issues/1/comments?per_page=100",
-                Some("Accept: application/vnd.github.squirrel-girl-preview+json"),
-            ),
-            vec![
-                "api",
-                "-H",
-                "Accept: application/vnd.github.squirrel-girl-preview+json",
-                "--paginate",
-                "--slurp",
-                "repos/owner/repo/issues/1/comments?per_page=100"
-            ]
         );
         assert_eq!(
             paginated_api_page_path("repos/owner/repo/issues/1/comments?per_page=100", 2),

--- a/src/github.rs
+++ b/src/github.rs
@@ -12,7 +12,7 @@ use tokio::time::sleep;
 use tracing::{debug, error, info, warn};
 
 use crate::config::{Config, SearchSection, github_repo_from_remote_url};
-use crate::github_queue::{GitHubQueueBackend, GitHubRequestPriority};
+use crate::github_queue::{GitHubQueueBackend, GitHubRateResource, GitHubRequestPriority};
 use crate::model::{
     ActionHints, CheckRunSummary, CheckSummary, CommentPreview, CommentPreviewKind,
     CommitCheckStatus, FailedCheckRunSummary, ItemKind, LinkedIssue, LinkedPullRequest,
@@ -33,6 +33,36 @@ const MAX_PULL_REQUEST_ACTIVITY_COMMITS: usize = 20;
 const GITHUB_API_PAGE_SIZE: usize = 100;
 const GH_JSON_RETRY_DELAYS: [Duration; 2] =
     [Duration::from_millis(300), Duration::from_millis(1_000)];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct GitHubRateLimitResource {
+    pub name: String,
+    pub limit: u64,
+    pub used: u64,
+    pub remaining: u64,
+    pub reset: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct GitHubRateLimitSnapshot {
+    pub fetched_at: DateTime<Utc>,
+    pub resources: Vec<GitHubRateLimitResource>,
+    pub scheduler: crate::github_queue::GitHubQueueSnapshot,
+}
+
+#[derive(Debug, Deserialize)]
+struct GitHubRateLimitResponse {
+    resources: HashMap<String, GitHubRateLimitResourceRaw>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GitHubRateLimitResourceRaw {
+    limit: u64,
+    #[serde(default)]
+    used: u64,
+    remaining: u64,
+    reset: i64,
+}
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum MergeMethod {
@@ -4688,6 +4718,52 @@ async fn run_gh_json(args: &[String]) -> Result<String> {
     run_gh_json_raw(args).await
 }
 
+pub(crate) async fn fetch_github_rate_limits() -> Result<GitHubRateLimitSnapshot> {
+    let args = vec!["api".to_string(), "/rate_limit".to_string()];
+    let backend = crate::github_api::selected_backend();
+    // This diagnostic must remain reachable while the core queue is waiting for reset.
+    let (queue_backend, output) = match backend {
+        crate::github_api::GitHubBackend::DirectApi => (
+            GitHubQueueBackend::DirectApi,
+            crate::github_api::run_api(&args, GitHubRateResource::Core).await?,
+        ),
+        crate::github_api::GitHubBackend::GitHubCli => (
+            GitHubQueueBackend::GitHubCli,
+            crate::github_gh::run_api(&args, GitHubRateResource::Core).await?,
+        ),
+    };
+    let resources = parse_rate_limit_resources(&output)?;
+    Ok(GitHubRateLimitSnapshot {
+        fetched_at: Utc::now(),
+        resources,
+        scheduler: crate::github_queue::snapshot(queue_backend),
+    })
+}
+
+fn parse_rate_limit_resources(output: &str) -> Result<Vec<GitHubRateLimitResource>> {
+    let response: GitHubRateLimitResponse =
+        serde_json::from_str(output).context("failed to parse GitHub rate limits")?;
+    let mut resources = response
+        .resources
+        .into_iter()
+        .filter(|(name, _)| matches!(name.as_str(), "core" | "search" | "graphql"))
+        .map(|(name, resource)| GitHubRateLimitResource {
+            name,
+            limit: resource.limit,
+            used: resource.used,
+            remaining: resource.remaining,
+            reset: resource.reset,
+        })
+        .collect::<Vec<_>>();
+    resources.sort_by_key(|resource| match resource.name.as_str() {
+        "core" => 0,
+        "search" => 1,
+        "graphql" => 2,
+        _ => 3,
+    });
+    Ok(resources)
+}
+
 async fn run_gh_json_raw(args: &[String]) -> Result<String> {
     for (attempt, delay) in GH_JSON_RETRY_DELAYS.iter().copied().enumerate() {
         match run_gh_json_raw_once(args).await {
@@ -4701,7 +4777,7 @@ async fn run_gh_json_raw(args: &[String]) -> Result<String> {
                     retry_in_ms = delay.as_millis(),
                     error = %error,
                     command = %crate::github_gh::command_display(args),
-                    "retrying transient gh request failure"
+                    "retrying read-only GitHub request"
                 );
                 sleep(delay).await;
             }
@@ -4721,25 +4797,83 @@ async fn run_gh_json_raw_once(args: &[String]) -> Result<String> {
         crate::github_api::GitHubBackend::DirectApi => GitHubQueueBackend::DirectApi,
         crate::github_api::GitHubBackend::GitHubCli => GitHubQueueBackend::GitHubCli,
     };
-    let _permit = crate::github_queue::acquire(queue_backend, current_gh_request_priority()).await;
+    let resource = github_request_rate_resource(args);
+    let _permit = if github_request_bypasses_queue(args) {
+        None
+    } else {
+        Some(
+            crate::github_queue::acquire(queue_backend, current_gh_request_priority(), resource)
+                .await,
+        )
+    };
     match backend {
-        crate::github_api::GitHubBackend::DirectApi => crate::github_api::run_api(args).await,
-        crate::github_api::GitHubBackend::GitHubCli => crate::github_gh::run_api(args).await,
+        crate::github_api::GitHubBackend::DirectApi => {
+            crate::github_api::run_api(args, resource).await
+        }
+        crate::github_api::GitHubBackend::GitHubCli => {
+            crate::github_gh::run_api(args, resource).await
+        }
+    }
+}
+
+fn github_request_rate_resource(args: &[String]) -> GitHubRateResource {
+    if args.get(1).is_some_and(|arg| arg == "graphql") {
+        GitHubRateResource::Graphql
+    } else if args
+        .iter()
+        .any(|arg| arg.trim_start_matches('/').starts_with("search/"))
+    {
+        GitHubRateResource::Search
+    } else {
+        GitHubRateResource::Core
     }
 }
 
 fn is_retryable_gh_json_request(args: &[String]) -> bool {
     match args.first().map(String::as_str) {
-        Some("api") if args.get(1).is_some_and(|arg| arg == "graphql") => !args.iter().any(|arg| {
-            arg.trim_start_matches("query=")
-                .trim_start()
-                .starts_with("mutation")
-        }),
+        Some("api") if args.get(1).is_some_and(|arg| arg == "graphql") => args
+            .iter()
+            .find_map(|arg| arg.strip_prefix("query="))
+            .is_some_and(graphql_document_is_read_only),
         Some("api") => gh_api_method(args)
             .map(|method| method.eq_ignore_ascii_case("GET"))
-            .unwrap_or(true),
+            .unwrap_or_else(|| !gh_api_args_default_to_post(args)),
         _ => false,
     }
+}
+
+fn github_request_bypasses_queue(args: &[String]) -> bool {
+    match args.first().map(String::as_str) {
+        Some("api") if args.get(1).is_some_and(|arg| arg == "graphql") => args
+            .iter()
+            .find_map(|arg| arg.strip_prefix("query="))
+            .is_some_and(graphql_document_is_mutation),
+        Some("api") => gh_api_method(args)
+            .map(|method| !method.eq_ignore_ascii_case("GET"))
+            .unwrap_or_else(|| gh_api_args_default_to_post(args)),
+        _ => false,
+    }
+}
+
+fn graphql_document_is_read_only(document: &str) -> bool {
+    !graphql_document_is_mutation(document)
+}
+
+fn graphql_document_is_mutation(document: &str) -> bool {
+    document
+        .split(|ch: char| !ch.is_ascii_alphanumeric() && ch != '_')
+        .any(|token| token.eq_ignore_ascii_case("mutation"))
+}
+
+fn gh_api_args_default_to_post(args: &[String]) -> bool {
+    args.iter().any(|arg| {
+        matches!(
+            arg.as_str(),
+            "-f" | "--raw-field" | "-F" | "--field" | "--input"
+        ) || arg.starts_with("--raw-field=")
+            || arg.starts_with("--field=")
+            || arg.starts_with("--input=")
+    })
 }
 
 fn gh_api_method(args: &[String]) -> Option<&str> {
@@ -5938,10 +6072,7 @@ mod tests {
 
     #[test]
     fn gh_request_priority_defaults_to_user() {
-        assert_eq!(
-            current_gh_request_priority(),
-            GitHubRequestPriority::User
-        );
+        assert_eq!(current_gh_request_priority(), GitHubRequestPriority::User);
     }
 
     #[tokio::test]
@@ -5950,10 +6081,7 @@ mod tests {
             with_background_github_priority(async { current_gh_request_priority() }).await;
 
         assert_eq!(priority, GitHubRequestPriority::Background);
-        assert_eq!(
-            current_gh_request_priority(),
-            GitHubRequestPriority::User
-        );
+        assert_eq!(current_gh_request_priority(), GitHubRequestPriority::User);
     }
 
     #[test]
@@ -6009,6 +6137,12 @@ mod tests {
         ]));
         assert!(!is_retryable_gh_json_request(&[
             "api".to_string(),
+            "repos/owner/repo/issues/1/comments".to_string(),
+            "-f".to_string(),
+            "body=hello".to_string(),
+        ]));
+        assert!(!is_retryable_gh_json_request(&[
+            "api".to_string(),
             "--method=PATCH".to_string(),
             "repos/owner/repo/issues/1".to_string(),
         ]));
@@ -6019,6 +6153,102 @@ mod tests {
             "query=mutation($id: ID!) { updateSubscription(input: {subscribableId: $id}) { subscribable { id } } }"
                 .to_string(),
         ]));
+        assert!(!is_retryable_gh_json_request(&[
+            "api".to_string(),
+            "graphql".to_string(),
+            "-f".to_string(),
+            "query=fragment Fields on PullRequest { id } mutation { updatePullRequest(input: {}) { pullRequest { ...Fields } } }"
+                .to_string(),
+        ]));
+    }
+
+    #[test]
+    fn write_requests_bypass_the_backend_queue() {
+        for method in ["POST", "PATCH", "PUT", "DELETE"] {
+            assert!(github_request_bypasses_queue(&[
+                "api".to_string(),
+                "-X".to_string(),
+                method.to_string(),
+                "repos/owner/repo/issues/1".to_string(),
+            ]));
+        }
+        assert!(github_request_bypasses_queue(&[
+            "api".to_string(),
+            "repos/owner/repo/issues/1/comments".to_string(),
+            "-f".to_string(),
+            "body=hello".to_string(),
+        ]));
+        assert!(github_request_bypasses_queue(&[
+            "api".to_string(),
+            "graphql".to_string(),
+            "-f".to_string(),
+            "query=mutation { addComment(input: {}) { clientMutationId } }".to_string(),
+        ]));
+        assert!(!github_request_bypasses_queue(&[
+            "api".to_string(),
+            "repos/owner/repo/issues/1".to_string(),
+        ]));
+        assert!(!github_request_bypasses_queue(&[
+            "api".to_string(),
+            "graphql".to_string(),
+            "-f".to_string(),
+            "query=query { viewer { login } }".to_string(),
+        ]));
+    }
+
+    #[test]
+    fn requests_are_assigned_to_rate_limit_resources() {
+        assert_eq!(
+            github_request_rate_resource(&[
+                "api".to_string(),
+                "repos/owner/repo/issues/1".to_string(),
+            ]),
+            GitHubRateResource::Core
+        );
+        assert_eq!(
+            github_request_rate_resource(&[
+                "api".to_string(),
+                "--method".to_string(),
+                "GET".to_string(),
+                "/search/issues".to_string(),
+            ]),
+            GitHubRateResource::Search
+        );
+        assert_eq!(
+            github_request_rate_resource(&[
+                "api".to_string(),
+                "graphql".to_string(),
+                "-f".to_string(),
+                "query=query { viewer { login } }".to_string(),
+            ]),
+            GitHubRateResource::Graphql
+        );
+    }
+
+    #[test]
+    fn rate_limit_response_keeps_and_orders_used_resources() {
+        let resources = parse_rate_limit_resources(
+            r#"{
+                "resources": {
+                    "graphql": {"limit": 5000, "used": 700, "remaining": 4300, "reset": 1800000300},
+                    "actions_runner_registration": {"limit": 10000, "used": 1, "remaining": 9999, "reset": 1800000400},
+                    "core": {"limit": 5000, "used": 1200, "remaining": 3800, "reset": 1800000100},
+                    "search": {"limit": 30, "used": 5, "remaining": 25, "reset": 1800000200}
+                }
+            }"#,
+        )
+        .expect("rate limit response");
+
+        assert_eq!(
+            resources
+                .iter()
+                .map(|resource| resource.name.as_str())
+                .collect::<Vec<_>>(),
+            ["core", "search", "graphql"]
+        );
+        assert_eq!(resources[0].used, 1200);
+        assert_eq!(resources[1].remaining, 25);
+        assert_eq!(resources[2].limit, 5000);
     }
 
     #[test]

--- a/src/github_api.rs
+++ b/src/github_api.rs
@@ -5,6 +5,7 @@ use octocrab::Octocrab;
 use serde_json::{Map, Value};
 use tracing::{debug, error};
 
+use crate::github_queue::{GitHubQueueBackend, GitHubRateResource, observe_response};
 use crate::log::{GhLogRequest, fail_api_request, finish_api_request, start_gh_request};
 
 const TOKEN_ENV_VARS: [&str; 3] = ["GHR_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"];
@@ -51,7 +52,7 @@ pub fn parse_api_args(args: &[String]) -> Result<ApiRequest> {
     parse_api_args_impl(args)
 }
 
-pub async fn run_api(args: &[String]) -> Result<String> {
+pub async fn run_api(args: &[String], resource: GitHubRateResource) -> Result<String> {
     let request = match parse_api_args(args) {
         Ok(request) => request,
         Err(request_error) => {
@@ -66,11 +67,12 @@ pub async fn run_api(args: &[String]) -> Result<String> {
     let log_request = start_gh_request("api", &command, None);
     debug!(kind = "api", command, "GitHub API request started");
 
-    run_direct_request(&request, log_request, &command).await
+    run_direct_request(&request, resource, log_request, &command).await
 }
 
 async fn run_direct_request(
     request: &ApiRequest,
+    resource: GitHubRateResource,
     log_request: GhLogRequest,
     command: &str,
 ) -> Result<String> {
@@ -114,6 +116,7 @@ async fn run_direct_request(
     };
 
     let status = response.status();
+    let headers = response.headers().clone();
     let body = match client
         .body_to_string(response)
         .await
@@ -121,6 +124,13 @@ async fn run_direct_request(
     {
         Ok(body) => body,
         Err(request_error) => {
+            observe_response(
+                GitHubQueueBackend::DirectApi,
+                resource,
+                status.as_u16(),
+                &headers,
+                Some(&request_error.to_string()),
+            );
             log_request_finished(
                 log_request,
                 command,
@@ -131,8 +141,22 @@ async fn run_direct_request(
             return Err(request_error);
         }
     };
+    let response_message = if !status.is_success() {
+        Some(github_error_message(&body))
+    } else if graphql {
+        graphql_error_message(&body)
+    } else {
+        None
+    };
+    observe_response(
+        GitHubQueueBackend::DirectApi,
+        resource,
+        status.as_u16(),
+        &headers,
+        response_message.as_deref(),
+    );
     if !status.is_success() {
-        let message = github_error_message(&body);
+        let message = response_message.expect("failed response should have an error message");
         let request_error = anyhow!(
             "GitHub API request failed: HTTP {}: {message}",
             status.as_u16()
@@ -146,7 +170,7 @@ async fn run_direct_request(
         );
         return Err(request_error);
     }
-    if graphql && let Some(message) = graphql_error_message(&body) {
+    if let Some(message) = response_message {
         let request_error = anyhow!("GitHub GraphQL request failed: {message}");
         log_request_finished(
             log_request,

--- a/src/github_gh.rs
+++ b/src/github_gh.rs
@@ -2,23 +2,23 @@ use std::io::{self, ErrorKind};
 use std::process::{Command as StdCommand, Output};
 
 use anyhow::{Context, Result, anyhow, bail};
+use http::{HeaderMap, HeaderName, HeaderValue};
 use tokio::process::Command as TokioCommand;
-use tokio::sync::OnceCell;
 use tracing::{debug, error};
 
+use crate::github_queue::{GitHubQueueBackend, GitHubRateResource, observe_response};
 use crate::log::{GhLogRequest, fail_gh_request_to_start, finish_gh_request, start_gh_request};
 
-static API_SLURP_SUPPORTED: OnceCell<bool> = OnceCell::const_new();
-
-pub async fn run_api(args: &[String]) -> Result<String> {
+pub async fn run_api(args: &[String], resource: GitHubRateResource) -> Result<String> {
     if args.first().map(String::as_str) != Some("api") {
         bail!("GitHub CLI backend expected a `gh api` request");
     }
 
     let request = log_request_started(args);
-    let output = TokioCommand::new("gh")
+    let command_args = included_headers_args(args);
+    let mut output = TokioCommand::new("gh")
         .env("GH_PROMPT_DISABLED", "1")
-        .args(args)
+        .args(&command_args)
         .output()
         .await
         .map_err(|error| {
@@ -29,6 +29,28 @@ pub async fn run_api(args: &[String]) -> Result<String> {
                 anyhow!("failed to run {}: {error}", command_display(args))
             }
         })?;
+    let response = match parse_included_response(&output.stdout) {
+        Ok(response) => response,
+        Err(parse_error) => {
+            log_request_finished(request, args, &output);
+            if !output.status.success() {
+                bail!("{}", failure_message(args, &output_message(&output)));
+            }
+            return Err(anyhow!(
+                "failed to parse response headers from {}: {parse_error}",
+                command_display(args)
+            ));
+        }
+    };
+    let message = (!output.status.success()).then(|| output_message(&output));
+    observe_response(
+        GitHubQueueBackend::GitHubCli,
+        resource,
+        response.status,
+        &response.headers,
+        message.as_deref(),
+    );
+    output.stdout = response.body;
     log_request_finished(request, args, &output);
 
     if !output.status.success() {
@@ -37,12 +59,6 @@ pub async fn run_api(args: &[String]) -> Result<String> {
     }
 
     String::from_utf8(output.stdout).context("gh output was not UTF-8")
-}
-
-pub async fn api_slurp_supported() -> bool {
-    *API_SLURP_SUPPORTED
-        .get_or_init(detect_api_slurp_support)
-        .await
 }
 
 pub fn version_output() -> io::Result<Output> {
@@ -70,44 +86,67 @@ pub fn command_display(args: &[String]) -> String {
     format!("gh {}", args.join(" "))
 }
 
-async fn detect_api_slurp_support() -> bool {
-    let args = vec!["api".to_string(), "--help".to_string()];
-    let request = log_request_started(&args);
-    let output = TokioCommand::new("gh")
-        .env("GH_PROMPT_DISABLED", "1")
-        .args(&args)
-        .output()
-        .await;
-
-    match output {
-        Ok(output) if output.status.success() => {
-            log_request_finished(request, &args, &output);
-            let stdout = String::from_utf8_lossy(&output.stdout);
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            api_help_has_flag(&stdout, "--slurp") || api_help_has_flag(&stderr, "--slurp")
-        }
-        Ok(output) => {
-            log_request_finished(request, &args, &output);
-            debug!(
-                status = %output.status,
-                "failed to inspect gh api help for --slurp support; assuming supported"
-            );
-            true
-        }
-        Err(error) => {
-            log_request_failed_to_start(request, &args, &error);
-            debug!(
-                error = %error,
-                "failed to inspect gh api help for --slurp support; assuming supported"
-            );
-            true
-        }
-    }
+struct IncludedResponse {
+    status: u16,
+    headers: HeaderMap,
+    body: Vec<u8>,
 }
 
-fn api_help_has_flag(help: &str, flag: &str) -> bool {
-    help.split(|ch: char| ch.is_whitespace() || matches!(ch, ',' | '[' | ']' | '(' | ')' | '`'))
-        .any(|token| token == flag)
+fn included_headers_args(args: &[String]) -> Vec<String> {
+    if args
+        .iter()
+        .any(|arg| matches!(arg.as_str(), "-i" | "--include"))
+    {
+        return args.to_vec();
+    }
+    let mut command_args = args.to_vec();
+    command_args.insert(1, "--include".to_string());
+    command_args
+}
+
+fn parse_included_response(output: &[u8]) -> Result<IncludedResponse> {
+    let output = std::str::from_utf8(output).context("gh api response was not UTF-8")?;
+    let (header_text, body) = split_headers_and_body(output)
+        .ok_or_else(|| anyhow!("gh api response did not include an HTTP header block"))?;
+    let mut lines = header_text.lines();
+    let status_line = lines
+        .next()
+        .ok_or_else(|| anyhow!("gh api response status line is missing"))?;
+    let status = status_line
+        .split_whitespace()
+        .nth(1)
+        .ok_or_else(|| anyhow!("invalid gh api response status line `{status_line}`"))?
+        .parse::<u16>()
+        .with_context(|| format!("invalid gh api response status line `{status_line}`"))?;
+    let mut headers = HeaderMap::new();
+    for line in lines.filter(|line| !line.trim().is_empty()) {
+        let (name, value) = line
+            .split_once(':')
+            .ok_or_else(|| anyhow!("invalid gh api response header `{line}`"))?;
+        let name = HeaderName::from_bytes(name.trim().to_ascii_lowercase().as_bytes())
+            .with_context(|| format!("invalid gh api response header name `{name}`"))?;
+        let value = HeaderValue::from_str(value.trim())
+            .with_context(|| format!("invalid gh api response header value for `{name}`"))?;
+        headers.append(name, value);
+    }
+
+    Ok(IncludedResponse {
+        status,
+        headers,
+        body: body.as_bytes().to_vec(),
+    })
+}
+
+fn split_headers_and_body(output: &str) -> Option<(&str, &str)> {
+    let crlf = output.find("\r\n\r\n").map(|index| (index, 4));
+    let lf = output.find("\n\n").map(|index| (index, 2));
+    let (index, delimiter_len) = match (crlf, lf) {
+        (Some(crlf), Some(lf)) => Some(crlf.min(lf)),
+        (Some(crlf), None) => Some(crlf),
+        (None, Some(lf)) => Some(lf),
+        (None, None) => None,
+    }?;
+    Some((&output[..index], &output[index + delimiter_len..]))
 }
 
 fn log_request_started(args: &[String]) -> GhLogRequest {
@@ -241,15 +280,22 @@ mod tests {
     }
 
     #[test]
-    fn api_help_flag_detection_matches_complete_flags() {
-        assert!(api_help_has_flag(
-            "      --slurp               Use an array of arrays for paginated responses",
-            "--slurp"
-        ));
-        assert!(!api_help_has_flag(
-            "      --paginate            Fetch all pages",
-            "--slurp"
-        ));
+    fn gh_api_requests_include_response_headers() {
+        assert_eq!(
+            included_headers_args(&["api".to_string(), "user".to_string()]),
+            vec!["api", "--include", "user"]
+        );
+    }
+
+    #[test]
+    fn included_response_parser_returns_headers_and_clean_body() {
+        let output = b"HTTP/2.0 200 OK\nX-RateLimit-Remaining: 42\r\nX-RateLimit-Resource: core\r\n\r\n{\"login\":\"octocat\"}";
+        let response = parse_included_response(output).expect("response should parse");
+
+        assert_eq!(response.status, 200);
+        assert_eq!(response.headers["x-ratelimit-remaining"], "42");
+        assert_eq!(response.headers["x-ratelimit-resource"], "core");
+        assert_eq!(response.body, br#"{"login":"octocat"}"#);
     }
 
     #[test]

--- a/src/github_queue.rs
+++ b/src/github_queue.rs
@@ -1,0 +1,349 @@
+use std::collections::VecDeque;
+use std::sync::{Mutex, MutexGuard, OnceLock};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use http::HeaderMap;
+use tokio::sync::Notify;
+use tokio::time::sleep;
+use tracing::warn;
+
+const RATE_LIMIT_FALLBACK_DELAY: Duration = Duration::from_secs(60);
+const RATE_LIMIT_RESET_GRACE: Duration = Duration::from_secs(1);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum GitHubQueueBackend {
+    DirectApi,
+    GitHubCli,
+}
+
+impl GitHubQueueBackend {
+    fn label(self) -> &'static str {
+        match self {
+            Self::DirectApi => "direct API",
+            Self::GitHubCli => "gh",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum GitHubRequestPriority {
+    User,
+    Background,
+}
+
+static DIRECT_API_QUEUE: OnceLock<RequestQueue> = OnceLock::new();
+static GH_CLI_QUEUE: OnceLock<RequestQueue> = OnceLock::new();
+
+pub(crate) async fn acquire(
+    backend: GitHubQueueBackend,
+    priority: GitHubRequestPriority,
+) -> RequestPermit<'static> {
+    queue(backend).acquire(priority).await
+}
+
+pub(crate) fn observe_response(
+    backend: GitHubQueueBackend,
+    status: u16,
+    headers: &HeaderMap,
+    message: Option<&str>,
+) -> Option<Duration> {
+    let delay = rate_limit_delay(status, headers, message)?;
+    queue(backend).defer_for(delay);
+    warn!(
+        backend = backend.label(),
+        status,
+        resource = header_value(headers, "x-ratelimit-resource").unwrap_or("unknown"),
+        retry_in_seconds = delay.as_secs(),
+        "GitHub request queue cooling down"
+    );
+    Some(delay)
+}
+
+pub(crate) fn message_looks_rate_limited(message: &str) -> bool {
+    let message = message.to_ascii_lowercase();
+    message.contains("api rate limit exceeded")
+        || message.contains("rate limit exceeded")
+        || message.contains("secondary rate limit")
+        || message.contains("abuse detection")
+        || message.contains("http 429")
+}
+
+fn queue(backend: GitHubQueueBackend) -> &'static RequestQueue {
+    match backend {
+        GitHubQueueBackend::DirectApi => DIRECT_API_QUEUE.get_or_init(RequestQueue::default),
+        GitHubQueueBackend::GitHubCli => GH_CLI_QUEUE.get_or_init(RequestQueue::default),
+    }
+}
+
+#[derive(Default)]
+struct RequestQueue {
+    state: Mutex<RequestQueueState>,
+    changed: Notify,
+}
+
+#[derive(Default)]
+struct RequestQueueState {
+    active: bool,
+    next_ticket: u64,
+    user_waiters: VecDeque<u64>,
+    background_waiters: VecDeque<u64>,
+    cooldown_until: Option<Instant>,
+}
+
+enum AcquireState {
+    Ready,
+    Waiting,
+    CoolingDown(Duration),
+}
+
+impl RequestQueue {
+    async fn acquire(&self, priority: GitHubRequestPriority) -> RequestPermit<'_> {
+        let ticket = {
+            let mut state = self.lock_state();
+            let ticket = state.next_ticket;
+            state.next_ticket = state.next_ticket.wrapping_add(1);
+            state.waiters_mut(priority).push_back(ticket);
+            ticket
+        };
+        let mut pending = PendingRequest {
+            queue: self,
+            priority,
+            ticket,
+            queued: true,
+        };
+
+        loop {
+            let changed = self.changed.notified();
+            match self.try_acquire(priority, ticket) {
+                AcquireState::Ready => {
+                    pending.queued = false;
+                    return RequestPermit { queue: self };
+                }
+                AcquireState::Waiting => changed.await,
+                AcquireState::CoolingDown(delay) => {
+                    tokio::select! {
+                        _ = changed => {}
+                        _ = sleep(delay) => {}
+                    }
+                }
+            }
+        }
+    }
+
+    fn try_acquire(&self, priority: GitHubRequestPriority, ticket: u64) -> AcquireState {
+        let mut state = self.lock_state();
+        if state.active {
+            return AcquireState::Waiting;
+        }
+
+        if let Some(until) = state.cooldown_until {
+            let now = Instant::now();
+            if until > now {
+                return AcquireState::CoolingDown(until.duration_since(now));
+            }
+            state.cooldown_until = None;
+        }
+
+        let is_next = match priority {
+            GitHubRequestPriority::User => state.user_waiters.front() == Some(&ticket),
+            GitHubRequestPriority::Background => {
+                state.user_waiters.is_empty()
+                    && state.background_waiters.front() == Some(&ticket)
+            }
+        };
+        if !is_next {
+            return AcquireState::Waiting;
+        }
+
+        state.waiters_mut(priority).pop_front();
+        state.active = true;
+        AcquireState::Ready
+    }
+
+    fn defer_for(&self, delay: Duration) {
+        let until = Instant::now() + delay;
+        let mut state = self.lock_state();
+        if state.cooldown_until.is_none_or(|current| until > current) {
+            state.cooldown_until = Some(until);
+        }
+        drop(state);
+        self.changed.notify_waiters();
+    }
+
+    fn remove_waiter(&self, priority: GitHubRequestPriority, ticket: u64) {
+        let mut state = self.lock_state();
+        let waiters = state.waiters_mut(priority);
+        if let Some(position) = waiters.iter().position(|queued| *queued == ticket) {
+            waiters.remove(position);
+        }
+        drop(state);
+        self.changed.notify_waiters();
+    }
+
+    fn release(&self) {
+        let mut state = self.lock_state();
+        state.active = false;
+        drop(state);
+        self.changed.notify_waiters();
+    }
+
+    fn lock_state(&self) -> MutexGuard<'_, RequestQueueState> {
+        self.state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+}
+
+impl RequestQueueState {
+    fn waiters_mut(&mut self, priority: GitHubRequestPriority) -> &mut VecDeque<u64> {
+        match priority {
+            GitHubRequestPriority::User => &mut self.user_waiters,
+            GitHubRequestPriority::Background => &mut self.background_waiters,
+        }
+    }
+}
+
+struct PendingRequest<'a> {
+    queue: &'a RequestQueue,
+    priority: GitHubRequestPriority,
+    ticket: u64,
+    queued: bool,
+}
+
+impl Drop for PendingRequest<'_> {
+    fn drop(&mut self) {
+        if self.queued {
+            self.queue.remove_waiter(self.priority, self.ticket);
+        }
+    }
+}
+
+pub(crate) struct RequestPermit<'a> {
+    queue: &'a RequestQueue,
+}
+
+impl Drop for RequestPermit<'_> {
+    fn drop(&mut self) {
+        self.queue.release();
+    }
+}
+
+fn rate_limit_delay(status: u16, headers: &HeaderMap, message: Option<&str>) -> Option<Duration> {
+    if let Some(seconds) = header_u64(headers, "retry-after") {
+        return Some(Duration::from_secs(seconds.max(1)));
+    }
+
+    let remaining = header_u64(headers, "x-ratelimit-remaining");
+    if remaining == Some(0) {
+        return Some(
+            header_u64(headers, "x-ratelimit-reset")
+                .map(delay_until_epoch)
+                .unwrap_or(RATE_LIMIT_FALLBACK_DELAY),
+        );
+    }
+
+    if status == 429 || message.is_some_and(message_looks_rate_limited) {
+        return Some(RATE_LIMIT_FALLBACK_DELAY);
+    }
+
+    None
+}
+
+fn delay_until_epoch(reset_epoch: u64) -> Duration {
+    let now_epoch = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    Duration::from_secs(reset_epoch.saturating_sub(now_epoch)) + RATE_LIMIT_RESET_GRACE
+}
+
+fn header_u64(headers: &HeaderMap, name: &str) -> Option<u64> {
+    header_value(headers, name)?.parse().ok()
+}
+
+fn header_value<'a>(headers: &'a HeaderMap, name: &str) -> Option<&'a str> {
+    headers.get(name)?.to_str().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use tokio::sync::mpsc;
+    use tokio::time::{Duration, timeout};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn queue_runs_one_request_at_a_time() {
+        let queue = Arc::new(RequestQueue::default());
+        let first = queue.acquire(GitHubRequestPriority::User).await;
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let waiting_queue = queue.clone();
+        let task = tokio::spawn(async move {
+            let _permit = waiting_queue.acquire(GitHubRequestPriority::User).await;
+            let _ = tx.send(());
+        });
+
+        assert!(timeout(Duration::from_millis(20), rx.recv()).await.is_err());
+        drop(first);
+        timeout(Duration::from_secs(1), rx.recv())
+            .await
+            .expect("second request should start")
+            .expect("second request should report start");
+        task.await.expect("queued task should finish");
+    }
+
+    #[tokio::test]
+    async fn user_request_overtakes_waiting_background_request() {
+        let queue = Arc::new(RequestQueue::default());
+        let active = queue.acquire(GitHubRequestPriority::Background).await;
+        let (tx, mut rx) = mpsc::unbounded_channel();
+
+        let background_queue = queue.clone();
+        let background_tx = tx.clone();
+        let background = tokio::spawn(async move {
+            let _permit = background_queue
+                .acquire(GitHubRequestPriority::Background)
+                .await;
+            let _ = background_tx.send("background");
+        });
+        while queue.lock_state().background_waiters.is_empty() {
+            tokio::task::yield_now().await;
+        }
+
+        let user_queue = queue.clone();
+        let user = tokio::spawn(async move {
+            let _permit = user_queue.acquire(GitHubRequestPriority::User).await;
+            let _ = tx.send("user");
+        });
+        while queue.lock_state().user_waiters.is_empty() {
+            tokio::task::yield_now().await;
+        }
+
+        drop(active);
+        assert_eq!(rx.recv().await, Some("user"));
+        assert_eq!(rx.recv().await, Some("background"));
+        user.await.expect("user task should finish");
+        background.await.expect("background task should finish");
+    }
+
+    #[test]
+    fn retry_after_header_controls_cooldown() {
+        let mut headers = HeaderMap::new();
+        headers.insert("retry-after", "12".parse().unwrap());
+
+        assert_eq!(
+            rate_limit_delay(403, &headers, Some("secondary rate limit")),
+            Some(Duration::from_secs(12))
+        );
+    }
+
+    #[test]
+    fn permission_error_without_rate_limit_headers_does_not_cool_down() {
+        assert_eq!(
+            rate_limit_delay(403, &HeaderMap::new(), Some("Resource not accessible")),
+            None
+        );
+    }
+}

--- a/src/github_queue.rs
+++ b/src/github_queue.rs
@@ -9,6 +9,7 @@ use tracing::warn;
 
 const RATE_LIMIT_FALLBACK_DELAY: Duration = Duration::from_secs(60);
 const RATE_LIMIT_RESET_GRACE: Duration = Duration::from_secs(1);
+const MAX_USER_REQUESTS_IN_FLIGHT: usize = 16;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum GitHubQueueBackend {
@@ -17,7 +18,7 @@ pub(crate) enum GitHubQueueBackend {
 }
 
 impl GitHubQueueBackend {
-    fn label(self) -> &'static str {
+    pub(crate) fn label(self) -> &'static str {
         match self {
             Self::DirectApi => "direct API",
             Self::GitHubCli => "gh",
@@ -31,28 +32,78 @@ pub(crate) enum GitHubRequestPriority {
     Background,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum GitHubRateResource {
+    Core,
+    Search,
+    Graphql,
+}
+
+impl GitHubRateResource {
+    const COUNT: usize = 3;
+
+    fn index(self) -> usize {
+        match self {
+            Self::Core => 0,
+            Self::Search => 1,
+            Self::Graphql => 2,
+        }
+    }
+
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            Self::Core => "core",
+            Self::Search => "search",
+            Self::Graphql => "graphql",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct GitHubQueueResourceSnapshot {
+    pub(crate) resource: GitHubRateResource,
+    pub(crate) user_waiting: usize,
+    pub(crate) background_waiting: usize,
+    pub(crate) cooldown_remaining: Option<Duration>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct GitHubQueueSnapshot {
+    pub(crate) backend: GitHubQueueBackend,
+    pub(crate) active: usize,
+    pub(crate) max_active: usize,
+    pub(crate) resources: Vec<GitHubQueueResourceSnapshot>,
+}
+
 static DIRECT_API_QUEUE: OnceLock<RequestQueue> = OnceLock::new();
 static GH_CLI_QUEUE: OnceLock<RequestQueue> = OnceLock::new();
 
 pub(crate) async fn acquire(
     backend: GitHubQueueBackend,
     priority: GitHubRequestPriority,
+    resource: GitHubRateResource,
 ) -> RequestPermit<'static> {
-    queue(backend).acquire(priority).await
+    queue(backend).acquire(priority, resource).await
+}
+
+pub(crate) fn snapshot(backend: GitHubQueueBackend) -> GitHubQueueSnapshot {
+    queue(backend).snapshot(backend)
 }
 
 pub(crate) fn observe_response(
     backend: GitHubQueueBackend,
+    request_resource: GitHubRateResource,
     status: u16,
     headers: &HeaderMap,
     message: Option<&str>,
 ) -> Option<Duration> {
     let delay = rate_limit_delay(status, headers, message)?;
-    queue(backend).defer_for(delay);
+    let resource = response_rate_resource(headers, request_resource);
+    queue(backend).defer_for(resource, delay);
     warn!(
         backend = backend.label(),
         status,
-        resource = header_value(headers, "x-ratelimit-resource").unwrap_or("unknown"),
+        resource = resource.label(),
         retry_in_seconds = delay.as_secs(),
         "GitHub request queue cooling down"
     );
@@ -83,11 +134,11 @@ struct RequestQueue {
 
 #[derive(Default)]
 struct RequestQueueState {
-    active: bool,
+    active: usize,
     next_ticket: u64,
-    user_waiters: VecDeque<u64>,
-    background_waiters: VecDeque<u64>,
-    cooldown_until: Option<Instant>,
+    user_waiters: [VecDeque<u64>; GitHubRateResource::COUNT],
+    background_waiters: [VecDeque<u64>; GitHubRateResource::COUNT],
+    cooldown_until: [Option<Instant>; GitHubRateResource::COUNT],
 }
 
 enum AcquireState {
@@ -97,24 +148,31 @@ enum AcquireState {
 }
 
 impl RequestQueue {
-    async fn acquire(&self, priority: GitHubRequestPriority) -> RequestPermit<'_> {
+    async fn acquire(
+        &self,
+        priority: GitHubRequestPriority,
+        resource: GitHubRateResource,
+    ) -> RequestPermit<'_> {
         let ticket = {
             let mut state = self.lock_state();
             let ticket = state.next_ticket;
             state.next_ticket = state.next_ticket.wrapping_add(1);
-            state.waiters_mut(priority).push_back(ticket);
+            state.waiters_mut(priority, resource).push_back(ticket);
             ticket
         };
         let mut pending = PendingRequest {
             queue: self,
             priority,
+            resource,
             ticket,
             queued: true,
         };
 
         loop {
             let changed = self.changed.notified();
-            match self.try_acquire(priority, ticket) {
+            tokio::pin!(changed);
+            changed.as_mut().enable();
+            match self.try_acquire(priority, resource, ticket) {
                 AcquireState::Ready => {
                     pending.queued = false;
                     return RequestPermit { queue: self };
@@ -130,49 +188,86 @@ impl RequestQueue {
         }
     }
 
-    fn try_acquire(&self, priority: GitHubRequestPriority, ticket: u64) -> AcquireState {
+    fn try_acquire(
+        &self,
+        priority: GitHubRequestPriority,
+        resource: GitHubRateResource,
+        ticket: u64,
+    ) -> AcquireState {
         let mut state = self.lock_state();
-        if state.active {
-            return AcquireState::Waiting;
-        }
-
-        if let Some(until) = state.cooldown_until {
-            let now = Instant::now();
-            if until > now {
-                return AcquireState::CoolingDown(until.duration_since(now));
-            }
-            state.cooldown_until = None;
+        let now = Instant::now();
+        state.clear_expired_cooldowns(now);
+        if let Some(until) = state.cooldown_until[resource.index()] {
+            return AcquireState::CoolingDown(until.duration_since(now));
         }
 
         let is_next = match priority {
-            GitHubRequestPriority::User => state.user_waiters.front() == Some(&ticket),
+            GitHubRequestPriority::User => {
+                state.active < MAX_USER_REQUESTS_IN_FLIGHT
+                    && state.next_ready_ticket(GitHubRequestPriority::User) == Some(ticket)
+            }
             GitHubRequestPriority::Background => {
-                state.user_waiters.is_empty()
-                    && state.background_waiters.front() == Some(&ticket)
+                state.active == 0
+                    && state
+                        .next_ready_ticket(GitHubRequestPriority::User)
+                        .is_none()
+                    && state.next_ready_ticket(GitHubRequestPriority::Background) == Some(ticket)
             }
         };
         if !is_next {
             return AcquireState::Waiting;
         }
 
-        state.waiters_mut(priority).pop_front();
-        state.active = true;
+        state.waiters_mut(priority, resource).pop_front();
+        state.active += 1;
         AcquireState::Ready
     }
 
-    fn defer_for(&self, delay: Duration) {
+    fn defer_for(&self, resource: GitHubRateResource, delay: Duration) {
         let until = Instant::now() + delay;
         let mut state = self.lock_state();
-        if state.cooldown_until.is_none_or(|current| until > current) {
-            state.cooldown_until = Some(until);
+        let cooldown = &mut state.cooldown_until[resource.index()];
+        if cooldown.is_none_or(|current| until > current) {
+            *cooldown = Some(until);
         }
         drop(state);
         self.changed.notify_waiters();
     }
 
-    fn remove_waiter(&self, priority: GitHubRequestPriority, ticket: u64) {
+    fn snapshot(&self, backend: GitHubQueueBackend) -> GitHubQueueSnapshot {
         let mut state = self.lock_state();
-        let waiters = state.waiters_mut(priority);
+        let now = Instant::now();
+        state.clear_expired_cooldowns(now);
+        let resources = [
+            GitHubRateResource::Core,
+            GitHubRateResource::Search,
+            GitHubRateResource::Graphql,
+        ]
+        .into_iter()
+        .map(|resource| GitHubQueueResourceSnapshot {
+            resource,
+            user_waiting: state.user_waiters[resource.index()].len(),
+            background_waiting: state.background_waiters[resource.index()].len(),
+            cooldown_remaining: state.cooldown_until[resource.index()]
+                .map(|until| until.duration_since(now)),
+        })
+        .collect();
+        GitHubQueueSnapshot {
+            backend,
+            active: state.active,
+            max_active: MAX_USER_REQUESTS_IN_FLIGHT,
+            resources,
+        }
+    }
+
+    fn remove_waiter(
+        &self,
+        priority: GitHubRequestPriority,
+        resource: GitHubRateResource,
+        ticket: u64,
+    ) {
+        let mut state = self.lock_state();
+        let waiters = state.waiters_mut(priority, resource);
         if let Some(position) = waiters.iter().position(|queued| *queued == ticket) {
             waiters.remove(position);
         }
@@ -182,7 +277,7 @@ impl RequestQueue {
 
     fn release(&self) {
         let mut state = self.lock_state();
-        state.active = false;
+        state.active = state.active.saturating_sub(1);
         drop(state);
         self.changed.notify_waiters();
     }
@@ -195,10 +290,35 @@ impl RequestQueue {
 }
 
 impl RequestQueueState {
-    fn waiters_mut(&mut self, priority: GitHubRequestPriority) -> &mut VecDeque<u64> {
+    fn waiters_mut(
+        &mut self,
+        priority: GitHubRequestPriority,
+        resource: GitHubRateResource,
+    ) -> &mut VecDeque<u64> {
         match priority {
-            GitHubRequestPriority::User => &mut self.user_waiters,
-            GitHubRequestPriority::Background => &mut self.background_waiters,
+            GitHubRequestPriority::User => &mut self.user_waiters[resource.index()],
+            GitHubRequestPriority::Background => &mut self.background_waiters[resource.index()],
+        }
+    }
+
+    fn next_ready_ticket(&self, priority: GitHubRequestPriority) -> Option<u64> {
+        let waiters = match priority {
+            GitHubRequestPriority::User => &self.user_waiters,
+            GitHubRequestPriority::Background => &self.background_waiters,
+        };
+        waiters
+            .iter()
+            .enumerate()
+            .filter(|(index, _)| self.cooldown_until[*index].is_none())
+            .filter_map(|(_, queue)| queue.front().copied())
+            .min()
+    }
+
+    fn clear_expired_cooldowns(&mut self, now: Instant) {
+        for cooldown in &mut self.cooldown_until {
+            if cooldown.is_some_and(|until| until <= now) {
+                *cooldown = None;
+            }
         }
     }
 }
@@ -206,6 +326,7 @@ impl RequestQueueState {
 struct PendingRequest<'a> {
     queue: &'a RequestQueue,
     priority: GitHubRequestPriority,
+    resource: GitHubRateResource,
     ticket: u64,
     queued: bool,
 }
@@ -213,7 +334,8 @@ struct PendingRequest<'a> {
 impl Drop for PendingRequest<'_> {
     fn drop(&mut self) {
         if self.queued {
-            self.queue.remove_waiter(self.priority, self.ticket);
+            self.queue
+                .remove_waiter(self.priority, self.resource, self.ticket);
         }
     }
 }
@@ -265,6 +387,18 @@ fn header_value<'a>(headers: &'a HeaderMap, name: &str) -> Option<&'a str> {
     headers.get(name)?.to_str().ok()
 }
 
+fn response_rate_resource(
+    headers: &HeaderMap,
+    request_resource: GitHubRateResource,
+) -> GitHubRateResource {
+    match header_value(headers, "x-ratelimit-resource") {
+        Some("search" | "code_search") => GitHubRateResource::Search,
+        Some("graphql") => GitHubRateResource::Graphql,
+        Some(_) => GitHubRateResource::Core,
+        None => request_resource,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
@@ -274,14 +408,18 @@ mod tests {
 
     use super::*;
 
+    const CORE: GitHubRateResource = GitHubRateResource::Core;
+
     #[tokio::test]
-    async fn queue_runs_one_request_at_a_time() {
+    async fn background_queue_runs_one_request_at_a_time() {
         let queue = Arc::new(RequestQueue::default());
-        let first = queue.acquire(GitHubRequestPriority::User).await;
+        let first = queue.acquire(GitHubRequestPriority::Background, CORE).await;
         let (tx, mut rx) = mpsc::unbounded_channel();
         let waiting_queue = queue.clone();
         let task = tokio::spawn(async move {
-            let _permit = waiting_queue.acquire(GitHubRequestPriority::User).await;
+            let _permit = waiting_queue
+                .acquire(GitHubRequestPriority::Background, CORE)
+                .await;
             let _ = tx.send(());
         });
 
@@ -295,37 +433,177 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn queue_snapshot_reports_active_waiters_and_cooldown() {
+        let queue = Arc::new(RequestQueue::default());
+        let permit = queue.acquire(GitHubRequestPriority::User, CORE).await;
+        queue.defer_for(GitHubRateResource::Search, Duration::from_secs(30));
+        let waiting_queue = queue.clone();
+        let waiter = tokio::spawn(async move {
+            let _permit = waiting_queue
+                .acquire(
+                    GitHubRequestPriority::Background,
+                    GitHubRateResource::Graphql,
+                )
+                .await;
+        });
+
+        while queue.lock_state().background_waiters[GitHubRateResource::Graphql.index()].is_empty()
+        {
+            tokio::task::yield_now().await;
+        }
+        let snapshot = queue.snapshot(GitHubQueueBackend::DirectApi);
+        assert_eq!(snapshot.active, 1);
+        assert_eq!(snapshot.max_active, MAX_USER_REQUESTS_IN_FLIGHT);
+        let search = &snapshot.resources[GitHubRateResource::Search.index()];
+        assert!(search.cooldown_remaining.is_some());
+        let graphql = &snapshot.resources[GitHubRateResource::Graphql.index()];
+        assert_eq!(graphql.background_waiting, 1);
+
+        waiter.abort();
+        drop(permit);
+    }
+
+    #[tokio::test]
     async fn user_request_overtakes_waiting_background_request() {
         let queue = Arc::new(RequestQueue::default());
-        let active = queue.acquire(GitHubRequestPriority::Background).await;
+        let mut active = Vec::new();
+        for _ in 0..MAX_USER_REQUESTS_IN_FLIGHT {
+            active.push(queue.acquire(GitHubRequestPriority::User, CORE).await);
+        }
         let (tx, mut rx) = mpsc::unbounded_channel();
 
         let background_queue = queue.clone();
         let background_tx = tx.clone();
         let background = tokio::spawn(async move {
             let _permit = background_queue
-                .acquire(GitHubRequestPriority::Background)
+                .acquire(GitHubRequestPriority::Background, CORE)
                 .await;
             let _ = background_tx.send("background");
         });
-        while queue.lock_state().background_waiters.is_empty() {
+        while queue.lock_state().background_waiters[CORE.index()].is_empty() {
             tokio::task::yield_now().await;
         }
 
         let user_queue = queue.clone();
         let user = tokio::spawn(async move {
-            let _permit = user_queue.acquire(GitHubRequestPriority::User).await;
+            let _permit = user_queue.acquire(GitHubRequestPriority::User, CORE).await;
             let _ = tx.send("user");
         });
-        while queue.lock_state().user_waiters.is_empty() {
+        while queue.lock_state().user_waiters[CORE.index()].is_empty() {
             tokio::task::yield_now().await;
         }
 
-        drop(active);
+        drop(active.pop());
         assert_eq!(rx.recv().await, Some("user"));
+        drop(active);
         assert_eq!(rx.recv().await, Some("background"));
         user.await.expect("user task should finish");
         background.await.expect("background task should finish");
+    }
+
+    #[tokio::test]
+    async fn cancelled_waiter_does_not_block_the_queue() {
+        let queue = Arc::new(RequestQueue::default());
+        let mut active = Vec::new();
+        for _ in 0..MAX_USER_REQUESTS_IN_FLIGHT {
+            active.push(queue.acquire(GitHubRequestPriority::User, CORE).await);
+        }
+        let waiting_queue = queue.clone();
+        let waiting = tokio::spawn(async move {
+            let _permit = waiting_queue
+                .acquire(GitHubRequestPriority::User, CORE)
+                .await;
+        });
+        while queue.lock_state().user_waiters[CORE.index()].is_empty() {
+            tokio::task::yield_now().await;
+        }
+
+        waiting.abort();
+        let _ = waiting.await;
+        drop(active);
+        timeout(
+            Duration::from_secs(1),
+            queue.acquire(GitHubRequestPriority::Background, CORE),
+        )
+        .await
+        .expect("cancelled waiter should be removed");
+    }
+
+    #[tokio::test]
+    async fn user_requests_use_bounded_concurrency() {
+        let queue = Arc::new(RequestQueue::default());
+        let mut active = Vec::new();
+        let resources = [
+            GitHubRateResource::Core,
+            GitHubRateResource::Search,
+            GitHubRateResource::Graphql,
+        ];
+        for index in 0..MAX_USER_REQUESTS_IN_FLIGHT {
+            active.push(
+                queue
+                    .acquire(
+                        GitHubRequestPriority::User,
+                        resources[index % resources.len()],
+                    )
+                    .await,
+            );
+        }
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let waiting_queue = queue.clone();
+        let task = tokio::spawn(async move {
+            let _permit = waiting_queue
+                .acquire(GitHubRequestPriority::User, CORE)
+                .await;
+            let _ = tx.send(());
+        });
+
+        assert!(timeout(Duration::from_millis(20), rx.recv()).await.is_err());
+        drop(active.pop());
+        timeout(Duration::from_secs(1), rx.recv())
+            .await
+            .expect("request should start when capacity is available")
+            .expect("request should report start");
+        drop(active);
+        task.await.expect("queued task should finish");
+    }
+
+    #[tokio::test]
+    async fn cooldown_only_blocks_matching_resource() {
+        let queue = Arc::new(RequestQueue::default());
+        queue.defer_for(GitHubRateResource::Search, Duration::from_millis(100));
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let search_queue = queue.clone();
+        let search = tokio::spawn(async move {
+            let _permit = search_queue
+                .acquire(GitHubRequestPriority::User, GitHubRateResource::Search)
+                .await;
+            let _ = tx.send(());
+        });
+        while queue.lock_state().user_waiters[GitHubRateResource::Search.index()].is_empty() {
+            tokio::task::yield_now().await;
+        }
+
+        let core = timeout(
+            Duration::from_secs(1),
+            queue.acquire(GitHubRequestPriority::User, GitHubRateResource::Core),
+        )
+        .await
+        .expect("search cooldown should not block core requests");
+        let graphql = timeout(
+            Duration::from_secs(1),
+            queue.acquire(GitHubRequestPriority::User, GitHubRateResource::Graphql),
+        )
+        .await
+        .expect("search cooldown should not block GraphQL requests");
+        assert!(timeout(Duration::from_millis(20), rx.recv()).await.is_err());
+
+        drop(core);
+        drop(graphql);
+        timeout(Duration::from_secs(1), rx.recv())
+            .await
+            .expect("search request should resume after its cooldown")
+            .expect("search request should report start");
+        search.await.expect("search task should finish");
     }
 
     #[test]
@@ -340,10 +618,48 @@ mod tests {
     }
 
     #[test]
+    fn exhausted_primary_limit_waits_until_reset() {
+        let reset = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+            + 5;
+        let mut headers = HeaderMap::new();
+        headers.insert("x-ratelimit-remaining", "0".parse().unwrap());
+        headers.insert("x-ratelimit-reset", reset.to_string().parse().unwrap());
+
+        let delay = rate_limit_delay(200, &headers, None).expect("cooldown should be set");
+        assert!(delay >= Duration::from_secs(5));
+        assert!(delay <= Duration::from_secs(6));
+    }
+
+    #[test]
     fn permission_error_without_rate_limit_headers_does_not_cool_down() {
         assert_eq!(
             rate_limit_delay(403, &HeaderMap::new(), Some("Resource not accessible")),
             None
+        );
+    }
+
+    #[test]
+    fn response_headers_select_the_rate_limit_resource() {
+        for (header, expected) in [
+            ("search", GitHubRateResource::Search),
+            ("code_search", GitHubRateResource::Search),
+            ("graphql", GitHubRateResource::Graphql),
+            ("core", GitHubRateResource::Core),
+        ] {
+            let mut headers = HeaderMap::new();
+            headers.insert("x-ratelimit-resource", header.parse().unwrap());
+            assert_eq!(
+                response_rate_resource(&headers, GitHubRateResource::Core),
+                expected
+            );
+        }
+
+        assert_eq!(
+            response_rate_resource(&HeaderMap::new(), GitHubRateResource::Search),
+            GitHubRateResource::Search
         );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod dirs;
 mod github;
 mod github_api;
 mod github_gh;
+mod github_queue;
 mod log;
 mod model;
 mod snapshot;


### PR DESCRIPTION
## Summary

Improve GitHub request scheduling and prevent background/detail refreshes from unnecessarily exhausting API quotas.


## Changes

- Refresh Inbox every 60 seconds while idle.
- Maintain separate request queues for Direct API and `gh`.
- Separate `core`, `search`, and `graphql` rate-limit resources.
- Allow up to 16 concurrent foreground reads while keeping background requests serialized and lower priority.
- Parse `Retry-After` and `X-RateLimit-*` headers from both Direct API and `gh api`.
- Wait until the affected resource resets before retrying rate-limited reads.
- Keep write requests high priority and never retry them automatically.
- Stop automatic detail reload loops after an error; use `r` to retry manually.
- Only invalidate cached details when the selected item's `updated_at` advances.
- Apply the same invalidation rule to Inbox and regular view refreshes.
- Add a `Rate Limit` command showing:
  - Core, Search, and GraphQL quotas
  - Remaining and used requests
  - Reset times
  - Local queue, waiter, and cooldown state
